### PR TITLE
fix: Adjust operator deployment name for backwards compatibility 

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: instana-agent-operator
+  name: controller-manager
   namespace: system
   labels:
     app.kubernetes.io/name: instana-agent-operator


### PR DESCRIPTION
Card reference: [159440](https://instana.kanbanize.com/ctrl_board/50/cards/159440/details/)

If the name of the operator deployment is `instana-agent-operator`, the initial install works fine. It still becomes a problem, once we try to update existing operator v2 installations, as the `instana-agent-operator` pods will try to become leader and conflict with existing `manager-controller` pods.
By adjusting the name of the deployment, Kubernetes will apply a rolling-update to the operator deployment and thereby will demote existing leaders and let new deployments win the leader election eventually.

On a GKE cluster, the v2 installation looks like below by default (with a custom resource instance deployed):
```
$ kubectl get all -n instana-agent
NAME                                     READY   STATUS    RESTARTS   AGE
pod/controller-manager-97475db78-4fwjx   1/1     Running   0          5m22s
pod/controller-manager-97475db78-8rrhh   1/1     Running   0          5m22s
pod/instana-agent-dfqds                  1/1     Running   0          5m14s
pod/instana-agent-fxtqr                  1/1     Running   0          5m14s
pod/instana-agent-hg6c5                  1/1     Running   0          5m14s
pod/k8sensor-b969c455b-b9m5x             1/1     Running   0          5m14s
pod/k8sensor-b969c455b-bdgdj             1/1     Running   0          5m14s
pod/k8sensor-b969c455b-ndg59             1/1     Running   0          5m14s

NAME                             TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                                 AGE
service/instana-agent            ClusterIP   10.60.13.20   <none>        42699/TCP,55680/TCP,4317/TCP,4318/TCP   5m15s
service/instana-agent-headless   ClusterIP   None          <none>        42699/TCP,55680/TCP,4317/TCP,4318/TCP   5m15s

NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/instana-agent   3         3         3       3            3           <none>          5m15s

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/controller-manager   2/2     2            2           5m23s
deployment.apps/k8sensor             3/3     3            3           5m15s

NAME                                           DESIRED   CURRENT   READY   AGE
replicaset.apps/controller-manager-97475db78   2         2         2       5m23s
replicaset.apps/k8sensor-b969c455b             3         3         3       5m15s
```

Once an update install happens with the code before my change, the problem becomes visible:
```
$ kubectl get all -n instana-agent
NAME                                          READY   STATUS    RESTARTS      AGE
pod/controller-manager-97475db78-4fwjx        1/1     Running   0             8m35s
pod/controller-manager-97475db78-8rrhh        1/1     Running   1 (41s ago)   8m35s
pod/instana-agent-7kkm6                       1/1     Running   0             27s
pod/instana-agent-k8sensor-59d49f994f-92vq2   1/1     Running   0             27s
pod/instana-agent-k8sensor-59d49f994f-jdt4f   1/1     Running   0             27s
pod/instana-agent-k8sensor-59d49f994f-w67rz   1/1     Running   0             27s
pod/instana-agent-mtnlg                       1/1     Running   0             27s
pod/instana-agent-n2456                       1/1     Running   0             27s
pod/instana-agent-operator-f9c5cddbf-244mh    1/1     Running   0             51s
pod/instana-agent-operator-f9c5cddbf-rqgw5    1/1     Running   0             51s

NAME                             TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                                 AGE
service/instana-agent            ClusterIP   10.60.4.206   <none>        42699/TCP,55680/TCP,4317/TCP,4318/TCP   29s
service/instana-agent-headless   ClusterIP   None          <none>        42699/TCP,55680/TCP,4317/TCP,4318/TCP   29s

NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/instana-agent   3         3         3       3            3           <none>          29s

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/controller-manager       2/2     2            2           8m36s
deployment.apps/instana-agent-k8sensor   3/3     3            3           29s
deployment.apps/instana-agent-operator   2/2     2            2           52s

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/controller-manager-97475db78        2         2         2       8m36s
replicaset.apps/instana-agent-k8sensor-59d49f994f   3         3         3       29s
replicaset.apps/instana-agent-operator-f9c5cddbf    2         2         2       52s
```

Note, there is a new deployment instana-agent-operator, and the old deployment controller-manager, both deploy two pods instead of updating the existing once.
The new operator pods will stay in the leader election state forever:
```
...
{"level":"info","ts":"2024-05-02T09:44:30Z","logger":"instana.main","msg":"Starting manager"}
{"level":"info","ts":"2024-05-02T09:44:30Z","logger":"instana.controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-05-02T09:44:30Z","logger":"instana","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2024-05-02T09:44:30Z","logger":"instana.controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
I0502 09:44:30.400071       1 leaderelection.go:250] attempting to acquire leader lease instana-agent/819a9291.instana.io...
```

With the PR change applied, the correct state gets rolled out:
```
$ kubectl get all -n instana-agent
NAME                                        READY   STATUS    RESTARTS   AGE
pod/controller-manager-f9c5cddbf-kbrr2      1/1     Running   0          72m
pod/controller-manager-f9c5cddbf-pfnc5      1/1     Running   0          73m
pod/instana-agent-k8sensor-56bbcd8d-jxzlg   1/1     Running   0          69m
pod/instana-agent-k8sensor-56bbcd8d-lwsj9   1/1     Running   0          69m
pod/instana-agent-k8sensor-56bbcd8d-r7trn   1/1     Running   0          69m
pod/instana-agent-mx7dl                     1/1     Running   0          69m
pod/instana-agent-qtlgp                     1/1     Running   0          69m
pod/instana-agent-vsj88                     1/1     Running   0          69m

NAME                             TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                                 AGE
service/instana-agent            ClusterIP   10.60.9.114   <none>        42699/TCP,55680/TCP,4317/TCP,4318/TCP   72m
service/instana-agent-headless   ClusterIP   None          <none>        42699/TCP,55680/TCP,4317/TCP,4318/TCP   72m

NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/instana-agent   3         3         3       3            3           <none>          72m

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/controller-manager       2/2     2            2           73m
deployment.apps/instana-agent-k8sensor   3/3     3            3           72m

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/controller-manager-97475db78        0         0         0       73m
replicaset.apps/controller-manager-f9c5cddbf        2         2         2       73m
replicaset.apps/instana-agent-k8sensor-56bbcd8d     3         3         3       69m
replicaset.apps/instana-agent-k8sensor-59d49f994f   0         0         0       72m
```

The logs confirm, that one of both pods is promoted to be the new leader:
```
$ k logs -f -n instana-agent pod/controller-manager-f9c5cddbf-pfnc5
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.main","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.main","msg":"Operator Git Commit SHA: fd8521d"}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.main","msg":"Go Version: go1.22.1"}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.main","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.main","msg":"Starting manager"}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana.controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2024-05-02T09:44:20Z","logger":"instana","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
I0502 09:44:20.465375       1 leaderelection.go:250] attempting to acquire leader lease instana-agent/819a9291.instana.io...
I0502 09:44:37.048445       1 leaderelection.go:260] successfully acquired lease instana-agent/819a9291.instana.io
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.InstanaAgent"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.DaemonSet"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.Deployment"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.ConfigMap"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.Secret"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.ServiceAccount"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.Service"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.ClusterRole"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting EventSource","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","source":"kind source: *v1.ClusterRoleBinding"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting Controller","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent"}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana","msg":"Starting workers","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","worker count":1}
{"level":"info","ts":"2024-05-02T09:44:37Z","logger":"instana.agent-controller","msg":"reconciling Agent CR","controller":"instanaagent","controllerGroup":"instana.io","controllerKind":"InstanaAgent","InstanaAgent":{"name":"instana-agent","namespace":"instana-agent"},"namespace":"instana-agent","name":"instana-agent","reconcileID":"8f8463fa-6d3b-483d-af13-c64c3f98056e","Generation":2,"UID":"82a67bdf-db23-4189-a652-6916baf7d507"}
...
```