### PR TITLE
Ensure instana-agent.daemonset.yaml is on-par with the agent daemonset in docs where applicable

### DIFF
--- a/src/main/resources/instana-agent.daemonset.yaml
+++ b/src/main/resources/instana-agent.daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: instana-agent
@@ -9,12 +9,15 @@ metadata:
       name: placeholder
       uid: placeholder
 spec:
+  selector:
+    matchLabels:
+      app: instana-agent
   template:
     metadata:
       labels:
         app: instana-agent
     spec:
-      serviceAccount: instana-agent
+      serviceAccountName: instana-agent
       hostIPC: true
       hostNetwork: true
       hostPID: true
@@ -35,7 +38,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: INSTANA_AGENT_POD_IP
+            - name: POD_IP
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -53,6 +56,8 @@ spec:
               mountPath: /sys
             - name: log
               mountPath: /var/log
+            - name: var-lib
+              mountPath: /var/lib/containers/storage
             - name: machine-id
               mountPath: /etc/machine-id
           livenessProbe:
@@ -79,6 +84,9 @@ spec:
         - name: log
           hostPath:
             path: /var/log
+        - name: var-lib
+          hostPath:
+            path: /var/lib/containers/storage
         - name: machine-id
           hostPath:
             path: /etc/machine-id


### PR DESCRIPTION
Ensure instana-agent.daemonset.yaml is on-par with https://github.com/instana/docs/blob/master/src/pages/quick_start/agent_setup/container/kubernetes/assets/instana-agent.yaml where appropriate:

- Use the `apps/v1` API for DaemonSet instead of the deprecated `extensions/v1beta1`
- `DaemonSet` spec selectors must match the pod template's labels: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#daemonsetspec-v1-apps, therefore adding a matching selector under `spec`
- Use `serviceAccountName` instead of the deprecated `serviceAccount`: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podspec-v1-core
- Add mount and volume for `/var/lib/containers/storage`. This was added for CRI-O support.
- Rename the `INSTANA_AGENT_POD_IP` env variable in the `instana-agent` container to `POD_IP`, as the former wasn't being used