### PR TITLE
Liveness Checks and expose Environment Variables

### DIFF
--- a/deploy/instana-agent.customresource.yaml
+++ b/deploy/instana-agent.customresource.yaml
@@ -8,6 +8,8 @@ spec:
   agent.key: put your Instana agent key here
   agent.endpoint.host: the monitoring ingress endpoint
   agent.endpoint.port: the monitoring ingress endpoint port, wrapped in quotes
+  agent.env:
+    INSTANA_AGENT_TAGS: example
   config.files:
     configuration.yaml: |
       # You can leave this empty, or use this to configure your instana agent.

--- a/docs/install-manually.md
+++ b/docs/install-manually.md
@@ -24,6 +24,7 @@ Edit the template and replace at least the following values:
   * `agent.endpoint` must be set with the monitoring ingress endpoint, generally either `saas-us-west-2.instana.io` or `saas-eu-west-1.instana.io`.
   * `agent.endpoint.port` must be set with the monitoring ingress port, generally `"443"` (wrapped in quotes).
   * `agent.zone.name` should be set with the name of the Kubernetes cluster that is be displayed in Instana.
+  * `agent.env` can be used to specify environment variables for the agent, for instance, proxy configuration. See possible environment values [here](https://docs.instana.io/quick_start/agent_setup/container/docker/).
 
 In case you need to adapt `configuration.yaml`, view the documentation here: [https://docs.instana.io/quick_start/agent_setup/container/kubernetes/](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/).
 

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -284,27 +284,6 @@ public class AgentDeployer {
           .endValueFrom()
           .build());
     }
-    if (!isBlank(config.getAgentProxyHost())) {
-      env.add(createEnvVar("INSTANA_AGENT_PROXY_HOST", config.getAgentProxyHost()));
-    }
-    if (config.getAgentProxyPort() != null) {
-      env.add(createEnvVar("INSTANA_AGENT_PROXY_PORT", config.getAgentProxyPort().toString()));
-    }
-    if (!isBlank(config.getAgentProxyProtocol())) {
-      env.add(createEnvVar("INSTANA_AGENT_PROXY_PROTOCOL", config.getAgentProxyProtocol()));
-    }
-    if (!isBlank(config.getAgentProxyUser())) {
-      env.add(createEnvVar("INSTANA_AGENT_PROXY_USER", config.getAgentProxyUser()));
-    }
-    if (!isBlank(config.getAgentProxyPassword())) {
-      env.add(createEnvVar("INSTANA_AGENT_PROXY_PASSWORD", config.getAgentProxyPassword()));
-    }
-    if (config.isAgentProxyUseDNS() != null && config.isAgentProxyUseDNS()) {
-      env.add(createEnvVar("INSTANA_AGENT_PROXY_USE_DNS", config.isAgentProxyUseDNS().toString()));
-    }
-    if (!isBlank(config.getAgentHttpListen())) {
-      env.add(createEnvVar("INSTANA_AGENT_HTTP_LISTEN", config.getAgentHttpListen()));
-    }
     if (!isBlank(config.getClusterName())) {
       env.add(createEnvVar("INSTANA_KUBERNETES_CLUSTER_NAME", config.getClusterName()));
     }

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -15,10 +15,7 @@ import io.fabric8.kubernetes.api.model.DoneableSecret;
 import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.EnvVarSource;
-import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.HostPathVolumeSource;
 import io.fabric8.kubernetes.api.model.HostPathVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -57,7 +54,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.nio.charset.Charset;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -264,8 +260,8 @@ public class AgentDeployer {
     return configMap;
   }
 
-  private DaemonSet newDaemonSet(InstanaAgent owner,
-                                 MixedOperation<DaemonSet, DaemonSetList, DoneableDaemonSet, Resource<DaemonSet, DoneableDaemonSet>> op) {
+  DaemonSet newDaemonSet(InstanaAgent owner,
+                         MixedOperation<DaemonSet, DaemonSetList, DoneableDaemonSet, Resource<DaemonSet, DoneableDaemonSet>> op) {
     InstanaAgentSpec config = owner.getSpec();
     DaemonSet daemonSet = load("instana-agent.daemonset.yaml", owner, op);
 
@@ -275,7 +271,6 @@ public class AgentDeployer {
     env.add(createEnvVar("INSTANA_ZONE", config.getAgentZoneName()));
     env.add(createEnvVar("INSTANA_AGENT_ENDPOINT", config.getAgentEndpointHost()));
     env.add(createEnvVar("INSTANA_AGENT_ENDPOINT_PORT", "" + config.getAgentEndpointPort()));
-    env.add(createEnvVar("INSTANA_AGENT_MODE", config.getAgentMode()));
     env.add(createEnvVar("JAVA_OPTS", "-Xmx" + config.getAgentMemLimit() / 3 + "M -XX:+ExitOnOutOfMemoryError"));
 
     if (!isBlank(config.getAgentDownloadKey())) {
@@ -313,6 +308,7 @@ public class AgentDeployer {
     if (!isBlank(config.getClusterName())) {
       env.add(createEnvVar("INSTANA_KUBERNETES_CLUSTER_NAME", config.getClusterName()));
     }
+    config.getAgentEnv().forEach((k, v) -> env.add(createEnvVar(k, v)));
     System.getenv().entrySet().stream()
         .filter(e -> e.getKey().startsWith("INSTANA_AGENT_") && !"INSTANA_AGENT_KEY".equals(e.getKey()))
         .forEach(e -> {

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
@@ -62,8 +62,6 @@ public class InstanaAgentSpec {
   private String agentImageName = DEFAULT_AGENT_IMAGE_NAME;
   @JsonProperty(value = "agent.image.tag", defaultValue = DEFAULT_AGENT_IMAGE_TAG)
   private String agentImageTag = DEFAULT_AGENT_IMAGE_TAG;
-  @JsonProperty(value = "agent.mode", defaultValue = DEFAULT_AGENT_MODE)
-  private String agentMode = DEFAULT_AGENT_MODE;
   @JsonProperty(value = "agent.cpuReq", defaultValue = DEFAULT_AGENT_CPU_REQ)
   private Double agentCpuReq = Double.parseDouble(DEFAULT_AGENT_CPU_REQ);
   @JsonProperty(value = "agent.cpuLimit", defaultValue = DEFAULT_AGENT_CPU_LIMIT)
@@ -92,6 +90,8 @@ public class InstanaAgentSpec {
   private String agentHostRepository;
   @JsonProperty(value = "cluster.name")
   private String clusterName;
+  @JsonProperty(value = "agent.env")
+  private Map<String, String> agentEnv;
 
   public Map<String, String> getConfigFiles() {
     if (configFiles == null) {
@@ -209,14 +209,6 @@ public class InstanaAgentSpec {
     this.agentImageTag = agentImageTag;
   }
 
-  public String getAgentMode() {
-    return agentMode;
-  }
-
-  public void setAgentMode(String agentMode) {
-    this.agentMode = agentMode;
-  }
-
   public Double getAgentCpuReq() {
     return agentCpuReq;
   }
@@ -323,6 +315,17 @@ public class InstanaAgentSpec {
 
   public String getClusterName() {
     return clusterName;
+  }
+
+  public Map<String, String> getAgentEnv() {
+    if (agentEnv == null)
+      return Collections.emptyMap();
+    else
+      return agentEnv;
+  }
+
+  public void setAgentEnv(Map<String, String> env) {
+    agentEnv = env;
   }
 
   // We call equals() to check if the Spec was updated.

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
@@ -32,7 +32,6 @@ public class InstanaAgentSpec {
   static final String DEFAULT_AGENT_CPU_LIMIT = "1.5";
   static final String DEFAULT_AGENT_MEM_REQ = "512";
   static final String DEFAULT_AGENT_MEM_LIMIT = "512";
-  static final String DEFAULT_AGENT_HTTP_LISTEN = "*";
 
   @JsonProperty("config.files")
   private Map<String, String> configFiles;
@@ -72,20 +71,6 @@ public class InstanaAgentSpec {
   private Integer agentMemLimit = Integer.parseInt(DEFAULT_AGENT_MEM_LIMIT);
   @JsonProperty(value = "agent.downloadKey")
   private String agentDownloadKey;
-  @JsonProperty(value = "agent.proxy.host")
-  private String agentProxyHost;
-  @JsonProperty(value = "agent.proxy.port")
-  private Integer agentProxyPort;
-  @JsonProperty(value = "agent.proxy.protocol")
-  private String agentProxyProtocol;
-  @JsonProperty(value = "agent.proxy.user")
-  private String agentProxyUser;
-  @JsonProperty(value = "agent.proxy.password")
-  private String agentProxyPassword;
-  @JsonProperty(value = "agent.proxy.use.dns")
-  private Boolean agentProxyUseDNS;
-  @JsonProperty(value = "agent.http.listen", defaultValue = DEFAULT_AGENT_HTTP_LISTEN)
-  private String agentHttpListen = DEFAULT_AGENT_HTTP_LISTEN;
   @JsonProperty(value = "agent.host.repository")
   private String agentHostRepository;
   @JsonProperty(value = "cluster.name")
@@ -247,62 +232,6 @@ public class InstanaAgentSpec {
 
   public void setAgentDownloadKey(String agentDownloadKey) {
     this.agentDownloadKey = agentDownloadKey;
-  }
-
-  public String getAgentProxyHost() {
-    return agentProxyHost;
-  }
-
-  public void setAgentProxyHost(String agentProxyHost) {
-    this.agentProxyHost = agentProxyHost;
-  }
-
-  public Integer getAgentProxyPort() {
-    return agentProxyPort;
-  }
-
-  public void setAgentProxyPort(Integer agentProxyPort) {
-    this.agentProxyPort = agentProxyPort;
-  }
-
-  public String getAgentProxyProtocol() {
-    return agentProxyProtocol;
-  }
-
-  public void setAgentProxyProtocol(String agentProxyProtocol) {
-    this.agentProxyProtocol = agentProxyProtocol;
-  }
-
-  public String getAgentProxyUser() {
-    return agentProxyUser;
-  }
-
-  public void setAgentProxyUser(String agentProxyUser) {
-    this.agentProxyUser = agentProxyUser;
-  }
-
-  public String getAgentProxyPassword() {
-    return agentProxyPassword;
-  }
-
-  public void setAgentProxyPassword(String agentProxyPassword) {
-    this.agentProxyPassword = agentProxyPassword;
-  }
-
-  public Boolean isAgentProxyUseDNS() {
-    return agentProxyUseDNS;
-  }
-
-  public void setAgentProxyUseDNS(boolean agentProxyUseDNS) {
-    this.agentProxyUseDNS = agentProxyUseDNS;
-  }
-
-  public String getAgentHttpListen() {
-    return agentHttpListen;
-  }
-
-  public void setAgentHttpListen(String agentHttpListen) {
-    this.agentHttpListen = agentHttpListen;
   }
 
   public String getAgentHostRepository() {

--- a/src/main/resources/instana-agent.daemonset.yaml
+++ b/src/main/resources/instana-agent.daemonset.yaml
@@ -64,8 +64,8 @@ spec:
             httpGet:
               path: /status
               port: 42699
-            initialDelaySeconds: 75
-            periodSeconds: 5
+            initialDelaySeconds: 300
+            timeoutSeconds: 3
           ports:
             - containerPort: 42699
       volumes:

--- a/src/test/java/com/instana/operator/AgentDeployerTest.java
+++ b/src/test/java/com/instana/operator/AgentDeployerTest.java
@@ -1,0 +1,44 @@
+package com.instana.operator;
+
+import com.google.common.collect.ImmutableMap;
+import com.instana.operator.customresource.InstanaAgent;
+import com.instana.operator.customresource.InstanaAgentSpec;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.apps.DaemonSet;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+
+class AgentDeployerTest {
+
+  private final DefaultKubernetesClient client = new DefaultKubernetesClient();
+
+  @Test
+  void daemonset_must_include_environment() {
+    AgentDeployer deployer = new AgentDeployer();
+
+    InstanaAgentSpec agentSpec = new InstanaAgentSpec();
+    agentSpec.setAgentEnv(ImmutableMap.<String, String>builder()
+        .put("INSTANA_AGENT_MODE", "APM")
+        .build());
+
+    InstanaAgent crd = new InstanaAgent();
+    crd.setSpec(agentSpec);
+
+    DaemonSet daemonSet = deployer.newDaemonSet(
+        crd,
+        client.inNamespace("instana-agent").apps().daemonSets());
+
+    PodSpec podSpec = daemonSet.getSpec().getTemplate().getSpec();
+
+    Container agentContainer = podSpec.getContainers().get(0);
+
+    assertThat(agentContainer.getEnv(), allOf(
+        hasItem(new EnvVar("INSTANA_AGENT_MODE", "APM", null))));
+  }
+}

--- a/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
+++ b/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
@@ -13,12 +13,10 @@ import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_CPU_LIMIT;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_CPU_REQ;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_DAEMON_SET_NAME;
-import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_HTTP_LISTEN;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_IMAGE_NAME;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_IMAGE_TAG;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MEM_LIMIT;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MEM_REQ;
-import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MODE;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_RBAC_CREATE;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_SECRET_NAME;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_SERVICE_ACCOUNT_NAME;
@@ -59,16 +57,9 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentCpuLimit(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_LIMIT)));
     assertThat(spec.getAgentMemReq(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_REQ)));
     assertThat(spec.getAgentMemLimit(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_LIMIT)));
-    assertThat(spec.getAgentHttpListen(), equalTo(DEFAULT_AGENT_HTTP_LISTEN));
     assertThat(spec.getAgentHostRepository(), nullValue());
 
     assertThat(spec.getAgentDownloadKey(), nullValue());
-    assertThat(spec.getAgentProxyHost(), nullValue());
-    assertThat(spec.getAgentProxyPort(), nullValue());
-    assertThat(spec.getAgentProxyProtocol(), nullValue());
-    assertThat(spec.getAgentProxyUser(), nullValue());
-    assertThat(spec.getAgentProxyPassword(), nullValue());
-    assertThat(spec.isAgentProxyUseDNS(), nullValue());
 
     assertThat(spec.getAgentEnv().entrySet(), empty());
   }
@@ -103,16 +94,8 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentCpuLimit(), equalTo(1.8));
     assertThat(spec.getAgentMemReq(), equalTo(513));
     assertThat(spec.getAgentMemLimit(), equalTo(518));
-    assertThat(spec.getAgentHttpListen(), equalTo("127.0.0.1"));
     assertThat(spec.getAgentHostRepository(), equalTo("/Users/stan/.m2/repository"));
-
     assertThat(spec.getAgentDownloadKey(), equalTo("test-download-key"));
-    assertThat(spec.getAgentProxyHost(), equalTo("proxy.instana.io"));
-    assertThat(spec.getAgentProxyPort(), equalTo(8443));
-    assertThat(spec.getAgentProxyProtocol(), equalTo("https"));
-    assertThat(spec.getAgentProxyUser(), equalTo("proxy-user"));
-    assertThat(spec.getAgentProxyPassword(), equalTo("proxy-password"));
-    assertThat(spec.isAgentProxyUseDNS(), equalTo(true));
   }
 
   @Test

--- a/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
+++ b/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
@@ -55,7 +55,6 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.isAgentRbacCreate(), equalTo(Boolean.parseBoolean(DEFAULT_AGENT_RBAC_CREATE)));
     assertThat(spec.getAgentImageName(), equalTo(DEFAULT_AGENT_IMAGE_NAME));
     assertThat(spec.getAgentImageTag(), equalTo(DEFAULT_AGENT_IMAGE_TAG));
-    assertThat(spec.getAgentMode(), equalTo(DEFAULT_AGENT_MODE));
     assertThat(spec.getAgentCpuReq(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_REQ)));
     assertThat(spec.getAgentCpuLimit(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_LIMIT)));
     assertThat(spec.getAgentMemReq(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_REQ)));
@@ -70,6 +69,8 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentProxyUser(), nullValue());
     assertThat(spec.getAgentProxyPassword(), nullValue());
     assertThat(spec.isAgentProxyUseDNS(), nullValue());
+
+    assertThat(spec.getAgentEnv().entrySet(), empty());
   }
 
   @Test
@@ -87,6 +88,8 @@ class InstanaAgentSpecDeserializeTest {
         hasEntry(equalTo("configuration.yaml"), startsWith("# You can leave ")),
         hasEntry(equalTo("other"), startsWith("some other config file"))));
 
+    assertThat(spec.getAgentEnv(), hasEntry(equalTo("INSTANA_AGENT_MODE"), equalTo("APM")));
+
     assertThat(spec.getAgentClusterRoleName(), equalTo("test-cluster-role"));
     assertThat(spec.getAgentClusterRoleBindingName(), equalTo("test-cluster-role-binding"));
     assertThat(spec.getAgentServiceAccountName(), equalTo("test-service-account"));
@@ -96,7 +99,6 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.isAgentRbacCreate(), equalTo(Boolean.FALSE));
     assertThat(spec.getAgentImageName(), equalTo("instana/test-image"));
     assertThat(spec.getAgentImageTag(), equalTo("1.2.3"));
-    assertThat(spec.getAgentMode(), equalTo("NONE"));
     assertThat(spec.getAgentCpuReq(), equalTo(0.7));
     assertThat(spec.getAgentCpuLimit(), equalTo(1.8));
     assertThat(spec.getAgentMemReq(), equalTo(513));

--- a/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
+++ b/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
@@ -3,6 +3,7 @@ package com.instana.operator.customresource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.instana.operator.util.FileUtil;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringStartsWith.startsWith;
@@ -58,10 +60,9 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentMemReq(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_REQ)));
     assertThat(spec.getAgentMemLimit(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_LIMIT)));
     assertThat(spec.getAgentHostRepository(), nullValue());
