### PR TITLE
Specify patch of the toolchain to fix pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/instana/instana-agent-operator
 
 go 1.22
+toolchain go1.22.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Build pipeline is currently failing with
```
go: download go1.22 for linux/amd64: toolchain not available
```
The issue and fix is outlined: https://github.com/golang/go/issues/62278
