### PR TITLE
Fix: Bind only enabled ports on agent pods

### DIFF
--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -252,7 +252,7 @@ function verify_multi_backend_config_generation_and_injection() {
         if kubectl exec -n ${NAMESPACE} "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg; then
             echo "Could cat file"
             exec_successful=true
-            continue
+            break
         fi
         set -e
         ((timeout+=POD_WAIT_INTERVAL))

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset.go
@@ -105,7 +105,6 @@ func (d *daemonSetBuilder) getEnvVars() []corev1.EnvVar {
 func (d *daemonSetBuilder) getContainerPorts() []corev1.ContainerPort {
 	return d.GetContainerPorts(
 		ports.AgentAPIsPort,
-		ports.AgentSocketPort,
 		ports.OpenTelemetryLegacyPort,
 		ports.OpenTelemetryGRPCPort,
 		ports.OpenTelemetryHTTPPort,

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset_test.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset_test.go
@@ -194,7 +194,6 @@ func TestDaemonSetBuilder_getContainerPorts(t *testing.T) {
 	portsBuilder := mocks.NewMockPortsBuilder(ctrl)
 	portsBuilder.EXPECT().GetContainerPorts(
 		ports.AgentAPIsPort,
-		ports.AgentSocketPort,
 		ports.OpenTelemetryLegacyPort,
 		ports.OpenTelemetryGRPCPort,
 		ports.OpenTelemetryHTTPPort,

--- a/pkg/k8s/object/builders/common/ports/instana_agent_port.go
+++ b/pkg/k8s/object/builders/common/ports/instana_agent_port.go
@@ -28,8 +28,6 @@ type InstanaAgentPort string
 const (
 	AgentAPIsPort                 InstanaAgentPort = "agent-apis"
 	AgentAPIsPortNumber           int32            = 42699
-	AgentSocketPort               InstanaAgentPort = "agent-socket"
-	AgentSocketPortNumber         int32            = 42666
 	OpenTelemetryLegacyPort       InstanaAgentPort = "otlp-legacy"
 	OpenTelemetryLegacyPortNumber int32            = 55680
 	OpenTelemetryGRPCPort         InstanaAgentPort = "otlp-grpc"
@@ -46,8 +44,6 @@ func (p InstanaAgentPort) PortNumber() int32 {
 	switch p {
 	case AgentAPIsPort:
 		return AgentAPIsPortNumber
-	case AgentSocketPort:
-		return AgentSocketPortNumber
 	case OpenTelemetryLegacyPort:
 		return OpenTelemetryLegacyPortNumber
 	case OpenTelemetryGRPCPort:
@@ -68,8 +64,6 @@ func (p InstanaAgentPort) IsEnabled(openTelemetrySettings instanav1.OpenTelemetr
 	case OpenTelemetryHTTPPort:
 		return openTelemetrySettings.HttpIsEnabled()
 	case AgentAPIsPort:
-		fallthrough
-	case AgentSocketPort:
 		fallthrough
 	default:
 		return true

--- a/pkg/k8s/object/builders/common/ports/instana_agent_port.go
+++ b/pkg/k8s/object/builders/common/ports/instana_agent_port.go
@@ -56,16 +56,12 @@ func (p InstanaAgentPort) PortNumber() int32 {
 }
 
 func (p InstanaAgentPort) IsEnabled(openTelemetrySettings instanav1.OpenTelemetry) bool {
-	switch p {
-	case OpenTelemetryLegacyPort:
-		fallthrough
-	case OpenTelemetryGRPCPort:
+	if p == OpenTelemetryLegacyPort || p == OpenTelemetryGRPCPort {
 		return openTelemetrySettings.GrpcIsEnabled()
-	case OpenTelemetryHTTPPort:
-		return openTelemetrySettings.HttpIsEnabled()
-	case AgentAPIsPort:
-		fallthrough
-	default:
-		return true
 	}
+	if p == OpenTelemetryHTTPPort {
+		return openTelemetrySettings.HttpIsEnabled()
+	}
+	// AgentAPIsPort is always enabled
+	return true
 }

--- a/pkg/k8s/object/builders/common/ports/ports_builder.go
+++ b/pkg/k8s/object/builders/common/ports/ports_builder.go
@@ -49,5 +49,10 @@ func (p *portsBuilder) GetServicePorts(ports ...InstanaAgentPort) []corev1.Servi
 }
 
 func (p *portsBuilder) GetContainerPorts(ports ...InstanaAgentPort) []corev1.ContainerPort {
-	return list.NewListMapTo[InstanaAgentPort, corev1.ContainerPort]().MapTo(ports, toContainerPort)
+	enabledPorts := list.NewListFilter[InstanaAgentPort]().Filter(
+		ports, func(port InstanaAgentPort) bool {
+			return port.IsEnabled(p.InstanaAgent.Spec.OpenTelemetry)
+		},
+	)
+	return list.NewListMapTo[InstanaAgentPort, corev1.ContainerPort]().MapTo(enabledPorts, toContainerPort)
 }

--- a/pkg/k8s/object/builders/common/ports/ports_test.go
+++ b/pkg/k8s/object/builders/common/ports/ports_test.go
@@ -49,14 +49,6 @@ func TestInstanaAgentPortMappings(t *testing.T) {
 		},
 
 		{
-			name:                  string(ports.AgentSocketPort),
-			port:                  ports.AgentSocketPort,
-			openTelemetrySettings: instanav1.OpenTelemetry{Enabled: instanav1.Enabled{Enabled: &enabled}, GRPC: &instanav1.Enabled{Enabled: &enabled}},
-			expectedPortNumber:    ports.AgentSocketPortNumber,
-			expectEnabled:         true,
-		},
-
-		{
 			name:                  string(ports.OpenTelemetryLegacyPort) + "_not_enabled",
 			port:                  ports.OpenTelemetryLegacyPort,
 			openTelemetrySettings: instanav1.OpenTelemetry{Enabled: instanav1.Enabled{Enabled: &enabled}, GRPC: &instanav1.Enabled{Enabled: &disabled}},
@@ -142,12 +134,6 @@ func TestPortsBuilderGetServicePorts(t *testing.T) {
 			Protocol:   corev1.ProtocolTCP,
 		},
 		{
-			Name:       string(ports.AgentSocketPort),
-			Port:       ports.AgentSocketPortNumber,
-			TargetPort: intstr.FromString(string(ports.AgentSocketPort)),
-			Protocol:   corev1.ProtocolTCP,
-		},
-		{
 			Name:       string(ports.OpenTelemetryGRPCPort),
 			Port:       ports.OpenTelemetryGRPCPortNumber,
 			TargetPort: intstr.FromString(string(ports.OpenTelemetryGRPCPort)),
@@ -169,7 +155,6 @@ func TestPortsBuilderGetServicePorts(t *testing.T) {
 	actual := pb.
 		GetServicePorts(
 			ports.AgentAPIsPort,
-			ports.AgentSocketPort,
 			ports.OpenTelemetryGRPCPort,
 			ports.OpenTelemetryHTTPPort,
 		)
@@ -187,11 +172,6 @@ func TestPortsBuilderGetContainerPorts(t *testing.T) {
 			Protocol:      corev1.ProtocolTCP,
 		},
 		{
-			Name:          string(ports.AgentSocketPort),
-			ContainerPort: ports.AgentSocketPortNumber,
-			Protocol:      corev1.ProtocolTCP,
-		},
-		{
 			Name:          string(ports.OpenTelemetryGRPCPort),
 			ContainerPort: ports.OpenTelemetryGRPCPortNumber,
 			Protocol:      corev1.ProtocolTCP,
@@ -202,7 +182,6 @@ func TestPortsBuilderGetContainerPorts(t *testing.T) {
 		NewPortsBuilder(&instanav1.InstanaAgent{}).
 		GetContainerPorts(
 			ports.AgentAPIsPort,
-			ports.AgentSocketPort,
 			ports.OpenTelemetryGRPCPort,
 		)
 


### PR DESCRIPTION
Card: [INSTA-12524](https://jsw.ibm.com/browse/INSTA-12524)

- Remove obsolete agent-socket port 42666
- Do only bind ports which are enabled on the Daemonset

```
spec:
  agent:
    configuration_yaml: |
      # You can leave this empty, or use this to configure your instana agent.
      # See https://github.com/instana/instana-agent-operator/blob/main/config/samples/instana_v1_extended_instanaagent.yaml for the extended version.
    endpointHost: xxx
    endpointPort: "443"
    env: {}
    key: xxx
  cluster:
    name: konrad
  opentelemetry:
    grpc:
      enabled: false
    http:
      enabled: true
```

If grpc is enabled, bind 42699 (agent apis) and 55680 (oltp-legacy) and 4317 (otlp-grpc) ports. 

If http is enabled, bind 42699 (agent apis) and 4318 (oltp-http) ports.

By default, bind all ports.