### PR TITLE
Add labels to the Agent resources to help identify how the Agent is installed

### DIFF
--- a/olm/operator-resources/instana-agent-operator.yaml
+++ b/olm/operator-resources/instana-agent-operator.yaml
@@ -171,7 +171,7 @@ roleRef:
   name: instana-agent-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: agents.instana.io

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.2.9</version>

--- a/src/main/resources/instana-agent.clusterrole.yaml
+++ b/src/main/resources/instana-agent.clusterrole.yaml
@@ -8,6 +8,8 @@ metadata:
       kind: InstanaAgent
       name: placeholder
       uid: placeholder
+  labels:
+    app.kubernetes.io/managed-by: instana-agent-operator
 rules:
   - nonResourceURLs:
       - "/version"

--- a/src/main/resources/instana-agent.clusterrolebinding.yaml
+++ b/src/main/resources/instana-agent.clusterrolebinding.yaml
@@ -8,6 +8,8 @@ metadata:
       kind: InstanaAgent
       name: placeholder
       uid: placeholder
+  labels:
+    app.kubernetes.io/managed-by: instana-agent-operator
 subjects:
   - kind: ServiceAccount
     name: instana-agent

--- a/src/main/resources/instana-agent.configmap.yaml
+++ b/src/main/resources/instana-agent.configmap.yaml
@@ -8,4 +8,6 @@ metadata:
       kind: InstanaAgent
       name: placeholder
       uid: placeholder
+  labels:
+    app.kubernetes.io/managed-by: instana-agent-operator
 data: {}

--- a/src/main/resources/instana-agent.daemonset.yaml
+++ b/src/main/resources/instana-agent.daemonset.yaml
@@ -8,6 +8,8 @@ metadata:
       kind: InstanaAgent
       name: placeholder
       uid: placeholder
+  labels:
+    app.kubernetes.io/managed-by: instana-agent-operator
 spec:
   selector:
     matchLabels:

--- a/src/main/resources/instana-agent.secret.yaml
+++ b/src/main/resources/instana-agent.secret.yaml
@@ -8,6 +8,8 @@ metadata:
       kind: InstanaAgent
       name: placeholder
       uid: placeholder
+  labels:
+    app.kubernetes.io/managed-by: instana-agent-operator
 type: Opaque
 data:
   key: placeholder

--- a/src/main/resources/instana-agent.serviceaccount.yaml
+++ b/src/main/resources/instana-agent.serviceaccount.yaml
@@ -8,3 +8,5 @@ metadata:
       kind: InstanaAgent
       name: placeholder
       uid: placeholder
+  labels:
+    app.kubernetes.io/managed-by: instana-agent-operator

--- a/src/test/java/com/instana/operator/AgentDeployerTest.java
+++ b/src/test/java/com/instana/operator/AgentDeployerTest.java
@@ -1,31 +1,56 @@
 package com.instana.operator;
 
+import static com.instana.operator.env.Environment.RELATED_IMAGE_INSTANA_AGENT;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.google.common.collect.ImmutableMap;
 import com.instana.operator.customresource.InstanaAgent;
 import com.instana.operator.customresource.InstanaAgentSpec;
 import com.instana.operator.env.Environment;
