### PR TITLE
Add IBM license header

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
 
           sh "./mvnw versions:set -DnewVersion=$VERSION"
 
-          sh "./mvnw -C -B clean package"
+          sh "./mvnw -C -B clean verify"
         }
       }
     }

--- a/e2e-testing/with-kind/create-cluster.sh
+++ b/e2e-testing/with-kind/create-cluster.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 
 set -e
 

--- a/e2e-testing/with-kind/delete-cluster.sh
+++ b/e2e-testing/with-kind/delete-cluster.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 
 set -e
 

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,2 @@
+(c) Copyright IBM Corp. ${currentYear}
+(c) Copyright Instana Inc.

--- a/licenses/LICENSE
+++ b/licenses/LICENSE
@@ -1,5 +1,6 @@
 The MIT License
 
+Copyright (c) 2021 IBM Corp.
 Copyright (c) 2019 Instana, Inc. https://www.instana.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/olm/Dockerfile.bundle
+++ b/olm/Dockerfile.bundle
@@ -1,3 +1,8 @@
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 FROM scratch
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1

--- a/olm/Dockerfile.ci
+++ b/olm/Dockerfile.ci
@@ -1,3 +1,8 @@
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 FROM alpine
 
 RUN apk update

--- a/olm/create-artifacts.sh
+++ b/olm/create-artifacts.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 
 set -e
 

--- a/olm/operator-resources/create-github-release.sh
+++ b/olm/operator-resources/create-github-release.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 
 set -e
 

--- a/olm/operator-resources/create-operator-artifacts.sh
+++ b/olm/operator-resources/create-operator-artifacts.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 
 set -e
 

--- a/olm/operator-resources/download-github-release-assets.sh
+++ b/olm/operator-resources/download-github-release-assets.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 
 set -e
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <build-helper-plugin.version>3.2.0</build-helper-plugin.version>
+    <license-plugin.version>4.0.rc2</license-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -119,6 +121,62 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemProperties>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>timestamp-property</id>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <name>current.year</name>
+              <locale>en_US</locale>
+              <pattern>yyyy</pattern>
+              <unit>year</unit>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>${license-plugin.version}</version>
+        <configuration>
+          <useDefaultExcludes>true</useDefaultExcludes>
+          <aggregate>false</aggregate>
+          <defaultProperties>
+            <currentYear>${current.year}</currentYear>
+          </defaultProperties>
+          <mapping>
+            <Dockerfile.jvm>SCRIPT_STYLE</Dockerfile.jvm>
+            <Dockerfile.native>SCRIPT_STYLE</Dockerfile.native>
+            <Dockerfile.ci>SCRIPT_STYLE</Dockerfile.ci>
+            <Dockerfile.bundle>SCRIPT_STYLE</Dockerfile.bundle>
+          </mapping>
+          <licenseSets>
+            <licenseSet>
+              <header>license-header.txt</header>
+              <includes>
+                <include>**/src/main/java/**/*.java</include>
+                <include>**/src/test/java/**/*.java</include>
+                <include>**/*Dockerfile*</include>
+                <include>**/*.sh</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -1,3 +1,8 @@
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG VERSION=dev

--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -1,3 +1,8 @@
+#
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc.
+#
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 MAINTAINER Instana, support@instana.com
 

--- a/src/main/java/com/instana/operator/AgentDeployer.java
+++ b/src/main/java/com/instana/operator/AgentDeployer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.cache.Cache;

--- a/src/main/java/com/instana/operator/CustomResourceEventHandler.java
+++ b/src/main/java/com/instana/operator/CustomResourceEventHandler.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.customresource.DoneableInstanaAgent;

--- a/src/main/java/com/instana/operator/CustomResourceState.java
+++ b/src/main/java/com/instana/operator/CustomResourceState.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import static com.instana.operator.client.KubernetesClientProducer.CRD_NAME;

--- a/src/main/java/com/instana/operator/CustomResourceWatcher.java
+++ b/src/main/java/com/instana/operator/CustomResourceWatcher.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.cache.Cache;

--- a/src/main/java/com/instana/operator/DaemonSetWatcher.java
+++ b/src/main/java/com/instana/operator/DaemonSetWatcher.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.cache.Cache;

--- a/src/main/java/com/instana/operator/ExecutorProducer.java
+++ b/src/main/java/com/instana/operator/ExecutorProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import org.slf4j.Logger;

--- a/src/main/java/com/instana/operator/FatalErrorHandler.java
+++ b/src/main/java/com/instana/operator/FatalErrorHandler.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.cache.CacheService;

--- a/src/main/java/com/instana/operator/JacksonConfig.java
+++ b/src/main/java/com/instana/operator/JacksonConfig.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/src/main/java/com/instana/operator/KubernetesEventService.java
+++ b/src/main/java/com/instana/operator/KubernetesEventService.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import io.fabric8.kubernetes.api.model.Event;

