### PR TITLE
Parameterize Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ There are two ways to install the operator:
 * [docs/install-manually.md](docs/install-manually.md) describes how to install the operator by creating the required resources manually.
 * [docs/install-via-olm.md](docs/install-via-olm.md) describes how to install the operator using the Operator Lifecycle Manager (OLM).
 
+### Configuration
+
+[docs/configuration.md](doc/configuration.md) describes configuration options you can set via the Instana Agent CRD. 
+
 ### Building
 
 [![CircleCI](https://circleci.com/gh/instana/instana-agent-operator.svg?style=svg)](https://circleci.com/gh/instana/instana-agent-operator)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,19 @@
+## Configuration
+
+The Instana Agent Custom resource supports the following values:
+
+| Parameter | Description |
+| --- | --- |
+| `agent.key` | Instana agent key |
+| `agent.endpoint` | Reporting endpoint from agent management page |
+| `agent.endpoint.port` | Reporting port `"443"` (wrapped in quotes) |
+| `agent.zone.name` | Name of zone to display for things discovered by these agents |
+| `cluster.name` | Name of this Kubernetes cluster to display in Instana |
+| `agent.env` | (optional) Can be used to specify environment variables for the agent, for instance, proxy configuration. See possible environment values [here](https://docs.instana.io/quick_start/agent_setup/container/docker/) |
+| `agent.image` | (optional) Can be used to override the agent image (defaults to `instana/agent:latest`) |
+| `config.files` | (optional) Additional files to mount for configuration. Each entry in this object is mounted in the agent as a file in `/root/<key>` |
+| `agent.downloadKey` | (optional) Download key for agent artifacts (usually not required) |
+| `agent.cpuReq` | (optional) CPU requests for agent in CPU cores |
+| `agent.cpuLimit` | (optional) CPU limits for agent in CPU cores |
+| `agent.memReq` | (optional) Memory requests for agent in Mi |
+| `agent.memLimit` | (optional) Memory limits for agent in Mi |

--- a/docs/install-manually.md
+++ b/docs/install-manually.md
@@ -24,9 +24,24 @@ Edit the template and replace at least the following values:
   * `agent.endpoint` must be set with the monitoring ingress endpoint, generally either `saas-us-west-2.instana.io` or `saas-eu-west-1.instana.io`.
   * `agent.endpoint.port` must be set with the monitoring ingress port, generally `"443"` (wrapped in quotes).
   * `agent.zone.name` should be set with the name of the Kubernetes cluster that is be displayed in Instana.
-  * `agent.env` can be used to specify environment variables for the agent, for instance, proxy configuration. See possible environment values [here](https://docs.instana.io/quick_start/agent_setup/container/docker/).
+  * `agent.env` can be used to specify environment variables for the agent, for instance, proxy configuration. See possible environment values [here](https://docs.instana.io/quick_start/agent_setup/container/docker/). For instance:
 
-In case you need to adapt `configuration.yaml`, view the documentation here: [https://docs.instana.io/quick_start/agent_setup/container/kubernetes/](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/).
+        agent.env:
+          INSTANA_AGENT_TAGS: staging
+
+  * `config.files` can be used to specify configuration files, for instance, specifying a `configuration.yaml`:
+
+        config.files:
+          configuration.yaml: |
+            # Example of configuration yaml template
+
+            # Host
+            #com.instana.plugin.host:
+            #  tags:
+            #    - 'dev'
+            #    - 'app1'
+
+     In case you need to adapt `configuration.yaml`, view the documentation here: [https://docs.instana.io/quick_start/agent_setup/container/kubernetes/](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/).
 
 Apply the edited custom resource:
 

--- a/olm/Dockerfile
+++ b/olm/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 RUN apk update
 
-RUN apk add jsonnet --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add jsonnet --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
 RUN apk add python3 bash git zip
 

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -266,6 +266,11 @@ public class AgentDeployer {
     DaemonSet daemonSet = load("instana-agent.daemonset.yaml", owner, op);
 
     Container container = daemonSet.getSpec().getTemplate().getSpec().getContainers().get(0);
+
+    if (!isBlank(config.getAgentImage())) {
+      container.setImage(config.getAgentImage());
+    }
+
     List<EnvVar> env = container.getEnv();
 
     env.add(createEnvVar("INSTANA_ZONE", config.getAgentZoneName()));

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
@@ -25,9 +25,7 @@ public class InstanaAgentSpec {
   static final String DEFAULT_AGENT_DAEMON_SET_NAME = "instana-agent";
   static final String DEFAULT_AGENT_CONFIG_MAP_NAME = "instana-agent";
   static final String DEFAULT_AGENT_RBAC_CREATE = "true";
-  static final String DEFAULT_AGENT_IMAGE_NAME = "instana/agent";
-  static final String DEFAULT_AGENT_IMAGE_TAG = "latest";
-  static final String DEFAULT_AGENT_MODE = "APM";
+  static final String DEFAULT_AGENT_IMAGE = "instana/agent:latest";
   static final String DEFAULT_AGENT_CPU_REQ = "0.5";
   static final String DEFAULT_AGENT_CPU_LIMIT = "1.5";
   static final String DEFAULT_AGENT_MEM_REQ = "512";
@@ -57,10 +55,8 @@ public class InstanaAgentSpec {
   private String agentConfigMapName = DEFAULT_AGENT_CONFIG_MAP_NAME;
   @JsonProperty(value = "agent.rbac.create", defaultValue = DEFAULT_AGENT_RBAC_CREATE)
   private Boolean agentRbacCreate = Boolean.parseBoolean(DEFAULT_AGENT_RBAC_CREATE);
-  @JsonProperty(value = "agent.image", defaultValue = DEFAULT_AGENT_IMAGE_NAME)
-  private String agentImageName = DEFAULT_AGENT_IMAGE_NAME;
-  @JsonProperty(value = "agent.image.tag", defaultValue = DEFAULT_AGENT_IMAGE_TAG)
-  private String agentImageTag = DEFAULT_AGENT_IMAGE_TAG;
+  @JsonProperty(value = "agent.image", defaultValue = DEFAULT_AGENT_IMAGE)
+  private String agentImage = DEFAULT_AGENT_IMAGE;
   @JsonProperty(value = "agent.cpuReq", defaultValue = DEFAULT_AGENT_CPU_REQ)
   private Double agentCpuReq = Double.parseDouble(DEFAULT_AGENT_CPU_REQ);
   @JsonProperty(value = "agent.cpuLimit", defaultValue = DEFAULT_AGENT_CPU_LIMIT)
@@ -178,20 +174,12 @@ public class InstanaAgentSpec {
     this.agentRbacCreate = agentRbacCreate;
   }
 
-  public String getAgentImageName() {
-    return agentImageName;
+  public String getAgentImage() {
+    return agentImage;
   }
 
-  public void setAgentImageName(String agentImageName) {
-    this.agentImageName = agentImageName;
-  }
-
-  public String getAgentImageTag() {
-    return agentImageTag;
-  }
-
-  public void setAgentImageTag(String agentImageTag) {
-    this.agentImageTag = agentImageTag;
+  public void setAgentImage(String agentImage) {
+    this.agentImage = agentImage;
   }
 
   public Double getAgentCpuReq() {

--- a/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
+++ b/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
@@ -3,7 +3,6 @@ package com.instana.operator.customresource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.instana.operator.util.FileUtil;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -14,8 +13,7 @@ import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_CPU_LIMIT;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_CPU_REQ;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_DAEMON_SET_NAME;
-import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_IMAGE_NAME;
-import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_IMAGE_TAG;
+import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_IMAGE;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MEM_LIMIT;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MEM_REQ;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_RBAC_CREATE;
@@ -53,8 +51,7 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentDaemonSetName(), equalTo(DEFAULT_AGENT_DAEMON_SET_NAME));
     assertThat(spec.getAgentConfigMapName(), equalTo(DEFAULT_AGENT_CONFIG_MAP_NAME));
     assertThat(spec.isAgentRbacCreate(), equalTo(Boolean.parseBoolean(DEFAULT_AGENT_RBAC_CREATE)));
-    assertThat(spec.getAgentImageName(), equalTo(DEFAULT_AGENT_IMAGE_NAME));
-    assertThat(spec.getAgentImageTag(), equalTo(DEFAULT_AGENT_IMAGE_TAG));
+    assertThat(spec.getAgentImage(), equalTo(DEFAULT_AGENT_IMAGE));
     assertThat(spec.getAgentCpuReq(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_REQ)));
     assertThat(spec.getAgentCpuLimit(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_LIMIT)));
     assertThat(spec.getAgentMemReq(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_REQ)));
@@ -90,8 +87,7 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentDaemonSetName(), equalTo("test-daemon-set"));
     assertThat(spec.getAgentConfigMapName(), equalTo("test-config-map"));
     assertThat(spec.isAgentRbacCreate(), equalTo(Boolean.FALSE));
-    assertThat(spec.getAgentImageName(), equalTo("instana/test-image"));
-    assertThat(spec.getAgentImageTag(), equalTo("1.2.3"));
+    assertThat(spec.getAgentImage(), equalTo("instana/test-image:1.2.3"));
     assertThat(spec.getAgentCpuReq(), equalTo(0.7));
     assertThat(spec.getAgentCpuLimit(), equalTo(1.8));
     assertThat(spec.getAgentMemReq(), equalTo(513));

--- a/src/test/resources/customresource-max.yaml
+++ b/src/test/resources/customresource-max.yaml
@@ -10,8 +10,7 @@ agent.secretName: test-secret
 agent.daemonSetName: test-daemon-set
 agent.configMapName: test-config-map
 agent.rbac.create: false
-agent.image: instana/test-image
-agent.image.tag: 1.2.3
+agent.image: instana/test-image:1.2.3
 agent.cpuReq: 0.7
 agent.cpuLimit: 1.8
 agent.memReq: 513


### PR DESCRIPTION
# Why

Some of our partners require that the image the operator deploys is parameterizable.

# What

This adds the ability to specify the agent image via the `agent.image` parameter in the Instana Agent custom resource.

This also improves the documentation around the parameters which are available for the operator.