### PR TITLE
fix: Adjust kubebuilder to fix cluster role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,9 @@ deploy: manifests kustomize ## Deploy controller in the configured Kubernetes cl
 	cd config/manager && $(KUSTOMIZE) edit set image instana/instana-agent-operator=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+scale-to-zero: ## Scales the operator to zero in the cluster to allow local testing against a cluster
+	kubectl -n instana-agent scale --replicas=0 deployment.apps/instana-agent-operator && sleep 5 && kubectl get all -n instana-agent
+
 deploy-minikube: manifests kustomize ## Convenience target to push the docker image to a local running Minikube cluster and deploy the Operator there.
 	(eval $$(minikube docker-env) && docker rmi ${IMG} || true)
 	docker save ${IMG} | (eval $$(minikube docker-env) && docker load)

--- a/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     categories: Monitoring,Logging & Tracing,OpenShift Optional
     certified: "false"
     containerImage: icr.io/instana/instana-agent-operator:snapshot
-    createdAt: "2024-03-25T14:56:05Z"
+    createdAt: "2024-04-11T09:10:53Z"
     description: Fully automated Application Performance Monitoring (APM) for microservices.
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -179,32 +179,6 @@ spec:
           - create
           - patch
         - apiGroups:
-          - agents.instana.io
-          resources:
-          - instanaagent
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - agents.instana.io
-          resources:
-          - instanaagent/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - agents.instana.io
-          resources:
-          - instanaagent/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
@@ -240,6 +214,32 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - instana.io
+          resources:
+          - agents
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - instana.io
+          resources:
+          - agents/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - instana.io
+          resources:
+          - agents/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     categories: Monitoring,Logging & Tracing,OpenShift Optional
     certified: "false"
     containerImage: icr.io/instana/instana-agent-operator:snapshot
-    createdAt: "2024-04-12T12:02:25Z"
+    createdAt: "2024-04-26T10:39:24Z"
     description: Fully automated Application Performance Monitoring (APM) for microservices.
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -332,6 +332,7 @@ spec:
           - clusterrolebindings
           - clusterroles
           verbs:
+          - bind
           - create
           - delete
           - get

--- a/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/instana-agent-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     categories: Monitoring,Logging & Tracing,OpenShift Optional
     certified: "false"
     containerImage: icr.io/instana/instana-agent-operator:snapshot
-    createdAt: "2024-04-11T09:10:53Z"
+    createdAt: "2024-04-12T12:02:25Z"
     description: Fully automated Application Performance Monitoring (APM) for microservices.
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -178,6 +178,11 @@ spec:
           verbs:
           - create
           - patch
+        - nonResourceURLs:
+          - /healthz
+          - /version
+          verbs:
+          - get
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -200,6 +205,61 @@ spec:
           - update
           - watch
         - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - namespaces
+          - nodes
+          - persistentvolumeclaims
+          - persistentvolumes
+          - pods
+          - pods/log
+          - replicationcontrollers
+          - resourcequotas
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - configmaps
@@ -213,6 +273,16 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments
+          - ingresses
+          - replicasets
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - instana.io
@@ -241,6 +311,22 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resourceNames:
+          - instana-agent-k8sensor
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
@@ -253,6 +339,14 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         serviceAccountName: instana-agent-operator
       deployments:
       - label:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,32 +5,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - agents.instana.io
-  resources:
-  - instanaagent
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - agents.instana.io
-  resources:
-  - instanaagent/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - agents.instana.io
-  resources:
-  - instanaagent/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -66,6 +40,32 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - instana.io
+  resources:
+  - agents
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - instana.io
+  resources:
+  - agents/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - instana.io
+  resources:
+  - agents/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,6 +4,11 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
+- nonResourceURLs:
+  - /healthz
+  - /version
+  verbs:
+  - get
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -26,6 +31,61 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -39,6 +99,16 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  - ingresses
+  - replicasets
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - instana.io
@@ -67,6 +137,22 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resourceNames:
+  - instana-agent-k8sensor
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -79,3 +165,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -158,6 +158,7 @@ rules:
   - clusterrolebindings
   - clusterroles
   verbs:
+  - bind
   - create
   - delete
   - get

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -1,6 +1,6 @@
 /*
- * (c) Copyright IBM Corp. 2021
- * (c) Copyright Instana Inc. 2021
+ * (c) Copyright IBM Corp. 2021, 2024
+ * (c) Copyright Instana Inc. 2021, 2024
  */
 
 package controllers
@@ -95,7 +95,6 @@ func (r *InstanaAgentReconciler) reconcile(
 	log.Info("reconciling Agent CR")
 
 	agent.Default()
-
 	operatorUtils := operator_utils.NewOperatorUtils(ctx, r.client, agent)
 
 	if handleDeletionRes := r.handleDeletion(ctx, agent, operatorUtils); handleDeletionRes.suppliesReconcileResult() {
@@ -133,6 +132,18 @@ func (r *InstanaAgentReconciler) reconcile(
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=instana.io,resources=agents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=instana.io,resources=agents/finalizers,verbs=update
+
+// adding role property required to manage instana-agent-k8sensor ClusterRole
+// +kubebuilder:rbac:urls=/version;/healthz,verbs=get
+// +kubebuilder:rbac:groups=extensions,resources=deployments;replicasets;ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=configmaps;events;services;endpoints;namespaces;nodes;pods;pods/log;replicationcontrollers;resourcequotas;persistentvolumes;persistentvolumeclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;replicasets;statefulsets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=policy,resourceNames=instana-agent-k8sensor,resources=podsecuritypolicies,verbs=use
 
 func (r *InstanaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	res ctrl.Result,

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -128,7 +128,7 @@ func (r *InstanaAgentReconciler) reconcile(
 // +kubebuilder:rbac:groups=instana.io,resources=agents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets;deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets;configmaps;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=instana.io,resources=agents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=instana.io,resources=agents/finalizers,verbs=update

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -126,13 +126,13 @@ func (r *InstanaAgentReconciler) reconcile(
 	return reconcileSuccess(ctrl.Result{})
 }
 
-// +kubebuilder:rbac:groups=agents.instana.io,resources=instanaagent,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=instana.io,resources=agents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets;deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets;configmaps;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=agents.instana.io,resources=instanaagent/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=agents.instana.io,resources=instanaagent/finalizers,verbs=update
+// +kubebuilder:rbac:groups=instana.io,resources=agents/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=instana.io,resources=agents/finalizers,verbs=update
 
 func (r *InstanaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	res ctrl.Result,


### PR DESCRIPTION
The ClusterRole produced by the kubebuilder comments when running `make manifests` was out of sync with the definition in the CustomResourceDefinition. 

Whenever the operator was started locally via `make run`, the permissions from the local kubeconfig were inherited and worked fine, but starting from an image inside the cluster which relied on the serviceaccount mapped to the manger-role ClusterRole failed with forbidden.
This can be reproduced by running: `kubectl get
--as=system:serviceaccount:instana-agent:instana-agent-operator instanaagent.instana.io/instana-agent -n instana-agent`

Also worth noting: There is a custom verb `bind` for `rbac.authorization.k8s.io`. It must be set in this context, otherwise the operator is not allowed to bind a `clusterrole` to a `serviceaccount`, even if it has the create permission for the `clusterrolebinding` resource. This is necessary, as the agent operator will provision a ServiceAccount, a ClusterRole and a ClusterRoleBinding for the k8s_sensor.