### PR TITLE
Fix Resource Version parsing, as String instead of numeric

### DIFF
--- a/src/main/java/com/instana/operator/cache/ResourceMap.java
+++ b/src/main/java/com/instana/operator/cache/ResourceMap.java
@@ -6,10 +6,7 @@ package com.instana.operator.cache;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 class ResourceMap<T extends HasMetadata> {
 
@@ -19,11 +16,11 @@ class ResourceMap<T extends HasMetadata> {
    * @return true if the map was updated, false otherwise.
    */
   boolean putIfNewer(String uid, T resource) {
-    synchronized(map) {
+    synchronized (map) {
       if (map.containsKey(uid)) {
-        int currentResourceVersion = Integer.parseInt(map.get(uid).getMetadata().getResourceVersion());
-        int newResourceVersion = Integer.parseInt(resource.getMetadata().getResourceVersion());
-        if (currentResourceVersion < newResourceVersion) {
+        String currentResourceVersion = Objects.toString(map.get(uid).getMetadata().getResourceVersion(), "");
+        String newResourceVersion = Objects.toString(resource.getMetadata().getResourceVersion(), "");
+        if (!currentResourceVersion.equals(newResourceVersion)) {
           map.put(uid, resource);
           return true;
         } else {

--- a/src/test/java/com/instana/operator/cache/CacheTest.java
+++ b/src/test/java/com/instana/operator/cache/CacheTest.java
@@ -63,7 +63,7 @@ class CacheTest {
       simulator.simulatePodModified("uid1", 125);
       simulator.simulatePodModified("uid1", 139);
       simulator.simulatePodAdded("uid2", "pod2", 789);
-      simulator.simulatePodModified("uid2", 633); // less than the previous version for pod2
+      simulator.simulatePodModified("uid2", 789); // similar to the previous version so ignored
       simulator.simulatePodDeleted("uid1");
     }
     cacheService.terminate(5, TimeUnit.SECONDS);


### PR DESCRIPTION
When setting watches, the client receives Resource Versions to know if something got updated.
Currently this version is converted to an `int` and doing a 'greater than' comparison to learn if the new version is newer.

But according to Kubernetes doc, the String value can't be converted to integer and should just be compared as-is to learn if changes happened. See: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions

So making that change in the code, to just process String values.