### PR TITLE
Fix issue where go exits due to go version being the wrong format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/instana/instana-agent-operator
 
-go 1.22.1
+go 1.22
 
 require (
 	github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
Invalid format of go version causes .mod related go commands to exit 2
```
invalid -go=go1.22.1
exit status 2
```