### PR TITLE
Pre-commit git hook that ensures the required license headers are added where appropriate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           - m2-{{ checksum "pom.xml" }}
           - m2-
 
-    - run: ./mvnw package
+    - run: ./mvnw -C -B clean verify
 
     - setup_remote_docker:
         version: 18.06.0-ce

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Pre-commit script to ensure the required IBM/Instana
+# license headers are added to the relevant source files.
+# Note that if you bypass this pre-commit git hook and didn't
+# run the maven command mentioned below to add the license headers
+# to new files, the build will fail.
+
+echo
+echo Running "${BASH_SOURCE[0]}"
+echo
+
+command_exists () {
+  command -v "$1" >/dev/null 2>&1
+}
+
+command_exists mvn || {
+	echo >&2 "Can't find 'mvn' in PATH. Please ensure you have installed Maven."
+	exit 1
+}
+
+echo "Updating license headers where necessary..."
+if mvn --quiet validate license:format; then
+	echo "Successfully updated license headers"
+else
+	echo >&2 "Failed to update license headers, please check the output of 'mvn validate license:format' to see what's wrong and rectify"
+	exit 1
+fi

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,7 +4,7 @@ Building the Instana Agent Operator from Source
 The following command will build the `instana/instana-agent-operator` Docker image locally:
 
 ```bash
-./mvnw -C -B clean package
+./mvnw -C -B clean verify
 docker build -f src/main/docker/Dockerfile.jvm -t instana/instana-agent-operator .
 ```
 
@@ -13,6 +13,6 @@ To build the Docker image with GraalVM native image, use the following command:
 > Note: The native image does not work yet because of [https://github.com/quarkusio/quarkus/issues/3077](https://github.com/quarkusio/quarkus/issues/3077)
 
 ```bash
-./mvnw -C -B clean package -Pnative -Dnative-image.docker-build=true
+./mvnw -C -B clean verify -Pnative -Dnative-image.docker-build=true
 docker build -f src/main/docker/Dockerfile.native -t instana/instana-agent-operator .
 ```

--- a/e2e-testing/with-kind/create-cluster.sh
+++ b/e2e-testing/with-kind/create-cluster.sh
@@ -19,7 +19,7 @@ kind --config $KIND_CONFIG_FILE create cluster
 kubectl get nodes
 
 printf "%s\n" "Build and load Operator image into kind cluster"
-./mvnw -C -B clean package
+./mvnw -C -B clean verify
 docker build -f $BASE_DIR/src/main/docker/Dockerfile.jvm -t instana/instana-agent-operator:$VERSION $BASE_DIR
 kind load docker-image instana/instana-agent-operator
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <build-helper-plugin.version>3.2.0</build-helper-plugin.version>
     <license-plugin.version>4.0.rc2</license-plugin.version>
+    <git-build-hook-plugin.version>3.0.0</git-build-hook-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -174,6 +175,23 @@
           <execution>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.rudikershaw.gitbuildhook</groupId>
+        <artifactId>git-build-hook-maven-plugin</artifactId>
+        <version>${git-build-hook-plugin.version}</version>
+        <configuration>
+          <installHooks>
+            <pre-commit>.githooks/pre-commit</pre-commit>
+          </installHooks>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>install</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Similar to https://github.com/instana/backend/pull/8634

# Why

We added license headers to all relevant source files in #47. However, running `mvn validate license:format` needs to be somewhat automated for new files being checked in going forward so that engineers don't have to remember to run it manually.

In the near future, we could have a single entrypoint script like `./go` or `Makefile` (which delegates to `mvn` or other tools) that can manage all the sequencing of steps and which ones are required so we don't have to rely on specific tooling like Maven plugins for such things.

# What

Added a pre-commit git hook in `.githooks/` that runs `mvn validate license:format` and configure it to be run automatically by using [git-build-hook-maven-plugin](https://github.com/rudikershaw/git-build-hook).

# References

Refs: #47 