### PR TITLE
Parameterize agent image via RELATED_IMAGE_INSTANA_AGENT env var

### DIFF
--- a/deploy/instana-agent-operator.yaml
+++ b/deploy/instana-agent-operator.yaml
@@ -207,3 +207,5 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
+        - name: RELATED_IMAGE_INSTANA_AGENT
+          value: instana/agent:latest

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -93,6 +93,8 @@ public class AgentDeployer {
   @Inject
   @Named(ExecutorProducer.CDI_HANDLER)
   ScheduledExecutorService executor;
+  @Inject
+  Environment environment;
 
   // The custom endpoints will be the owner of all resources we create.
   private InstanaAgent owner = null;
@@ -101,8 +103,6 @@ public class AgentDeployer {
   private Disposable[] watchers = null;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentDeployer.class);
-
-  private Environment environment = System::getenv;
 
   public void customResourceAdded(InstanaAgent customResource) {
     if (owner != null) {
@@ -301,7 +301,7 @@ public class AgentDeployer {
       env.add(createEnvVar("INSTANA_KUBERNETES_CLUSTER_NAME", config.getClusterName()));
     }
     config.getAgentEnv().forEach((k, v) -> env.add(createEnvVar(k, v)));
-    System.getenv().entrySet().stream()
+    environment.all().entrySet().stream()
         .filter(e -> e.getKey().startsWith("INSTANA_AGENT_") && !"INSTANA_AGENT_KEY".equals(e.getKey()))
         .forEach(e -> {
           env.add(createEnvVar(e.getKey().replaceAll("INSTANA_AGENT_", ""), e.getValue()));

--- a/src/main/java/com/instana/operator/CustomResourceWatcher.java
+++ b/src/main/java/com/instana/operator/CustomResourceWatcher.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.instana.operator.env.Environment.TARGET_NAMESPACES;
+
 @ApplicationScoped
 public class CustomResourceWatcher {
 
@@ -40,7 +42,7 @@ public class CustomResourceWatcher {
   @Inject
   MixedOperation<InstanaAgent, InstanaAgentList, DoneableInstanaAgent, Resource<InstanaAgent, DoneableInstanaAgent>> client;
   @Inject
-  @Named(NamespaceProducer.TARGET_NAMESPACES)
+  @Named(TARGET_NAMESPACES)
   Set<String> targetNamespaces;
   @Inject
   Event<CustomResourceDeleted> deletedEvent;

--- a/src/main/java/com/instana/operator/OperatorLeaderElector.java
+++ b/src/main/java/com/instana/operator/OperatorLeaderElector.java
@@ -4,7 +4,12 @@ import com.instana.operator.cache.Cache;
 import com.instana.operator.cache.CacheService;
 import com.instana.operator.events.OperatorLeaderElected;
 import com.instana.operator.events.OperatorPodValidated;
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.slf4j.Logger;
@@ -22,8 +27,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.instana.operator.env.NamespaceProducer.OPERATOR_NAMESPACE;
-import static com.instana.operator.env.OperatorPodNameProducer.POD_NAME;
+import static com.instana.operator.env.Environment.OPERATOR_NAMESPACE;
+import static com.instana.operator.env.Environment.POD_NAME;
 import static com.instana.operator.util.ResourceUtils.hasOwner;
 import static com.instana.operator.util.ResourceUtils.name;
 

--- a/src/main/java/com/instana/operator/OperatorPodLoader.java
+++ b/src/main/java/com/instana/operator/OperatorPodLoader.java
@@ -22,8 +22,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.instana.operator.env.NamespaceProducer.OPERATOR_NAMESPACE;
-import static com.instana.operator.env.OperatorPodNameProducer.POD_NAME;
+import static com.instana.operator.env.Environment.OPERATOR_NAMESPACE;
+import static com.instana.operator.env.Environment.POD_NAME;
 import static com.instana.operator.util.ResourceUtils.RUNNING;
 import static com.instana.operator.util.ResourceUtils.isRunning;
 

--- a/src/main/java/com/instana/operator/client/ClientConfigProducer.java
+++ b/src/main/java/com/instana/operator/client/ClientConfigProducer.java
@@ -1,6 +1,7 @@
 package com.instana.operator.client;
 
 import com.instana.operator.FatalErrorHandler;
+import com.instana.operator.env.Environment;
 import io.fabric8.kubernetes.client.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,14 +11,18 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import static com.instana.operator.env.Environment.KUBERNETES_SERVICE_HOST;
+import static com.instana.operator.env.Environment.KUBERNETES_SERVICE_PORT_HTTPS;
+
 @ApplicationScoped
 public class ClientConfigProducer {
 
   @Inject
   FatalErrorHandler fatalErrorHandler;
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientConfigProducer.class);
-  private static final String KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
-  private static final String KUBERNETES_SERVICE_PORT_HTTPS = "KUBERNETES_SERVICE_PORT_HTTPS";
+
+  @Inject
+  Environment environment;
 
   @Produces
   @Singleton
@@ -31,14 +36,14 @@ public class ClientConfigProducer {
     if (!config.getMasterUrl().contains("kubernetes.default.svc")) {
       return config;
     }
-    String kubeApiIp = System.getenv(KUBERNETES_SERVICE_HOST);
+    String kubeApiIp = environment.get(KUBERNETES_SERVICE_HOST);
     if (null == kubeApiIp) {
       LOGGER.error("Environment variable " + KUBERNETES_SERVICE_HOST + " not found. If you are running the operator" +
           " outside of a Kubernetes cluster, make sure that this variable is set to the IP address of the" +
           " Kubernetes API server.");
       fatalErrorHandler.systemExit(-1);
     }
-    String kubeApiPort = System.getenv(KUBERNETES_SERVICE_PORT_HTTPS);
+    String kubeApiPort = environment.get(KUBERNETES_SERVICE_PORT_HTTPS);
     if (null == kubeApiPort) {
       kubeApiPort = "443";
     }

--- a/src/main/java/com/instana/operator/client/KubernetesClientProducer.java
+++ b/src/main/java/com/instana/operator/client/KubernetesClientProducer.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static com.instana.operator.env.NamespaceProducer.OPERATOR_NAMESPACE;
+import static com.instana.operator.env.Environment.OPERATOR_NAMESPACE;
 import static com.instana.operator.util.StringUtils.isEmpty;
 import static okhttp3.ConnectionSpec.CLEARTEXT;
 

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
@@ -25,7 +25,6 @@ public class InstanaAgentSpec {
   static final String DEFAULT_AGENT_DAEMON_SET_NAME = "instana-agent";
   static final String DEFAULT_AGENT_CONFIG_MAP_NAME = "instana-agent";
   static final String DEFAULT_AGENT_RBAC_CREATE = "true";
-  static final String DEFAULT_AGENT_IMAGE = "instana/agent:latest";
   static final String DEFAULT_AGENT_CPU_REQ = "0.5";
   static final String DEFAULT_AGENT_CPU_LIMIT = "1.5";
   static final String DEFAULT_AGENT_MEM_REQ = "512";
@@ -55,8 +54,8 @@ public class InstanaAgentSpec {
   private String agentConfigMapName = DEFAULT_AGENT_CONFIG_MAP_NAME;
   @JsonProperty(value = "agent.rbac.create", defaultValue = DEFAULT_AGENT_RBAC_CREATE)
   private Boolean agentRbacCreate = Boolean.parseBoolean(DEFAULT_AGENT_RBAC_CREATE);
-  @JsonProperty(value = "agent.image", defaultValue = DEFAULT_AGENT_IMAGE)
-  private String agentImage = DEFAULT_AGENT_IMAGE;
+  @JsonProperty(value = "agent.image")
+  private String agentImage;
   @JsonProperty(value = "agent.cpuReq", defaultValue = DEFAULT_AGENT_CPU_REQ)
   private Double agentCpuReq = Double.parseDouble(DEFAULT_AGENT_CPU_REQ);
   @JsonProperty(value = "agent.cpuLimit", defaultValue = DEFAULT_AGENT_CPU_LIMIT)

--- a/src/main/java/com/instana/operator/env/Environment.java
+++ b/src/main/java/com/instana/operator/env/Environment.java
@@ -1,9 +1,31 @@
 package com.instana.operator.env;
 
-@FunctionalInterface
+import java.util.Map;
+
 public interface Environment {
 
   String RELATED_IMAGE_INSTANA_AGENT = "RELATED_IMAGE_INSTANA_AGENT";
+  String OPERATOR_NAMESPACE = "OPERATOR_NAMESPACE";
+  String TARGET_NAMESPACES = "TARGET_NAMESPACES";
+  String POD_NAME = "POD_NAME";
+  String KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
+  String KUBERNETES_SERVICE_PORT_HTTPS = "KUBERNETES_SERVICE_PORT_HTTPS";
 
   String get(String name);
+
+  Map<String, String> all();
+
+  static Environment fromMap(Map<String, String> map) {
+    return new Environment() {
+      @Override
+      public String get(String name) {
+        return map.get(name);
+      }
+
+      @Override
+      public Map<String, String> all() {
+        return map;
+      }
+    };
+  }
 }

--- a/src/main/java/com/instana/operator/env/Environment.java
+++ b/src/main/java/com/instana/operator/env/Environment.java
@@ -1,0 +1,9 @@
+package com.instana.operator.env;
+
+@FunctionalInterface
+public interface Environment {
+
+  String RELATED_IMAGE_INSTANA_AGENT = "RELATED_IMAGE_INSTANA_AGENT";
+
+  String get(String name);
+}

--- a/src/main/java/com/instana/operator/env/EnvironmentProducer.java
+++ b/src/main/java/com/instana/operator/env/EnvironmentProducer.java
@@ -1,0 +1,14 @@
+package com.instana.operator.env;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+@ApplicationScoped
+public class EnvironmentProducer {
+  @Produces
+  @Singleton
+  Environment getEnvironment() {
+    return Environment.fromMap(System.getenv());
+  }
+}

--- a/src/main/java/com/instana/operator/env/NamespaceProducer.java
+++ b/src/main/java/com/instana/operator/env/NamespaceProducer.java
@@ -18,12 +18,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static com.instana.operator.env.Environment.OPERATOR_NAMESPACE;
+import static com.instana.operator.env.Environment.TARGET_NAMESPACES;
+
 @ApplicationScoped
 public class NamespaceProducer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NamespaceProducer.class);
-  public static final String OPERATOR_NAMESPACE = "OPERATOR_NAMESPACE";
-  public static final String TARGET_NAMESPACES = "TARGET_NAMESPACES";
+
 
   // From the CSV deployment spec:
   // ----------------------------------------------
@@ -42,6 +44,9 @@ public class NamespaceProducer {
 
   @Inject
   FatalErrorHandler fatalErrorHandler;
+
+  @Inject
+  Environment environment;
 
   @Produces
   @Singleton
@@ -76,7 +81,7 @@ public class NamespaceProducer {
   @Named(TARGET_NAMESPACES)
   Set<String> loadTargetNamespaces() {
     Set<String> result = new TreeSet<>();
-    String targetNamespaces = System.getenv(TARGET_NAMESPACES);
+    String targetNamespaces = environment.get(TARGET_NAMESPACES);
     if (!StringUtils.isBlank(targetNamespaces)) {
       for (String ns : targetNamespaces.split(",")) {
         result.add(ns.trim());
@@ -95,6 +100,6 @@ public class NamespaceProducer {
   }
 
   private Optional<String> loadOperatorNamespaceFromEnv() {
-    return Optional.ofNullable(System.getenv(OPERATOR_NAMESPACE)).filter(s -> !StringUtils.isBlank(s));
+    return Optional.ofNullable(environment.get(OPERATOR_NAMESPACE)).filter(s -> !StringUtils.isBlank(s));
   }
 }

--- a/src/main/java/com/instana/operator/env/OperatorPodNameProducer.java
+++ b/src/main/java/com/instana/operator/env/OperatorPodNameProducer.java
@@ -10,20 +10,24 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import static com.instana.operator.env.Environment.POD_NAME;
+
 @ApplicationScoped
 public class OperatorPodNameProducer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OperatorPodNameProducer.class);
-  public static final String POD_NAME = "POD_NAME";
 
   @Inject
   FatalErrorHandler fatalErrorHandler;
+
+  @Inject
+  Environment environment;
 
   @Produces
   @Singleton
   @Named(POD_NAME)
   String findPodName() {
-    String podName = System.getenv(POD_NAME);
+    String podName = environment.get(POD_NAME);
     if (podName == null) {
       LOGGER.error("Environment variable " + POD_NAME + " not found." +
           " Please ensure the Downward API for " + POD_NAME + " is set using the provided YAML.");

--- a/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
+++ b/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
@@ -3,6 +3,7 @@ package com.instana.operator.customresource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.instana.operator.util.FileUtil;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -13,7 +14,6 @@ import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_CPU_LIMIT;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_CPU_REQ;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_DAEMON_SET_NAME;
-import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_IMAGE;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MEM_LIMIT;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_MEM_REQ;
 import static com.instana.operator.customresource.InstanaAgentSpec.DEFAULT_AGENT_RBAC_CREATE;
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringStartsWith.startsWith;
@@ -43,6 +44,7 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentEndpointHost(), equalTo("saas-us-west-2.instana.io"));
     assertThat(spec.getAgentEndpointPort(), equalTo(443));
     assertThat(spec.getConfigFiles().entrySet(), empty());
+    assertThat(spec.getAgentImage(), is(nullValue()));
 
     assertThat(spec.getAgentClusterRoleName(), equalTo(DEFAULT_AGENT_CLUSTER_ROLE_NAME));
     assertThat(spec.getAgentClusterRoleBindingName(), equalTo(DEFAULT_AGENT_CLUSTER_ROLE_BINDING_NAME));
@@ -51,7 +53,6 @@ class InstanaAgentSpecDeserializeTest {
     assertThat(spec.getAgentDaemonSetName(), equalTo(DEFAULT_AGENT_DAEMON_SET_NAME));
     assertThat(spec.getAgentConfigMapName(), equalTo(DEFAULT_AGENT_CONFIG_MAP_NAME));
     assertThat(spec.isAgentRbacCreate(), equalTo(Boolean.parseBoolean(DEFAULT_AGENT_RBAC_CREATE)));
-    assertThat(spec.getAgentImage(), equalTo(DEFAULT_AGENT_IMAGE));
     assertThat(spec.getAgentCpuReq(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_REQ)));
     assertThat(spec.getAgentCpuLimit(), equalTo(Double.parseDouble(DEFAULT_AGENT_CPU_LIMIT)));
     assertThat(spec.getAgentMemReq(), equalTo(Integer.parseInt(DEFAULT_AGENT_MEM_REQ)));


### PR DESCRIPTION
Operator Lifecycle Manager requires the `RELATED_IMAGE_` environment variable to parameterize the operator image.

This adds that as well as improving testability of Environment variables within the operator codebase by introducing an Environment class which wraps `System.getenv`. This allows injection of the environment variables for testing.