### PR TITLE
Add StatefulSet, DaemonSet, CronJobs to agent permissions

### DIFF
--- a/src/main/resources/instana-agent.clusterrole.yaml
+++ b/src/main/resources/instana-agent.clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   - apiGroups: ["batch"]
     resources:
       - "jobs"
+      - "cronjobs"
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions"]
     resources:
@@ -27,6 +28,8 @@ rules:
     resources:
       - "deployments"
       - "replicasets"
+      - "daemonsets"
+      - "statefulsets"
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources:
@@ -44,6 +47,10 @@ rules:
     resources:
       - "endpoints"
     verbs: ["create", "update", "patch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - "ingresses"
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps.openshift.io"]
     resources:
       - "deploymentconfigs"


### PR DESCRIPTION
They are added to the operator permissions, but unfortunately we need to add them to two places in the operator

1) for the operator to get the permissions, so it can grant them to the agent
2) for the agent itself

We should consider generating these permissions as well at some point.