### PR TITLE
instana_v1_extended_instanaagent: increase cpu requests and memory limits of k8sensor

### DIFF
--- a/config/samples/instana_v1_extended_instanaagent.yaml
+++ b/config/samples/instana_v1_extended_instanaagent.yaml
@@ -157,10 +157,10 @@ spec:
           # k8s_sensor.deployment.pod.requests.memory is the requested memory allocation in MiB for the agent pods.
           memory: 128Mi
           # k8s_sensor.deployment.pod.requests.cpu are the requested CPU units allocation for the agent pods.
-          cpu: 10m
+          cpu: 120m
         limits:
           # k8s_sensor.deployment.pod.limits.memory set the memory allocation limits in MiB for the agent pods.
-          memory: 1536Mi
+          memory: 2048Mi
           # k8s_sensor.deployment.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
           cpu: 500m
         affinity:


### PR DESCRIPTION
Previously the cpu request were by default at 1% of a CPU. This meant that in every deployment the CPU usage was always more than the minimum CPU resource scheduled.

The memory limit which is the maximum before the process is killed with an OOM is increased to 2GB to be conservative with clusters with many updates and resources, where memory usage usually hovers around 1.3G