### PR TITLE
Allow for an unchanging 'latest' version of the instana-agent-operator.yaml to be published

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,16 +30,15 @@ pipeline {
           def VERSION = dockerVersion(TAG)
           def BUILD_ARGS = "-f $DOCKERFILE --pull --build-arg VERSION=$VERSION --build-arg BUILD=$BUILD_NUMBER ."
 
-          docker.withRegistry('https://index.docker.io/v1/', '8a04e3ab-c6db-44af-8198-1beb391c98d2') {
-            def image = docker.build("instana/instana-agent-operator:$VERSION", BUILD_ARGS)
+          if (isFullRelease(TAG)) {
+            docker.withRegistry('https://index.docker.io/v1/', '8a04e3ab-c6db-44af-8198-1beb391c98d2') {
+              def image = docker.build("instana/instana-agent-operator:$VERSION", BUILD_ARGS)
 
-            image.push()
-
-            if (isFullRelease(TAG)) {
+              image.push()
               image.push('latest')
-            } else {
-              echo "Skipping pushing latest tag because this is a pre-release or branch."
             }
+          } else {
+            echo "Skipping pushing tag because this is a pre-release or branch."
           }
 
           if (isFullRelease(TAG)) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,8 +81,8 @@ pipeline {
       post {
         success {
           archiveArtifacts artifacts: 'target/redhat-*.zip'
-          archiveArtifacts artifacts: 'target/olm/*'
-          archiveArtifacts artifacts: 'target/operator-resources/*'
+          archiveArtifacts artifacts: 'target/olm-*.zip'
+          archiveArtifacts artifacts: 'target/operator-resources/**/*'
         }
       }
     }

--- a/olm/create-artifacts.sh
+++ b/olm/create-artifacts.sh
@@ -25,11 +25,11 @@ CRD_DESCRIPTORS=$(${SCRIPTPATH}/yaml_to_json < "$SCRIPTPATH/CRD.descriptors.yaml
 EXAMPLES=$(${SCRIPTPATH}/yaml_to_json < "$SCRIPTPATH/../deploy/instana-agent.customresource.yaml")
 
 # Generate versioned operator artifacts if they do not exist
-if [[ ! -f "$OPERATOR_RESOURCES_DIR/instana-agent-operator.v$VERSION.yaml" ]] ; then
+if [[ ! -f "$OPERATOR_RESOURCES_DIR/$VERSION/instana-agent-operator.yaml" ]] ; then
   ${SCRIPTPATH}/operator-resources/create-operator-artifacts.sh ${VERSION}
 fi
 
-RESOURCES=$(${SCRIPTPATH}/yaml_to_json < "$OPERATOR_RESOURCES_DIR/instana-agent-operator.v$VERSION.yaml")
+RESOURCES=$(${SCRIPTPATH}/yaml_to_json < "$OPERATOR_RESOURCES_DIR/$VERSION/instana-agent-operator.yaml")
 
 mkdir -p ${MANIFEST_DIR}
 

--- a/olm/operator-resources/create-github-release.sh
+++ b/olm/operator-resources/create-github-release.sh
@@ -13,7 +13,7 @@ fi
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../.."
 TARGET_DIR="$ROOT_DIR/target"
 MANIFEST_NAME="operator-resources"
-MANIFEST_DIR="$TARGET_DIR/$MANIFEST_NAME"
+MANIFEST_DIR="$TARGET_DIR/$MANIFEST_NAME/$VERSION"
 GITHUB_RELEASES_URL="https://api.github.com/repos/instana/instana-agent-operator/releases"
 
 printf "%s" "Checking if release v${VERSION} exists..."
@@ -37,7 +37,7 @@ if [[ -z "${GITHUB_RELEASE_ID}" ]] || [[ ${GITHUB_RELEASE_ID} == "null" ]]; then
   fi
 fi
 
-OPERATOR_RESOURCE_FILENAME="instana-agent-operator.v${VERSION}.yaml"
+OPERATOR_RESOURCE_FILENAME="instana-agent-operator.yaml"
 OPERATOR_RESOURCE="${MANIFEST_DIR}/${OPERATOR_RESOURCE_FILENAME}"
 
 upload_github_asset() {

--- a/olm/operator-resources/create-operator-artifacts.sh
+++ b/olm/operator-resources/create-operator-artifacts.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$ROOT_DIR/olm"
 MANIFEST_NAME="operator-resources"
 OPERATOR_RESOURCES_DIR="$SCRIPT_DIR/$MANIFEST_NAME"
 TARGET_DIR="$ROOT_DIR/target"
-MANIFEST_DIR="$TARGET_DIR/$MANIFEST_NAME"
+MANIFEST_DIR="$TARGET_DIR/$MANIFEST_NAME/$VERSION"
 OPERATOR_RESOURCES=$(${SCRIPT_DIR}/yaml_to_json < "$OPERATOR_RESOURCES_DIR/instana-agent-operator.yaml")
 
 mkdir -p ${MANIFEST_DIR}
@@ -33,4 +33,4 @@ do
   rm ${f}
 done
 
-mv ${TARGET_DIR}/instana-agent-operator.v${VERSION}.yaml ${MANIFEST_DIR}/instana-agent-operator.v${VERSION}.yaml
+mv ${TARGET_DIR}/instana-agent-operator.v${VERSION}.yaml ${MANIFEST_DIR}/instana-agent-operator.yaml


### PR DESCRIPTION
Changeset includes:
- Only publish to docker for full releases
- Don't version the instana-agent-operator.yaml filename. Instead place it in a versioned directory. This is so that we can use the 'latest' GitHub Release url to link to that file such that the url never changes when new versions are released