--- a/src/main/java/com/instana/operator/OperatorLeaderElector.java
+++ b/src/main/java/com/instana/operator/OperatorLeaderElector.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.cache.Cache;

--- a/src/main/java/com/instana/operator/OperatorPodLoader.java
+++ b/src/main/java/com/instana/operator/OperatorPodLoader.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.cache.Cache;

--- a/src/main/java/com/instana/operator/OperatorPodValidator.java
+++ b/src/main/java/com/instana/operator/OperatorPodValidator.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.instana.operator.env.Environment;

--- a/src/main/java/com/instana/operator/ResourceYamlLogger.java
+++ b/src/main/java/com/instana/operator/ResourceYamlLogger.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/instana/operator/cache/Cache.java
+++ b/src/main/java/com/instana/operator/cache/Cache.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/cache/CacheEvent.java
+++ b/src/main/java/com/instana/operator/cache/CacheEvent.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.fabric8.kubernetes.client.Watcher;

--- a/src/main/java/com/instana/operator/cache/CacheService.java
+++ b/src/main/java/com/instana/operator/cache/CacheService.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/cache/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/instana/operator/cache/ExceptionHandlerWrapper.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/cache/ListThenWatchOperation.java
+++ b/src/main/java/com/instana/operator/cache/ListThenWatchOperation.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/cache/ListerWatcher.java
+++ b/src/main/java/com/instana/operator/cache/ListerWatcher.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;

--- a/src/main/java/com/instana/operator/cache/ResourceMap.java
+++ b/src/main/java/com/instana/operator/cache/ResourceMap.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;

--- a/src/main/java/com/instana/operator/cache/Retry.java
+++ b/src/main/java/com/instana/operator/cache/Retry.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.reactivex.Scheduler;

--- a/src/main/java/com/instana/operator/client/ClientConfigProducer.java
+++ b/src/main/java/com/instana/operator/client/ClientConfigProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.client;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/client/KubernetesClientProducer.java
+++ b/src/main/java/com/instana/operator/client/KubernetesClientProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.client;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/coordination/AgentCoordinator.java
+++ b/src/main/java/com/instana/operator/coordination/AgentCoordinator.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.coordination;
 
 import com.instana.operator.events.AgentPodAdded;

--- a/src/main/java/com/instana/operator/coordination/CoordinationRecord.java
+++ b/src/main/java/com/instana/operator/coordination/CoordinationRecord.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.coordination;
 
 

--- a/src/main/java/com/instana/operator/coordination/DefaultPodCoordinationIO.java
+++ b/src/main/java/com/instana/operator/coordination/DefaultPodCoordinationIO.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.coordination;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/instana/operator/coordination/PodCoordinationIO.java
+++ b/src/main/java/com/instana/operator/coordination/PodCoordinationIO.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.coordination;
 
 import io.fabric8.kubernetes.api.model.Pod;

--- a/src/main/java/com/instana/operator/coordination/RandomProducer.java
+++ b/src/main/java/com/instana/operator/coordination/RandomProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.coordination;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/src/main/java/com/instana/operator/customresource/DoneableInstanaAgent.java
+++ b/src/main/java/com/instana/operator/customresource/DoneableInstanaAgent.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import io.fabric8.kubernetes.api.builder.Function;

--- a/src/main/java/com/instana/operator/customresource/InstanaAgent.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgent.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentConfigFiles.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentConfigFiles.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentList.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentList.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentSpec.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/instana/operator/customresource/InstanaAgentStatus.java
+++ b/src/main/java/com/instana/operator/customresource/InstanaAgentStatus.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/instana/operator/customresource/ResourceInfo.java
+++ b/src/main/java/com/instana/operator/customresource/ResourceInfo.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/instana/operator/endpoints/HealthCheckResource.java
+++ b/src/main/java/com/instana/operator/endpoints/HealthCheckResource.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.endpoints;
 
 import org.eclipse.microprofile.health.Health;

--- a/src/main/java/com/instana/operator/endpoints/VersionResource.java
+++ b/src/main/java/com/instana/operator/endpoints/VersionResource.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.endpoints;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;

--- a/src/main/java/com/instana/operator/env/Environment.java
+++ b/src/main/java/com/instana/operator/env/Environment.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.env;
 
 import java.util.Map;

--- a/src/main/java/com/instana/operator/env/EnvironmentProducer.java
+++ b/src/main/java/com/instana/operator/env/EnvironmentProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.env;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/src/main/java/com/instana/operator/env/NamespaceProducer.java
+++ b/src/main/java/com/instana/operator/env/NamespaceProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.env;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/env/OperatorPodNameProducer.java
+++ b/src/main/java/com/instana/operator/env/OperatorPodNameProducer.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.env;
 
 import com.instana.operator.FatalErrorHandler;

--- a/src/main/java/com/instana/operator/events/AgentPodAdded.java
+++ b/src/main/java/com/instana/operator/events/AgentPodAdded.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import io.fabric8.kubernetes.api.model.Pod;

