### PR TITLE
ci(fix): Fix docker build for Golang 1.22.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY version/ version/
+COPY pkg/ pkg/
 
 # Build, injecting VERSION and GIT_COMMIT directly in the code
 RUN export ARCH=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'amd64' ;; 'linux/arm64') echo 'arm64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) \
@@ -33,7 +34,6 @@ RUN export ARCH=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'amd64' ;; 'li
 
 # Resulting image with actual Operator
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-MAINTAINER Instana, support@instana.com
 
 ARG TARGETPLATFORM='linux/amd64'
 ARG VERSION
@@ -56,7 +56,9 @@ LABEL name="instana-agent-operator" \
       io.openshift.tags="" \
       io.k8s.description="" \
       com.redhat.build-host="" \
-      com.redhat.component=""
+      com.redhat.component="" \
+      # MAINTAINER is deprecated -> https://docs.docker.com/reference/dockerfile/#maintainer
+      org.opencontainers.image.authors="Instana, support@instana.com"
 
 ENV OPERATOR=instana-agent-operator \
     USER_UID=1001 \


### PR DESCRIPTION
Without including pkg folder build errors are thrown, example:
```
0.636 api/v1/inline_types.go:15:2: no required module provides package github.com/instana/instana-agent-operator/pkg/map_defaulter; to add it:
0.636   go get github.com/instana/instana-agent-operator/pkg/map_defaulter
...
```
Comparing against main shows that the pkg folder was added as part of the operator_3.0 branch and is required in order to build the container image.

The target `make docker-build` works after the change.

Also, the MAINTAINER label is deprecated and should be replaced by using the standardized label `org.opencontainers.image.authors`: https://docs.docker.com/reference/dockerfile/#maintainer