### PR TITLE
[Breaking change] Upgrade quarkus from 1.2.1.Final to 1.9.0.Final

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,9 +33,7 @@ pipeline {
           if (isFullRelease(TAG)) {
             docker.withRegistry('https://index.docker.io/v1/', '8a04e3ab-c6db-44af-8198-1beb391c98d2') {
               def image = docker.build("instana/instana-agent-operator:$VERSION", BUILD_ARGS)
-
               image.push()
-              image.push('latest')
             }
           } else {
             echo "Skipping pushing tag because this is a pre-release or branch."
@@ -46,7 +44,6 @@ pipeline {
               // annoyingly no way to reuse the existing image with docker jenkins plugin.
               // probably should just pull all of this into a shell script
               def image = docker.build("scan.connect.redhat.com/ospid-6da7e6aa-00e1-4355-9c15-21d63fb091b6/instana-agent-operator:$VERSION", BUILD_ARGS)
-
               image.push()
             }
           }

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This repository contains the Kubernetes Operator to install and manage the Insta
 
 There are two ways to install the operator:
 
-* [Creating the required resources manually](https://docs.instana.io/setup_and_manage/host_agent/on/kubernetes/#install-operator-manually)
-* [Using the Operator Lifecycle Manager (OLM)](https://docs.instana.io/setup_and_manage/host_agent/on/openshift/#install-operator-via-olm)
+* [Creating the required resources manually](https://www.instana.com/docs/setup_and_manage/host_agent/on/kubernetes/#install-operator-manually)
+* [Using the Operator Lifecycle Manager (OLM)](https://www.instana.com/docs/setup_and_manage/host_agent/on/openshift/#install-operator-via-olm)
 
 ### Configuration
 
-[This documentation section](https://docs.instana.io/setup_and_manage/host_agent/on/kubernetes#operator-configuration) describes configuration options you can set via the Instana Agent CRD and environment variables.
+[This documentation section](https://www.instana.com/docs/setup_and_manage/host_agent/on/kubernetes#operator-configuration) describes configuration options you can set via the Instana Agent CRD and environment variables.
 
 ### Building
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,7 +4,7 @@ Building the Instana Agent Operator from Source
 The following command will build the `instana/instana-agent-operator` Docker image locally:
 
 ```bash
-./mvnw package
+./mvnw -C -B clean package
 docker build -f src/main/docker/Dockerfile.jvm -t instana/instana-agent-operator .
 ```
 
@@ -13,6 +13,6 @@ To build the Docker image with GraalVM native image, use the following command:
 > Note: The native image does not work yet because of [https://github.com/quarkusio/quarkus/issues/3077](https://github.com/quarkusio/quarkus/issues/3077)
 
 ```bash
-./mvnw package -Pnative -Dnative-image.docker-build=true
+./mvnw -C -B clean package -Pnative -Dnative-image.docker-build=true
 docker build -f src/main/docker/Dockerfile.native -t instana/instana-agent-operator .
 ```

--- a/e2e-testing/with-kind/create-cluster.sh
+++ b/e2e-testing/with-kind/create-cluster.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+VERSION=${1:-dev}
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BASE_DIR="$SCRIPT_DIR/../../"
+OS_NAME=$(uname | tr '[:upper:]' '[:lower:]')
+KIND_CONFIG_FILE="$SCRIPT_DIR/kind-config-$OS_NAME.yaml"
+
+printf "%s\n" "Creating cluster with kind-config-$OS_NAME.yaml"
+kind --config $KIND_CONFIG_FILE create cluster
+
+kubectl get nodes
+
+printf "%s\n" "Build and load Operator image into kind cluster"
+./mvnw -C -B clean package
+docker build -f $BASE_DIR/src/main/docker/Dockerfile.jvm -t instana/instana-agent-operator:$VERSION $BASE_DIR
+kind load docker-image instana/instana-agent-operator
+
+printf "%s\n" "Load Agent image into kind cluster"
+docker pull instana/agent
+kind load docker-image instana/agent

--- a/e2e-testing/with-kind/delete-cluster.sh
+++ b/e2e-testing/with-kind/delete-cluster.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+kind delete cluster

--- a/e2e-testing/with-kind/kind-config-darwin.yaml
+++ b/e2e-testing/with-kind/kind-config-darwin.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - containerPath: /hosthome
+        hostPath: /Users
+  - role: worker
+    extraMounts:
+      - containerPath: /hosthome
+        hostPath: /Users
+  - role: worker
+    extraMounts:
+      - containerPath: /hosthome
+        hostPath: /Users

--- a/e2e-testing/with-kind/kind-config-linux.yaml
+++ b/e2e-testing/with-kind/kind-config-linux.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - containerPath: /hosthome
+        hostPath: /home
+  - role: worker
+    extraMounts:
+      - containerPath: /hosthome
+        hostPath: /home
+  - role: worker
+    extraMounts:
+      - containerPath: /hosthome
+        hostPath: /home

--- a/olm/operator-resources/instana-agent-operator.yaml
+++ b/olm/operator-resources/instana-agent-operator.yaml
@@ -67,9 +67,9 @@ rules:
   - 'events'
   verbs:
   - 'create'
-# -------------------------------------------------------------------------
-# For the custom resource, the operator needs list, watch, get, update.
-# -------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# For the custom resource, the operator needs list, watch, get, update, create.
+# -----------------------------------------------------------------------------
 - apiGroups:
   - 'instana.io'
   resources:
@@ -79,6 +79,7 @@ rules:
   - 'update'
   - 'list'
   - 'watch'
+  - 'create'
 # -------------------------------------------------------------------------
 # Below are the permissions are for the agent.
 # The operator needs these permissions to create the agent's cluster role.

--- a/olm/operator-resources/operator-artifacts.jsonnet
+++ b/olm/operator-resources/operator-artifacts.jsonnet
@@ -10,9 +10,15 @@ local operatorResourcesWithVersion = std.map(addVersionToMetadataLabels, operato
 
 local addVersionToDeploymentSpec(deployment) = deployment + {
   spec+: {
-    template+: { metadata+: { labels+:
-      super.labels + { "app.kubernetes.io/version": version }
-    }}
+    template+: {
+      metadata+: {
+        labels+: super.labels + { "app.kubernetes.io/version": version }
+      },
+      spec+:
+        super.spec + {
+          containers: std.mapWithIndex(function(i, c) if i == 0 then c + {image: c.image + ":" + version} else c, super.containers)
+        }
+    }
   }
 };
 local isDeployment(res) = res.kind == "Deployment";

--- a/olm/template.jsonnet
+++ b/olm/template.jsonnet
@@ -25,7 +25,7 @@ local deployment = std.filterMap(isDeployment, mapDeployment, resources)[0] + {
 		assert std.length(super.containers) == 1 : "Expected exactly 1 container in operator deployment pod",
 		containers: [
 			super.containers[0] {
-				image: imagePrefix + super.image + ":" + version,
+				image: imagePrefix + super.image,
 				[if redhat then "ports"]: [{ containerPort: 9000 }],
 				[if redhat then "env"]: super.env + [
 					{

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>1.2.1.Final</quarkus.version>
+    <quarkus.version>1.9.0.Final</quarkus.version>
     <bouncycastle.version>1.62</bouncycastle.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -70,6 +70,7 @@ import static com.instana.operator.util.ResourceUtils.name;
 import static com.instana.operator.util.StringUtils.isBlank;
 import static io.fabric8.kubernetes.client.Watcher.Action.ADDED;
 import static io.fabric8.kubernetes.client.Watcher.Action.DELETED;
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
 
 @ApplicationScoped
 public class AgentDeployer {
@@ -204,7 +205,7 @@ public class AgentDeployer {
         customResourceState.update(created);
       } catch (KubernetesClientException e) {
         // For status codes, see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#http-status-codes
-        if (e.getCode() == 409 && nRetries > 1) {
+        if (e.getCode() == HTTP_CONFLICT && nRetries > 1) {
           // Another resource of the same name exists in the same namespace.
           // Maybe it's currently being removed, try again in a few seconds.
           executor.schedule(() -> createResource(nRetries - 1, op, factory), 10, TimeUnit.SECONDS);

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -30,7 +30,7 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.DaemonSet;
 import io.fabric8.kubernetes.api.model.apps.DaemonSetList;
 import io.fabric8.kubernetes.api.model.apps.DoneableDaemonSet;

--- a/src/main/java/com/instana/operator/CustomResourceState.java
+++ b/src/main/java/com/instana/operator/CustomResourceState.java
@@ -133,13 +133,16 @@ public class CustomResourceState {
       client.inNamespace(customResource.getMetadata().getNamespace()).createOrReplace(customResource);
     } catch (Exception e) {
       StringBuilder errorMessage = new StringBuilder();
-      errorMessage.append("Failed to update Custom Resource").append(CRD_NAME).append(name(customResource));
+      errorMessage
+          .append("Failed to update Custom Resource ")
+          .append("[" + CRD_NAME + "]")
+          .append(name(customResource) + ".");
       if (e instanceof KubernetesClientException) {
         if (((KubernetesClientException)e).getCode() == HTTP_FORBIDDEN) {
-          errorMessage.append(". Please ensure the operator has the updated cluster role permissions.");
+          errorMessage.append("Please ensure the operator has the updated cluster role permissions.");
         }
       }
-      LOGGER.warn(errorMessage.toString() + ": " + e.getMessage());
+      LOGGER.warn(errorMessage.toString() + " Error: " + e.getMessage());
       // No need to System.exit() if we cannot update the status. Ignore this and carry on.
     }
   }

--- a/src/main/java/com/instana/operator/CustomResourceState.java
+++ b/src/main/java/com/instana/operator/CustomResourceState.java
@@ -1,23 +1,28 @@
 package com.instana.operator;
 
+import static com.instana.operator.client.KubernetesClientProducer.CRD_NAME;
+import static com.instana.operator.util.ResourceUtils.name;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.instana.operator.customresource.DoneableInstanaAgent;
 import com.instana.operator.customresource.InstanaAgent;
 import com.instana.operator.customresource.InstanaAgentList;
 import com.instana.operator.customresource.InstanaAgentStatus;
 import com.instana.operator.customresource.ResourceInfo;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.Optional;
-
-import static com.instana.operator.client.KubernetesClientProducer.CRD_NAME;
-import static com.instana.operator.util.ResourceUtils.name;
 
 @ApplicationScoped
 public class CustomResourceState {
@@ -127,7 +132,14 @@ public class CustomResourceState {
     try {
       client.inNamespace(customResource.getMetadata().getNamespace()).createOrReplace(customResource);
     } catch (Exception e) {
-      LOGGER.warn("Failed to update " + CRD_NAME + " " + name(customResource) + ": " + e.getMessage());
+      StringBuilder errorMessage = new StringBuilder();
+      errorMessage.append("Failed to update Custom Resource").append(CRD_NAME).append(name(customResource));
+      if (e instanceof KubernetesClientException) {
+        if (((KubernetesClientException)e).getCode() == HTTP_FORBIDDEN) {
+          errorMessage.append(". Please ensure the operator has the updated cluster role permissions.");
+        }
+      }
+      LOGGER.warn(errorMessage.toString() + ": " + e.getMessage());
       // No need to System.exit() if we cannot update the status. Ignore this and carry on.
     }
   }

--- a/src/main/java/com/instana/operator/CustomResourceWatcher.java
+++ b/src/main/java/com/instana/operator/CustomResourceWatcher.java
@@ -6,14 +6,12 @@ import com.instana.operator.client.KubernetesClientProducer;
 import com.instana.operator.customresource.DoneableInstanaAgent;
 import com.instana.operator.customresource.InstanaAgent;
 import com.instana.operator.customresource.InstanaAgentList;
-import com.instana.operator.env.NamespaceProducer;
 import com.instana.operator.events.CustomResourceAdded;
 import com.instana.operator.events.CustomResourceDeleted;
 import com.instana.operator.events.CustomResourceModified;
 import com.instana.operator.events.CustomResourceOtherInstanceAdded;
 import com.instana.operator.events.OperatorLeaderElected;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -61,7 +59,7 @@ public class CustomResourceWatcher {
   private final AtomicReference<InstanaAgent> current = new AtomicReference<>();
 
   public void onElectedLeader(@ObservesAsync OperatorLeaderElected _ev) {
-    List<FilterWatchListMultiDeletable<InstanaAgent, InstanaAgentList, Boolean, Watch, Watcher<InstanaAgent>>> ops = new ArrayList<>();
+    List<FilterWatchListMultiDeletable<InstanaAgent, InstanaAgentList, Boolean, Watch>> ops = new ArrayList<>();
     if (targetNamespaces.isEmpty()) {
       LOGGER.info("Watching for " + KubernetesClientProducer.CRD_NAME + " resources in any namespace.");
       ops.add(client.inAnyNamespace());
@@ -72,7 +70,7 @@ public class CustomResourceWatcher {
       }
     }
     Cache<InstanaAgent, InstanaAgentList> cache = cacheService.newCache(InstanaAgent.class, InstanaAgentList.class);
-    for (FilterWatchListMultiDeletable<InstanaAgent, InstanaAgentList, Boolean, Watch, Watcher<InstanaAgent>> op : ops) {
+    for (FilterWatchListMultiDeletable<InstanaAgent, InstanaAgentList, Boolean, Watch> op : ops) {
       cache.listThenWatch(op).subscribe(event -> handleCacheEvent(cache.get(event.getUid())));
     }
   }

--- a/src/main/java/com/instana/operator/cache/Cache.java
+++ b/src/main/java/com/instana/operator/cache/Cache.java
@@ -35,7 +35,7 @@ public class Cache<T extends HasMetadata, L extends KubernetesResourceList<T>> {
     return map.get(uid);
   }
 
-  public Observable<CacheEvent> listThenWatch(FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> op) {
+  public Observable<CacheEvent> listThenWatch(FilterWatchListDeletable<T, L, Boolean, Watch> op) {
     return listThenWatch(new ListerWatcher<>(op));
   }
 

--- a/src/main/java/com/instana/operator/cache/ListerWatcher.java
+++ b/src/main/java/com/instana/operator/cache/ListerWatcher.java
@@ -11,9 +11,9 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
  */
 public class ListerWatcher<T extends HasMetadata, L extends KubernetesResourceList<T>> {
 
-  private final FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> op;
+  private final FilterWatchListDeletable<T, L, Boolean, Watch> op;
 
-  ListerWatcher(FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> op) {
+  ListerWatcher(FilterWatchListDeletable<T, L, Boolean, Watch> op) {
     this.op = op;
   }
 

--- a/src/main/java/com/instana/operator/client/KubernetesClientProducer.java
+++ b/src/main/java/com/instana/operator/client/KubernetesClientProducer.java
@@ -4,7 +4,7 @@ import com.instana.operator.FatalErrorHandler;
 import com.instana.operator.customresource.DoneableInstanaAgent;
 import com.instana.operator.customresource.InstanaAgent;
 import com.instana.operator.customresource.InstanaAgentList;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -34,7 +34,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.net.Proxy;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.instana.operator.env.Environment.OPERATOR_NAMESPACE;

--- a/src/test/java/com/instana/operator/AgentDeployerTest.java
+++ b/src/test/java/com/instana/operator/AgentDeployerTest.java
@@ -25,7 +25,7 @@ import com.instana.operator.env.Environment;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.api.model.apps.DaemonSet;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;


### PR DESCRIPTION
### Why

The version of the `quarkus` dependency is sorely outdated (`1.2.1.Final`). In order for us to leverage the `v1` api of `CustomResourceDefinition` (which we will need to do soon since `v1beta1/CustomResourceDefinition` is deprecated and will be removed in Kubernetes v1.22+), we need at least `kubernetes-client 4.11.x`. Version `1.9.0.Final` of quarkus gives us `kubernetes-client 4.12`. The last version update of `kubernetes-client` Quarkus did was to `4.10.3` before that.

**Note**: This is a breaking change as the version of `kubernetes-client` that's used when calling `.createOrReplace` on the Custom Resource's status requires an additional `create` permission in the ClusterRole for `instana.io`.

### What

- The main change here is the version bump of quarkus from 1.2.1.Final to 1.9.0.Final and all the necessary code changes for it to compile. 
- The other change to point out is that we had to add the `create` permissions to the `instana.io` apiGroup in the Operator's `ClusterRole` in `instana-agent-operator.yaml`. This is due to a change in `[kubernetes-client](https://github.com/fabric8io/kubernetes-client/issues/2292)` when calling `createOrReplace`, it will first try a `create` and if it fails with a conflict exception, then it'll try an `update`, which means that the operator will need `create` permissions in the `instana.io` apiGroup
- Added some additional error messaging to inform the user that they should check the operator has updated cluster role permissions if they encounter an error when applying the custom resource
- Also updated the `operator-artifacts.jsonnet` template to include the version of the `instana/instana-agent-operator` image tag in the generated `instana-agent-operator.yaml` to help ensure that the operators using a previous tag would still work if we introduce a breaking change in a new operator image that requires an updated `instana-agent-operator.yaml` (like the one we're doing now)
- No longer pushing the `latest` tag for the operator image in order to tie the operator yaml updates more closely with the operator image updates and avoid the situation where the customers are pulling the latest operator image containing a breaking change but not explicitly updating the operator yaml

The auxiliary changes are for easing the end-to-end testing with Kind with the introduction of 2 scripts that will:
1. Create a local Kind cluster with 1 control plane and 2 nodes (with support for macOS/Darwin and Linux), build the operator Docker image with the new maven artifacts and load that Docker image into the Kind cluster, pull the latest agent Docker image and load that into the Kind cluster
2. Delete that local Kind cluster