--- a/src/main/java/com/instana/operator/events/AgentPodDeleted.java
+++ b/src/main/java/com/instana/operator/events/AgentPodDeleted.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 public class AgentPodDeleted {

--- a/src/main/java/com/instana/operator/events/CustomResourceAdded.java
+++ b/src/main/java/com/instana/operator/events/CustomResourceAdded.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import com.instana.operator.customresource.InstanaAgent;

--- a/src/main/java/com/instana/operator/events/CustomResourceDeleted.java
+++ b/src/main/java/com/instana/operator/events/CustomResourceDeleted.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import com.instana.operator.customresource.InstanaAgent;

--- a/src/main/java/com/instana/operator/events/CustomResourceModified.java
+++ b/src/main/java/com/instana/operator/events/CustomResourceModified.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import com.instana.operator.customresource.InstanaAgent;

--- a/src/main/java/com/instana/operator/events/CustomResourceOtherInstanceAdded.java
+++ b/src/main/java/com/instana/operator/events/CustomResourceOtherInstanceAdded.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import com.instana.operator.customresource.InstanaAgent;

--- a/src/main/java/com/instana/operator/events/DaemonSetAdded.java
+++ b/src/main/java/com/instana/operator/events/DaemonSetAdded.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import io.fabric8.kubernetes.api.model.apps.DaemonSet;

--- a/src/main/java/com/instana/operator/events/DaemonSetDeleted.java
+++ b/src/main/java/com/instana/operator/events/DaemonSetDeleted.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 public class DaemonSetDeleted {

--- a/src/main/java/com/instana/operator/events/OperatorLeaderElected.java
+++ b/src/main/java/com/instana/operator/events/OperatorLeaderElected.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 public class OperatorLeaderElected {

--- a/src/main/java/com/instana/operator/events/OperatorPodRunning.java
+++ b/src/main/java/com/instana/operator/events/OperatorPodRunning.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import io.fabric8.kubernetes.api.model.Pod;

--- a/src/main/java/com/instana/operator/events/OperatorPodValidated.java
+++ b/src/main/java/com/instana/operator/events/OperatorPodValidated.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.events;
 
 import io.fabric8.kubernetes.api.model.Pod;

--- a/src/main/java/com/instana/operator/util/ResourceUtils.java
+++ b/src/main/java/com/instana/operator/util/ResourceUtils.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.util;
 
 import com.instana.operator.customresource.InstanaAgent;

--- a/src/main/java/com/instana/operator/util/StringUtils.java
+++ b/src/main/java/com/instana/operator/util/StringUtils.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.util;
 
 public class StringUtils {

--- a/src/test/java/com/instana/operator/AgentDeployerTest.java
+++ b/src/test/java/com/instana/operator/AgentDeployerTest.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator;
 
 import static com.instana.operator.env.Environment.RELATED_IMAGE_INSTANA_AGENT;

--- a/src/test/java/com/instana/operator/cache/CacheTest.java
+++ b/src/test/java/com/instana/operator/cache/CacheTest.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.fabric8.kubernetes.api.model.Pod;

--- a/src/test/java/com/instana/operator/cache/FatalErrorHandler.java
+++ b/src/test/java/com/instana/operator/cache/FatalErrorHandler.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 public class FatalErrorHandler extends com.instana.operator.FatalErrorHandler {

--- a/src/test/java/com/instana/operator/cache/KubernetesSimulator.java
+++ b/src/test/java/com/instana/operator/cache/KubernetesSimulator.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;

--- a/src/test/java/com/instana/operator/cache/RetryTest.java
+++ b/src/test/java/com/instana/operator/cache/RetryTest.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.cache;
 
 import io.reactivex.disposables.Disposable;

--- a/src/test/java/com/instana/operator/coordination/AgentCoordinatorTest.java
+++ b/src/test/java/com/instana/operator/coordination/AgentCoordinatorTest.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.coordination;
 
 import com.instana.operator.events.AgentPodAdded;

--- a/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
+++ b/src/test/java/com/instana/operator/customresource/InstanaAgentSpecDeserializeTest.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.customresource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/instana/operator/util/FileUtil.java
+++ b/src/test/java/com/instana/operator/util/FileUtil.java
@@ -1,3 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc.
+ */
 package com.instana.operator.util;
 
 import java.io.BufferedReader;


### PR DESCRIPTION
## Why

Because IBM requires it.

## What

Similar to what was done in the [backend/#8605](https://github.com/instana/backend/pull/8605), we're doing the same thing here using the same Maven plugins to generate the license header.

There's an existing file `licences/LICENSE` that is included in the container image that is built and uploaded to both DockerHub and RedHat Registry that isn't managed by the aforementioned Maven plugins. We can probably introduce some scripting to ensure the current year is updated in that file before it gets included in the respective images.
