### PR TITLE
Add serviceAccount annotations

### DIFF
--- a/config/samples/instana_v1_extended_instanaagent.yaml
+++ b/config/samples/instana_v1_extended_instanaagent.yaml
@@ -131,6 +131,8 @@ spec:
     # The name of the ServiceAccount to use.
     # If not set and `create` is true, a name is generated using the fullname template
     # name: instana-agent
+    # Annotations to add to the service account
+    annotations: {}
 
   k8s_sensor:
     image:


### PR DESCRIPTION
## Why

Public Cloud Providers use serviceAccount annotations to enable pod identity.

## References

- [Story / Card](https://instana.kanbanize.com/ctrl_board/50/cards/156768/details/)
