### PR TITLE
Only AllNamespaces is allowed for conversion webhook definitions

### DIFF
--- a/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
@@ -408,11 +408,11 @@ spec:
               terminationGracePeriodSeconds: 10
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces


### PR DESCRIPTION
See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/operators/index

OLM places the CSV in the failed phase if a conversion webhook definition does not adhere to the following constraints:
CSVs featuring a conversion webhook can only support the AllNamespaces install mode.