### PR TITLE
Upload RedHat Operator bundle automatically for full release tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ local.properties
 
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# macOS files
+.DS_Store

--- a/olm/operator-resources/create-github-release.sh
+++ b/olm/operator-resources/create-github-release.sh
@@ -16,7 +16,7 @@ MANIFEST_NAME="operator-resources"
 MANIFEST_DIR="$TARGET_DIR/$MANIFEST_NAME/$VERSION"
 GITHUB_RELEASES_URL="https://api.github.com/repos/instana/instana-agent-operator/releases"
 
-printf "%s" "Checking if release v${VERSION} exists..."
+printf "%s\n" "Checking if release v${VERSION} exists..."
 GITHUB_RELEASE_RESPONSE=$(curl -X GET \
   -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
   ${GITHUB_RELEASES_URL}/tags/v${VERSION})

--- a/olm/operator-resources/download-github-release-assets.sh
+++ b/olm/operator-resources/download-github-release-assets.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+VERSION=$1
+GITHUB_OAUTH_TOKEN=$2
+
+if [[ -z ${VERSION} ]] || [[ -z ${GITHUB_OAUTH_TOKEN} ]]; then
+  echo "Please ensure VERSION and GITHUB_OAUTH_TOKEN are set to continue"
+  exit 1
+fi
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../.."
+TARGET_DIR="$ROOT_DIR/target"
+DOWNLOAD_DIR="$TARGET_DIR/downloads/$VERSION"
+GITHUB_RELEASES_URL="https://api.github.com/repos/instana/instana-agent-operator/releases"
+
+mkdir -p ${DOWNLOAD_DIR}
+
+function github_curl() {
+  curl -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
+       -H "Accept: application/vnd.github.v3.raw" \
+       $@
+}
+
+printf "%s\n" "Checking if release v${VERSION} exists..."
+GITHUB_RELEASE_RESPONSE=$(github_curl ${GITHUB_RELEASES_URL}/tags/v${VERSION})
+
+GITHUB_RELEASE_ID=$(echo ${GITHUB_RELEASE_RESPONSE} | jq .id)
+if [[ -z "${GITHUB_RELEASE_ID}" ]] || [[ ${GITHUB_RELEASE_ID} == "null" ]]; then
+  printf "\n%s" "GitHub Release ${GITHUB_RELEASE_ID} does not exists. Cannot download assets."
+  exit 0
+fi
+
+ASSET_URLS=$(echo ${GITHUB_RELEASE_RESPONSE} | jq -r ".assets | .[].browser_download_url")
+
+# convert multiline string to array
+SAVEIFS=$IFS              # Save current IFS
+IFS=$'\n'                 # Change IFS to new line
+ASSET_URLS=($ASSET_URLS)  # split to array
+IFS=$SAVEIFS              # Restore IFS
+
+function download_github_asset() {
+  printf "%s\n" "Downloading asset ${1}"
+  wget -q --auth-no-challenge \
+    --header='Accept:application/octet-stream' \
+    -P ${DOWNLOAD_DIR} \
+    ${1}
+}
+
+printf "%s\n" "Downloading assets to ${DOWNLOAD_DIR}"
+for (( i=0; i<${#ASSET_URLS[@]}; i++ ))
+do
+  download_github_asset ${ASSET_URLS[$i]}
+done


### PR DESCRIPTION
## Why

RedHat has recently changed the process for updating a new version of the operator. One of the last steps of this process was to upload the operator bundle, which includes some metadata and manifests in the form of yaml files. This used to be a manual process by which we would upload a zip file at this location: https://connect.redhat.com/project/3928601/operator-metadata. However, there is now an Operator Bundle project https://connect.redhat.com/project/5791371/images, where you can upload a docker container image containing the same files. Therefore, we should perform this last step automatically instead of having to remember to do this manually.

## What

Update the Jenkins pipeline to download all the assets for a specific GitHub Release (so as to not assume that those assets are available on hand, for when we do move this pipeline to Concourse and each pipeline job being run in a separate container with a clean slate). Then unzip the specific `redhat-<version>.zip` file, build a docker container containing those files in that zip directory, and upload that container image to the RedHat registry so it shows up in the `Instana-Agent-Operator-Bundle` project: https://connect.redhat.com/project/5791371/images