### PR TITLE
Remove version from deployment label selector

### DIFF
--- a/olm/operator-resources/operator-artifacts.jsonnet
+++ b/olm/operator-resources/operator-artifacts.jsonnet
@@ -2,20 +2,17 @@ local operatorResources = std.parseJson(std.extVar('operatorResources'));
 local version = std.extVar('version');
 
 local addVersionToMetadataLabels(resource) = resource + {
-	metadata+: { labels+:
-	 super.labels + { "app.kubernetes.io/version": version }
-	}
+  metadata+: { labels+:
+    super.labels + { "app.kubernetes.io/version": version }
+  }
 };
 local operatorResourcesWithVersion = std.map(addVersionToMetadataLabels, operatorResources);
 
 local addVersionToDeploymentSpec(deployment) = deployment + {
   spec+: {
-    selector+: { matchLabels+:
-      super.matchLabels + { "app.kubernetes.io/version": version }
-  	},
-  	template+: { metadata+: { labels+:
-  	  super.labels + { "app.kubernetes.io/version": version }
-  	}}
+    template+: { metadata+: { labels+:
+      super.labels + { "app.kubernetes.io/version": version }
+    }}
   }
 };
 local isDeployment(res) = res.kind == "Deployment";


### PR DESCRIPTION
This breaks doing `kubectl apply` to upgrade

The error I get is

```
The Deployment "instana-agent-operator" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"instana-agent-operator", "app.kubernetes.io/version":"0.3.1"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

I don't think the version should be in the label selectors because since this field is immutable, one would need to delete the deployment and recreate it when upgrading. The only reason the version _would_ need to be in the label selector is if we were supporting running multiple versions at once, which we do not need to support.