+
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.api.model.apps.DaemonSet;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import org.junit.jupiter.api.Test;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 
-import java.util.Collections;
+public class AgentDeployerTest {
 
-import static com.instana.operator.env.Environment.RELATED_IMAGE_INSTANA_AGENT;
-import static java.util.Collections.emptyMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
+  private DefaultKubernetesClient client;
+  private KubernetesMockServer server;
 
-class AgentDeployerTest {
+  @BeforeEach
+  public void setup() {
+    server = new KubernetesMockServer();
+    server.start();
+    client = (DefaultKubernetesClient) server.createClient();
+  }
 
-  private final DefaultKubernetesClient client = new DefaultKubernetesClient();
+  @AfterEach
+  public void teardown() {
+    server.shutdown();
+  }
 
   @Test
   void daemonset_must_include_environment() {
     AgentDeployer deployer = new AgentDeployer();
+    deployer.setDefaultClient(client);
     deployer.setEnvironment(empty());
 
     InstanaAgentSpec agentSpec = new InstanaAgentSpec();
@@ -33,11 +58,11 @@ class AgentDeployerTest {
         .put("INSTANA_AGENT_MODE", "APM")
         .build());
 
-    InstanaAgent crd = new InstanaAgent();
-    crd.setSpec(agentSpec);
+    InstanaAgent customResource = new InstanaAgent();
+    customResource.setSpec(agentSpec);
 
     DaemonSet daemonSet = deployer.newDaemonSet(
-        crd,
+        customResource,
         client.inNamespace("instana-agent").apps().daemonSets());
 
     Container agentContainer = getAgentContainer(daemonSet);
@@ -49,16 +74,17 @@ class AgentDeployerTest {
   @Test
   void daemonset_must_include_specified_image() {
     AgentDeployer deployer = new AgentDeployer();
+    deployer.setDefaultClient(client);
     deployer.setEnvironment(empty());
 
     InstanaAgentSpec agentSpec = new InstanaAgentSpec();
     agentSpec.setAgentImage("other/image:some-tag");
 
-    InstanaAgent crd = new InstanaAgent();
-    crd.setSpec(agentSpec);
+    InstanaAgent customResource = new InstanaAgent();
+    customResource.setSpec(agentSpec);
 
     DaemonSet daemonSet = deployer.newDaemonSet(
-        crd,
+        customResource,
         client.inNamespace("instana-agent").apps().daemonSets());
 
     Container agentContainer = getAgentContainer(daemonSet);
@@ -70,18 +96,78 @@ class AgentDeployerTest {
   @Test
   void daemonset_must_include_image_from_csv_if_specified() {
     AgentDeployer deployer = new AgentDeployer();
+    deployer.setDefaultClient(client);
     deployer.setEnvironment(singleVar(RELATED_IMAGE_INSTANA_AGENT, "other/image:some-tag"));
 
-    InstanaAgent crd = new InstanaAgent();
-    crd.setSpec(new InstanaAgentSpec());
+    InstanaAgent customResource = new InstanaAgent();
+    customResource.setSpec(new InstanaAgentSpec());
 
     DaemonSet daemonSet = deployer.newDaemonSet(
-        crd,
+        customResource,
         client.inNamespace("instana-agent").apps().daemonSets());
 
     Container agentContainer = getAgentContainer(daemonSet);
 
     assertThat(agentContainer.getImage(), is("other/image:some-tag"));
+  }
+
+  @Test
+  public void daemonset_must_include_version_label_if_specified_on_crd() {
+    server
+        .expect()
+        .get()
+        .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/agents.instana.io")
+        .andReturn(HTTP_OK, new CustomResourceDefinitionBuilder()
+                  .withNewMetadata()
+                  .withName("agents.instana.io")
+                  .withLabels(ImmutableMap.of("app.kubernetes.io/version", "0.3.8"))
+                  .endMetadata()
+                  .build())
+        .always();
+
+    AgentDeployer deployer = new AgentDeployer();
+    deployer.setDefaultClient(client);
+    deployer.setEnvironment(empty());
+
+    InstanaAgent customResource = new InstanaAgent();
+    customResource.setSpec(new InstanaAgentSpec());
+
+    DaemonSet daemonSet = deployer.newDaemonSet(
+        customResource,
+        client.inNamespace("instana-agent").apps().daemonSets());
+
+    Map<String, String> labels = daemonSet.getMetadata().getLabels();
+    assertThat(labels, hasEntry(is("app.kubernetes.io/managed-by"), is("instana-agent-operator")));
+    assertThat(labels, hasEntry(is("app.kubernetes.io/version"), is("0.3.8")));
+  }
+
+  @Test
+  public void daemonset_must_not_include_version_label_if_not_specified_on_crd() {
+    server
+        .expect()
+        .get()
+        .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/agents.instana.io")
+        .andReturn(HTTP_OK, new CustomResourceDefinitionBuilder()
+            .withNewMetadata()
+            .withName("agents.instana.io")
+            .endMetadata()
+            .build())
+        .always();
+
+    AgentDeployer deployer = new AgentDeployer();
+    deployer.setDefaultClient(client);
+    deployer.setEnvironment(empty());
+
+    InstanaAgent customResource = new InstanaAgent();
+    customResource.setSpec(new InstanaAgentSpec());
+
+    DaemonSet daemonSet = deployer.newDaemonSet(
+        customResource,
+        client.inNamespace("instana-agent").apps().daemonSets());
+
+    Map<String, String> labels = daemonSet.getMetadata().getLabels();
+    assertThat(labels, hasEntry(is("app.kubernetes.io/managed-by"), is("instana-agent-operator")));
+    assertThat(labels, not(hasKey("app.kubernetes.io/version")));
   }
 
   private Container getAgentContainer(DaemonSet daemonSet) {
@@ -95,5 +181,4 @@ class AgentDeployerTest {
   private Environment singleVar(String key, String value) {
     return Environment.fromMap(Collections.singletonMap(key, value));
   }
-
 }


### PR DESCRIPTION
### Why

As part of the hand-off of the K8s artifacts to Team Agent, one of the things we want to understand better is how our customers are installing the Instana Agent on their Kubernetes clusters.

Agents installed by Helm similarly have `app.kubernetes.io/managed-by` and `app.kubernetes.io/version` labels on the Kubernetes resources that get created (specifically the DaemonSet). We want to use these labels to build telemetry data to better understand how our customers are installing the agent.

### What

- Add `app.kubernetes.io/managed-by` and `app.kubernetes.io/version` labels to the Agent resources to help identify how the Agent is installed. The `app.kubernetes.io/managed-by` label can be added in the specific resource's YAML, but the `app.kubernetes.io/version` label has to be added dynamically from the `CustomResourceDefinition` just after the resource is loaded from its YAML. In order to test this, I had to add the `quarkus-test-kubernetes-client` dependency to get access to fabric8's Kubernetes test framework.

- The `apiextensions.k8s.io/v1beta1` version of CustomResourceDefinition is deprecated and will no longer be served in v1.19. Use `apiextensions.k8s.io/v1` instead. This is according to the ['Deprecations and Removals' section](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals) of the Kubernetes changelog for 1.16