### PR TITLE
chore: Increase memory limit of controller manager (#171)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 600Mi
           requests:
             cpu: 200m
             memory: 200Mi


### PR DESCRIPTION
Allow up to 600Mi memory consumption, even if only 200Mi get requested upfront. Only the leader pod might exceed the 200Mi and the real amount of memory might depend on the environment, therefore adding some buffer.