-
     assertThat(spec.getAgentDownloadKey(), nullValue());
-
     assertThat(spec.getAgentEnv().entrySet(), empty());
+    assertThat(spec.getClusterName(), nullValue());
   }
 
   @Test
@@ -79,6 +80,7 @@ class InstanaAgentSpecDeserializeTest {
         hasEntry(equalTo("configuration.yaml"), startsWith("# You can leave ")),
         hasEntry(equalTo("other"), startsWith("some other config file"))));
 
+    assertThat(spec.getAgentEnv().size(), is(8));
     assertThat(spec.getAgentEnv(), hasEntry(equalTo("INSTANA_AGENT_MODE"), equalTo("APM")));
 
     assertThat(spec.getAgentClusterRoleName(), equalTo("test-cluster-role"));
@@ -96,6 +98,7 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentMemLimit(), equalTo(518));
     assertThat(spec.getAgentHostRepository(), equalTo("/Users/stan/.m2/repository"));
     assertThat(spec.getAgentDownloadKey(), equalTo("test-download-key"));
+    assertThat(spec.getClusterName(), equalTo("test-cluster-name"));
   }
 
   @Test

--- a/src/test/resources/customresource-max.yaml
+++ b/src/test/resources/customresource-max.yaml
@@ -16,16 +16,16 @@ agent.cpuLimit: 1.8
 agent.memReq: 513
 agent.memLimit: 518
 agent.downloadKey: test-download-key
