### PR TITLE
Enable P support in Concourse CI

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -17,10 +17,10 @@ resources:
     icon: github
     source:
       uri: https://github.com/instana/instana-agent-operator.git
-      branch: p-pipeline
+      branch: main
       #  match release tags like "v1.12.99"
       #  match pre-release tags like "v1.12.100-pre"
-      #tag_regex: ^v\d+\.\d+\.\d+.*$
+      tag_regex: ^v\d+\.\d+\.\d+.*$
       #          ^ beginning of the tag string
       #           ^ all tags start with "v"
       #            ^ ^ any number of digits

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -17,10 +17,10 @@ resources:
     icon: github
     source:
       uri: https://github.com/instana/instana-agent-operator.git
-      branch: main
+      branch: p-pipeline
       #  match release tags like "v1.12.99"
       #  match pre-release tags like "v1.12.100-pre"
-      tag_regex: ^v\d+\.\d+\.\d+.*$
+      #tag_regex: ^v\d+\.\d+\.\d+.*$
       #          ^ beginning of the tag string
       #           ^ all tags start with "v"
       #            ^ ^ any number of digits
@@ -79,6 +79,14 @@ resources:
       region: us-west-2
       access_key_id: ((codebuild-key.key_id))
       secret_access_key: ((codebuild-key.key_secret))
+  - name: codebuild-ppc64le
+    type: codebuild
+    icon: aws
+    source:
+      project: instana-agent-operator-codebuild
+      region: us-west-2
+      access_key_id: ((codebuild-key.key_id))
+      secret_access_key: ((codebuild-key.key_secret))
 
   - name: operator-image-amd64
     type: registry-image
@@ -102,6 +110,14 @@ resources:
     source:
       repository: gcr.io/instana-agent-qa/instana-agent-operator
       tag: latest-s390x
+      username: _json_key
+      password: ((project-berlin-tests-gcp-instana-qa))
+  - name: operator-image-ppc64le
+    type: registry-image
+    icon: docker
+    source:
+      repository: gcr.io/instana-agent-qa/instana-agent-operator
+      tag: latest-ppc64le
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 
@@ -250,6 +266,14 @@ jobs:
                   VERSION: ((.:operator-version))
                   COMMIT_SHA: ((.:commit-sha))
                   TARGETPLATFORM: linux/s390x
+            - put: codebuild-ppc64le
+              params:
+                source_version: ((.:s3-artifact-version))
+                env_var_overrides:
+                  ARCH: ppc64le
+                  VERSION: ((.:operator-version))
+                  COMMIT_SHA: ((.:commit-sha))
+                  TARGETPLATFORM: linux/ppc64le
       # upload the AWS CloudBuild built images to GCR:
       - in_parallel:
           fail_fast: true
@@ -266,6 +290,10 @@ jobs:
               params:
                   image: codebuild-s390x/artifacts/image.tar
                   additional_tags: codebuild-s390x/artifacts/tag
+            - put: operator-image-ppc64le
+              params:
+                  image: codebuild-ppc64le/artifacts/image.tar
+                  additional_tags: codebuild-ppc64le/artifacts/tag
 
   - name: multiarch-operator-manifest-publish
     max_in_flight: 1
@@ -280,6 +308,9 @@ jobs:
         params: { skip_download: true }
         passed: [ multiarch-operator-images-build ]
       - get: operator-image-s390x
+        params: { skip_download: true }
+        passed: [ multiarch-operator-images-build ]
+      - get: operator-image-ppc64le
         params: { skip_download: true }
         passed: [ multiarch-operator-images-build ]
 
@@ -326,16 +357,19 @@ jobs:
                 docker pull "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-amd64"
                 docker pull "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-s390x"
                 docker pull "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-arm64"
+                docker pull "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-ppc64le"
 
                 docker pull "gcr.io/instana-agent-qa/instana-agent-operator:latest-amd64"
                 docker pull "gcr.io/instana-agent-qa/instana-agent-operator:latest-s390x"
                 docker pull "gcr.io/instana-agent-qa/instana-agent-operator:latest-arm64"
+                docker pull "gcr.io/instana-agent-qa/instana-agent-operator:latest-ppc64le"
 
                 echo "---> Building multi-architectural manifest"
                 docker manifest create "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION" \
                   --amend "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-amd64" \
                   --amend "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-s390x" \
-                  --amend "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-arm64"
+                  --amend "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-arm64" \
+                  --amend "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-ppc64le"
 
                 echo "---> Pushing multi-architectural manifest"
                 docker manifest push "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION"
@@ -359,17 +393,20 @@ jobs:
                 docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-amd64" "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-amd64"
                 docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-s390x" "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-s390x"
                 docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-arm64" "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-arm64"
+                docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-ppc64le" "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-ppc64le"
 
                 echo "---> pushing images to docker.io"
                 docker push "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-amd64"
                 docker push "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-s390x"
                 docker push "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-arm64"
+                docker push "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-ppc64le"
 
                 echo "---> Building multi-architectural manifest on docker.io"
                 docker manifest create "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION" \
                   --amend "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-amd64" \
                   --amend "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-s390x" \
-                  --amend "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-arm64"
+                  --amend "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-arm64" \
+                  --amend "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION-ppc64le"
 
                 echo "---> Pushing multi-architectural manifest to docker.io"
                 docker manifest push --purge "docker.io/instana/instana-agent-operator:$OPERATOR_DOCKER_VERSION"
