### PR TITLE
Configure memory limit/request dependent on node architecture ppc

### DIFF
--- a/src/test/java/com/instana/operator/AgentDeployerTest.java
+++ b/src/test/java/com/instana/operator/AgentDeployerTest.java
@@ -8,8 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.instana.operator.customresource.InstanaAgent;
 import com.instana.operator.customresource.InstanaAgentSpec;
 import com.instana.operator.env.Environment;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.api.model.apps.DaemonSet;
 import io.fabric8.kubernetes.client.Config;
@@ -24,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Map;
 
+import static com.instana.operator.AgentDeployer.DEFAULT_AGENT_MEM_LIMIT_ON_PPC;
+import static com.instana.operator.AgentDeployer.DEFAULT_AGENT_MEM_REQ_ON_PPC;
 import static com.instana.operator.env.Environment.RELATED_IMAGE_INSTANA_AGENT;
 import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -151,6 +152,47 @@ public class AgentDeployerTest {
     Map<String, String> labels = daemonSet.getMetadata().getLabels();
     assertThat(labels, hasEntry(is("app.kubernetes.io/managed-by"), is("instana-agent-operator")));
     assertThat(labels, hasEntry(is("app.kubernetes.io/version"), is("0.3.8")));
+  }
+
+  @Test
+  void should_use_ppc_memory_setting_if_arch_contains_ppc() {
+
+    server
+        .expect()
+        .get()
+        .withPath("/api/v1/nodes")
+        .andReturn(HTTP_OK,
+            new NodeListBuilder()
+            .addNewItem()
+                .withStatus(
+                    new NodeStatusBuilder()
+                        .withNodeInfo(
+                            new NodeSystemInfoBuilder().withArchitecture("ppc64le").build()
+                        )
+                        .build())
+                .and()
+                .build())
+        .always();
+
+    AgentDeployer deployer = new AgentDeployer();
+    deployer.setDefaultClient(client);
+    deployer.setEnvironment(singleVar(RELATED_IMAGE_INSTANA_AGENT, "other/image:some-tag"));
+
+    InstanaAgentSpec agentSpec = new InstanaAgentSpec();
+    agentSpec.setAgentEnv(ImmutableMap.<String, String>builder()
+        .put("INSTANA_AGENT_MODE", "APM")
+        .build());
+
+    InstanaAgent customResource = new InstanaAgent();
+    customResource.setSpec(agentSpec);
+
+    DaemonSet daemonSet = deployer.newDaemonSet(
+        customResource,
+        client.inNamespace("instana-agent").apps().daemonSets());
+    Container agentContainer = getAgentContainer(daemonSet);
+
+    assertThat(agentContainer.getResources().getRequests().get("memory").getAmount(), is(Integer.toString(DEFAULT_AGENT_MEM_REQ_ON_PPC * 1024 * 1024)));
+    assertThat(agentContainer.getResources().getLimits().get("memory").getAmount(), is(Integer.toString(DEFAULT_AGENT_MEM_LIMIT_ON_PPC * 1024 * 1024)));
   }
 
   @Test


### PR DESCRIPTION
# Improve memory configuration for ppc-architecture

## Why

The agents consume more memory on a cluster with ppc-architecture

## What

Increase memory limit/request for agent running on ppc-architecture