-agent.proxy.host: proxy.instana.io
-agent.proxy.port: 8443
-agent.proxy.protocol: https
-agent.proxy.user: proxy-user
-agent.proxy.password: proxy-password
-agent.proxy.use.dns: true
-agent.http.listen: 127.0.0.1
 agent.host.repository: /Users/stan/.m2/repository
 agent.env:
   INSTANA_AGENT_MODE: APM
+  INSTANA_AGENT_PROXY_HOST: proxy.instana.io
+  INSTANA_AGENT_PROXY_PORT: 8443
+  INSTANA_AGENT_PROXY_PROTOCOL: https
+  INSTANA_AGENT_PROXY_USER: proxy-user
+  INSTANA_AGENT_PROXY_PASSSWORD: proxy-password
+  INSTANA_AGENT_PROXY_USE_DNS: true
+  INSTANA_AGENT_HTTP_LISTEN: 127.0.0.1
 config.files:
     configuration.yaml: |
       # You can leave this empty, or use this to configure your instana agent.

--- a/src/test/resources/customresource-max.yaml
+++ b/src/test/resources/customresource-max.yaml
@@ -11,7 +11,6 @@ agent.configMapName: test-config-map
 agent.rbac.create: false
 agent.image: instana/test-image
 agent.image.tag: 1.2.3
