### PR TITLE
ci(fixup): Enable image promotion, add sanity check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ ifneq ($(shell test -f $(OPERATOR_SDK) && echo -n yes),yes)
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 endif
 operator-sdk: ## Download the Operator SDK binary locally if necessary.
-	$(call curl-get-tool,$(OPERATOR_SDK),https://github.com/operator-framework/operator-sdk/releases/download/v1.33.0,operator-sdk_$${OS}_$${ARCH})
+	$(call curl-get-tool,$(OPERATOR_SDK),https://github.com/operator-framework/operator-sdk/releases/download/v1.16.0,operator-sdk_$${OS}_$${ARCH})
 
 
 # go-install-tool will 'go get' any package $2 and install it to $1.

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -440,48 +440,47 @@ jobs:
         params:
           globs:
             - preflight-linux-amd64
-      - try:
-          task: redhat-preflight-scans
-          config:
-            platform: linux
-            image_resource:
-              type: registry-image
-              source:
-                repository: registry.access.redhat.com/ubi8/ubi-minimal
-            inputs:
-              - name: preflight
-            params:
-              VERSION: ((.:operator-version))
-              RED_HAT_API_TOKEN: ((redhat-container-registry-5e9612d87512796c24e4aeef.api-token))
-              RED_HAT_REGISTRY_PASSWORD: ((redhat-container-registry-5e961c2c93604e02afa9ebdf.password))
-              RED_HAT_REGISTRY_USERNAME: ((redhat-container-registry-5e961c2c93604e02afa9ebdf.user))
-            run:
-              path: bash
-              args:
-                - -ce
-                - |
-                  microdnf install skopeo
-                  # strip the leading "v" from the operator version for release:
+      - task: redhat-preflight-scans
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: registry.access.redhat.com/ubi8/ubi-minimal
+          inputs:
+            - name: preflight
+          params:
+            VERSION: ((.:operator-version))
+            RED_HAT_API_TOKEN: ((redhat-container-registry-5e9612d87512796c24e4aeef.api-token))
+            RED_HAT_REGISTRY_PASSWORD: ((redhat-container-registry-5e961c2c93604e02afa9ebdf.password))
+            RED_HAT_REGISTRY_USERNAME: ((redhat-container-registry-5e961c2c93604e02afa9ebdf.user))
+          run:
+            path: bash
+            args:
+              - -ce
+              - |
+                microdnf install skopeo
+                # strip the leading "v" from the operator version for release:
 
-                  export PREFIX="v"
-                  export OPERATOR_DOCKER_VERSION=${VERSION#"$PREFIX"}
+                export PREFIX="v"
+                export OPERATOR_DOCKER_VERSION=${VERSION#"$PREFIX"}
 
-                  # Run Preflight Image Scans for RH Marketplace
+                # Run Preflight Image Scans for RH Marketplace
 
-                  export RED_HAT_PROJECT_ID=5e961c2c93604e02afa9ebdf
-                  export RED_HAT_REGISTRY="quay.io/redhat-isv-containers/${RED_HAT_PROJECT_ID}"
-                  skopeo login -u ${RED_HAT_REGISTRY_USERNAME} -p ${RED_HAT_REGISTRY_PASSWORD} --authfile $(pwd)/auth.json quay.io
-                  export DOCKER_CFG_FILE="$(pwd)/auth.json"
+                export RED_HAT_PROJECT_ID=5e961c2c93604e02afa9ebdf
+                export RED_HAT_REGISTRY="quay.io/redhat-isv-containers/${RED_HAT_PROJECT_ID}"
+                skopeo login -u ${RED_HAT_REGISTRY_USERNAME} -p ${RED_HAT_REGISTRY_PASSWORD} --authfile $(pwd)/auth.json quay.io
+                export DOCKER_CFG_FILE="$(pwd)/auth.json"
 
-                  pushd preflight
+                pushd preflight
 
-                  chmod +x preflight-linux-amd64
+                chmod +x preflight-linux-amd64
 
-                  ./preflight-linux-amd64 check container --artifacts amd64 "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
-                  ./preflight-linux-amd64 check container --artifacts s390x "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-s390x" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
-                  ./preflight-linux-amd64 check container --artifacts ppc64le "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-ppc64le" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
+                ./preflight-linux-amd64 check container --artifacts amd64 "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
+                ./preflight-linux-amd64 check container --artifacts s390x "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-s390x" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
+                ./preflight-linux-amd64 check container --artifacts ppc64le "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-ppc64le" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
 
-                  popd
+                popd
 
   - name: operator-olm-github-release
     max_in_flight: 1

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -392,10 +392,8 @@ jobs:
                   --dest-username ${ARTIFACTORY_USERNAME} \
                   --dest-password ${ARTIFACTORY_PASSWORD} \
                   docker://${DEV_BUILD_IMAGE}@${DIGEST} \
-                  docker://${DEV_BUILD_IMAGE}:test
+                  docker://${DEV_BUILD_IMAGE}:main
 
-                echo "Skipping during test"
-                exit 0
                 # For non-public releases we are done:
                 export RELEASE_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
                 if ! [[ $VERSION =~ $RELEASE_REGEX ]]; then
@@ -524,7 +522,7 @@ jobs:
               - -ceu
               - |
                 microdnf install make python3-devel gcc git tar gzip zip curl jq
-                pip3 install pyyaml
+                pip3 install pyyaml skopeo
 
                 # ubi8 still bundles Go 1.15 but we rely on 1.21, so install manually
                 export PATH="$PATH:/usr/local/go/bin"
@@ -576,6 +574,8 @@ jobs:
                   export OPERATOR_IMAGE=" icr.io/instana/instana-agent-operator@${OPERATOR_IMAGE_MANIFEST_SHA}"
                 fi
 
+                # check that the operator image is really present before creating a release
+                skopeo inspect docker://${OPERATOR_IMAGE}
                 # Create bundle for public operator with image:  icr.io/instana/instana-agent-operator:<version>
                 make IMG="${OPERATOR_IMAGE}" \
                   VERSION="${OLM_RELEASE_VERSION}" \

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -476,9 +476,7 @@ jobs:
 
                 chmod +x preflight-linux-amd64
 
-                ./preflight-linux-amd64 check container --artifacts amd64 "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
-                ./preflight-linux-amd64 check container --artifacts s390x "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-s390x" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
-                ./preflight-linux-amd64 check container --artifacts ppc64le "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-ppc64le" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
+                ./preflight-linux-amd64 check container --artifacts preflight-output "$RED_HAT_REGISTRY:$OPERATOR_DOCKER_VERSION-amd64" --certification-project-id=$RED_HAT_PROJECT_ID --docker-config $DOCKER_CFG_FILE --submit --pyxis-api-token=$RED_HAT_API_TOKEN
 
                 popd
 

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -383,6 +383,9 @@ jobs:
               - |
                 microdnf install skopeo
                 DEV_BUILD_IMAGE=delivery.instana.io/int-docker-agent-local/instana-agent-operator/dev-build
+                ICR_REPOSITORY=icr.io/instana/instana-agent-operator
+                ARTIFACTORY_REPOSITORY="${ARTIFACTORY_CONTAINER_DOCKER_URL}/instana-agent-operator"
+                RED_HAT_REGISTRY="quay.io/redhat-isv-containers/5e961c2c93604e02afa9ebdf"
 
                 DIGEST=$(cat agent-operator-image-manifest-sha/digest)
                 echo ${DIGEST}
@@ -416,7 +419,6 @@ jobs:
                   docker://${DEV_BUILD_IMAGE}@${DIGEST} \
                   docker://${ICR_REPOSITORY}:${OPERATOR_DOCKER_VERSION}
 
-                ARTIFACTORY_REPOSITORY="${ARTIFACTORY_CONTAINER_DOCKER_URL}/instana-agent-operator"
                 echo "---> Pushing multi-architectural manifest to ${ARTIFACTORY_REPOSITORY}"
                 skopeo copy -a --preserve-digests \
                   --src-username ${ARTIFACTORY_USERNAME_INTERNAL} \
@@ -427,7 +429,6 @@ jobs:
                   docker://${ARTIFACTORY_REPOSITORY}:${OPERATOR_DOCKER_VERSION}
 
                 echo "---> pushing images to Red Hat Container Registry"
-                export RED_HAT_REGISTRY="quay.io/redhat-isv-containers/5e961c2c93604e02afa9ebdf"
                 skopeo copy -a --preserve-digests \
                   --src-username ${ARTIFACTORY_USERNAME_INTERNAL} \
                   --src-password ${ARTIFACTORY_PASSWORD_INTERNAL} \


### PR DESCRIPTION
Before publishing a release, it should be checked if the operator image is really present in the target registry