### PR TITLE
Enable OTLP by default

### DIFF
--- a/api/v1/inline_types.go
+++ b/api/v1/inline_types.go
@@ -370,7 +370,7 @@ type OpenTelemetry struct {
 func (otlp OpenTelemetry) GrpcIsEnabled() bool {
 	switch otlp.GRPC {
 	case nil:
-		return pointer.DerefOrEmpty(otlp.Enabled.Enabled)
+		return true
 	default:
 		return pointer.DerefOrDefault(otlp.GRPC.Enabled, true)
 	}
@@ -379,7 +379,7 @@ func (otlp OpenTelemetry) GrpcIsEnabled() bool {
 func (otlp OpenTelemetry) HttpIsEnabled() bool {
 	switch otlp.HTTP {
 	case nil:
-		return false
+		return true
 	default:
 		return pointer.DerefOrDefault(otlp.HTTP.Enabled, true)
 	}

--- a/api/v1/inline_types_test.go
+++ b/api/v1/inline_types_test.go
@@ -1,3 +1,20 @@
+/*
+(c) Copyright IBM Corp. 2024
+(c) Copyright Instana Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
 
 import (
@@ -114,12 +131,7 @@ func testForOtlp(t *testing.T, otlp *OpenTelemetry, getExpected func(otlp *OpenT
 func grpcIsEnabled_expected(otlp *OpenTelemetry) bool {
 	switch grpc := otlp.GRPC; grpc {
 	case nil:
-		switch enabled := otlp.Enabled.Enabled; enabled {
-		case nil:
-			return false
-		default:
-			return *enabled
-		}
+		return true
 	default:
 		switch enabled := grpc.Enabled; enabled {
 		case nil:
@@ -145,7 +157,7 @@ func TestOpenTelemetry_GrpcIsEnabled(t *testing.T) {
 func httpIsEnabled_expected(otlp *OpenTelemetry) bool {
 	switch http := otlp.HTTP; http {
 	case nil:
-		return false
+		return true
 	default:
 		switch enabled := http.Enabled; enabled {
 		case nil:

--- a/config/samples/instana_v1_extended_instanaagent.yaml
+++ b/config/samples/instana_v1_extended_instanaagent.yaml
@@ -119,11 +119,11 @@ spec:
     create: true
 
   opentelemetry:
-   enabled: false # legacy setting, will only enable grpc, defaults to false
+  # enabled: false # legacy setting, will only enable grpc, defaults to false
    grpc:
-     enabled: false # takes precedence over legacy settings above, defaults to true if "grpc:" is present
+     enabled: true # takes precedence over legacy settings above, defaults to true if "grpc:" is present
    http:
-     enabled: false # allows to enable http endpoints, defaults to true if "http:" is present
+     enabled: true # allows to enable http endpoints, defaults to true if "http:" is present
 
   prometheus:
     remoteWrite:


### PR DESCRIPTION
## Why

This PR enables OTLP by default within the Operator


## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-8047)
- [Chart PR](https://github.ibm.com/instana/instana-agent-charts/pull/118)