-agent.mode: NONE
 agent.cpuReq: 0.7
 agent.cpuLimit: 1.8
 agent.memReq: 513
@@ -25,6 +24,8 @@ agent.proxy.password: proxy-password
 agent.proxy.use.dns: true
 agent.http.listen: 127.0.0.1
 agent.host.repository: /Users/stan/.m2/repository
+agent.env:
+  INSTANA_AGENT_MODE: APM
 config.files:
     configuration.yaml: |
       # You can leave this empty, or use this to configure your instana agent.

--- a/src/test/resources/customresource-max.yaml
+++ b/src/test/resources/customresource-max.yaml
@@ -1,3 +1,4 @@
+cluster.name: "test-cluster-name"
 agent.zone.name: my-k8s-cluster
 agent.key: _PUT_YOUR_AGENT_KEY_HERE_
 agent.endpoint.host: saas-us-west-2.instana.io


### PR DESCRIPTION
# Why

We changed the liveness checks in the other configurations (helm, yaml) and also introduced the ability to define arbitrary environment variables in the helm chart.

# What

- Bring the liveness checks in line with the other configurations
- Expose the ability to set arbitrary environment variables via the custom resource. This makes a lot of the values in the Custom Resource redundant as all they do is set an environment variable on the agent - we shouldn't need to maintain this here.
- Remove default `INSTANA_AGENT_HTTP_LISTEN=*` since this is not the default for other configurations.
- Add a test for the `AgentDeployer#newDaemonSet` method which (at this point) only checks the new environment variable logic.
- Update `customresource-max.yaml` with possible values of some environment variables, although this list is not exhaustive and probably doesn't need to be here.