### PR TITLE
Update instana-agent.daemonset.yaml

### DIFF
--- a/src/main/resources/instana-agent.daemonset.yaml
+++ b/src/main/resources/instana-agent.daemonset.yaml
@@ -18,6 +18,7 @@ spec:
         app: instana-agent
     spec:
       serviceAccountName: instana-agent
+      dnsPolicy: ClusterFirstWithHostNet
       hostIPC: true
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Currently agent can't resolve internal cluster hostnames because it has wrong (default) dns policy. Because of that it can't scrape metrics from cluster services. According to kubernetes documentation(https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) dnsPolicy for pods with `hostNetwork: true` should be set to ClusterFirstHostNet
Fixes #42 