@@ -389,11 +426,13 @@ jobs:
                 docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-amd64" "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64"
                 docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-s390x" "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-s390x"
                 docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-arm64" "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-arm64"
+                docker tag "gcr.io/instana-agent-qa/instana-agent-operator:$COMMIT_SHA-$VERSION-ppc64le" "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-ppc64le"
 
                 echo "---> pushing images to Red Hat Container Registry"
                 docker push "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64"
                 docker push "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-s390x"
                 docker push "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-arm64"
+                docker push "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-ppc64le"
 
                 # According to this knowledge base article https://access.redhat.com/solutions/5583611 the RH container registry does not support fat manifest lists.
                 # For now we will fall back to just publish the amd64 variant instead:
@@ -404,7 +443,8 @@ jobs:
                 # docker manifest create "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION" \
                 #  --amend "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64" \
                 #  --amend "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-s390x" \
-                #  --amend "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-arm64"
+                #  --amend "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-arm64" \
+                #  --amend "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-ppc64le"
 
                 # echo "---> Pushing multi-architectural manifest to Red Hat Container Registry"
                 # docker manifest push --purge "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION"


### PR DESCRIPTION
This PR adds Power (ppc64le) support to the Concourse CI pipeline. Test build: [plinux-agent-operator](https://ci.instana.io/teams/agent/pipelines/plinux-agent-operator)
- adds ppc64le to the list of ARCHs handled by multi-architecture build/publish via Concourse CI.

The image pushed by the CI to GCR has been validated on ppc64le by making sure that the pod comes up properly on minikube cluster. Logs below.

```
# kubectl get pods -A
NAMESPACE       NAME                                      READY   STATUS             RESTARTS   AGE
instana-agent   instana-agent-operator-6b596f8d67-2qk4n   1/1     Running            0          12s
kube-system     coredns-f9fd979d6-rjvm8                   1/1     Running            1          52d
kube-system     etcd-p006vm71                             1/1     Running            1          52d
kube-system     kube-apiserver-p006vm71                   1/1     Running            2          52d
kube-system     kube-controller-manager-p006vm71          1/1     Running            2          52d
kube-system     kube-proxy-gxp74                          1/1     Running            1          52d
kube-system     kube-scheduler-p006vm71                   1/1     Running            1          52d
# kubectl describe pod instana-agent-operator-6b596f8d67-2qk4n -n instana-agent
Name:         instana-agent-operator-6b596f8d67-2qk4n
Namespace:    instana-agent
Priority:     0
Node:         <HOSTNAME>/<HOSTIP>
Start Time:   Tue, 31 Aug 2021 11:38:32 -0500
Labels:       app.kubernetes.io/name=instana-agent-operator
              pod-template-hash=6b596f8d67
Annotations:  <none>
Status:       Running
IP:           172.17.0.3
IPs:
  IP:           172.17.0.3
Controlled By:  ReplicaSet/instana-agent-operator-6b596f8d67
Containers:
  instana-agent-operator:
    Container ID:   docker://7aca923db8ff571885581b659a07939a8574d7b20bc3e7d00c9d8cb2d12032b9
    Image:          gcr.io/instana-agent-qa/instana-agent-operator:latest-ppc64le
    Image ID:       docker-pullable://gcr.io/instana-agent-qa/instana-agent-operator@sha256:5b6da3497d3c5065f30fa725008d3e15f5bfb93e77eee5ffac6eec0d78775101
    Port:           8080/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Tue, 31 Aug 2021 11:38:34 -0500
    Ready:          True
    Restart Count:  0
    Environment:
      POD_NAME:            instana-agent-operator-6b596f8d67-2qk4n (v1:metadata.name)
      OPERATOR_NAMESPACE:  instana-agent (v1:metadata.namespace)
      TARGET_NAMESPACES:    (v1:metadata.annotations['olm.targetNamespaces'])
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from instana-agent-operator-token-lhvjg (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  instana-agent-operator-token-lhvjg:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  instana-agent-operator-token-lhvjg
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason                 Age   From               Message
  ----    ------                 ----  ----               -------
  Normal  Scheduled              32s   default-scheduler  Successfully assigned instana-agent/instana-agent-operator-6b596f8d67-2qk4n to p006vm71
  Normal  Pulled                 30s   kubelet, p006vm71  Container image "gcr.io/instana-agent-qa/instana-agent-operator:latest-ppc64le" already present on machine
  Normal  Created                30s   kubelet, p006vm71  Created container instana-agent-operator
  Normal  Started                30s   kubelet, p006vm71  Started container instana-agent-operator
  Normal  OperatorLeaderElected  27s                      Pod instana-agent/instana-agent-operator-6b596f8d67-2qk4n became the leading instana agent operator instance.
```
It can be seen that the image SHA from the pod description matches the one in [this job](https://ci.instana.io/teams/agent/pipelines/plinux-agent-operator/jobs/multiarch-operator-manifest-publish/builds/1) in the test build.

Note: Pushing the new commit reverting the `agent-operator-release-source` resource to `main` branch with `tag_regex` caused [multiarch-operator-images-build #2](https://ci.instana.io/teams/agent/pipelines/plinux-agent-operator/jobs/multiarch-operator-images-build/builds/2) which succeeded and [multiarch-operator-manifest-publish #2](https://ci.instana.io/teams/agent/pipelines/plinux-agent-operator/jobs/multiarch-operator-manifest-publish/builds/2) which was interrupted to avoid push to docker.io, RH.