### PR TITLE
ci: Rely on commit instead of branch for pulling images

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -490,8 +490,8 @@ jobs:
       - get: agent-operator-release-source
         trigger: true
         passed: [docker-build]
-      - get: agent-operator-image-amd64
-        passed: [docker-build]
+      - load_var: git-commit
+        file: agent-operator-release-source/.git/HEAD
       - get: pipeline-source
         passed: [docker-build]
       - get: agent-operator-image-manifest-sha
@@ -516,6 +516,7 @@ jobs:
                   username: _json_key
                   password: ((project-berlin-tests-gcp-instana-qa))
               params:
+                GIT_COMMIT: ((.:git-commit))
                 CLUSTER_INFO: '{ "name": "project-berlin-21", "zone": "us-central1-c", "project": "instana-agent-qa" }'
                 CLUSTER_TYPE: gke
                 NAME: gke-21
@@ -528,7 +529,6 @@ jobs:
                 ARTIFACTORY_PASSWORD: ((delivery-instana-io-internal-project-artifact-read-writer-creds.password))
               inputs:
                 - name: pipeline-source
-                - name: agent-operator-image-amd64
               run:
                 path: pipeline-source/ci/scripts/end-to-end-test.sh
             on_success:
@@ -592,6 +592,7 @@ jobs:
             config:
               <<: *gke-e2e-test-config
               params:
+                GIT_COMMIT: ((.:git-commit))
                 CLUSTER_INFO: '{ "name": "project-berlin-27", "zone": "us-central1-c", "project": "instana-agent-qa" }'
                 CLUSTER_TYPE: gke
                 NAME: gke-27
@@ -607,7 +608,6 @@ jobs:
                 ARTIFACTORY_PASSWORD: ((delivery-instana-io-internal-project-artifact-read-writer-creds.password))
               inputs:
                 - name: pipeline-source
-                - name: agent-operator-image-amd64
               run:
                 path: pipeline-source/ci/scripts/end-to-end-test.sh
             on_success:
@@ -671,6 +671,7 @@ jobs:
         #     config:
         #       <<: *gke-e2e-test-config
         #       params:
+        #         GIT_COMMIT: ((.:git-commit))
         #         CLUSTER_INFO: '{ "name": "project-berlin-openshift-4-10-qa" }'
         #         CLUSTER_TYPE: openshift
         #         KUBECONFIG_SOURCE: ((project-berlin-test-kubeconfig-openshift4))
@@ -688,7 +689,6 @@ jobs:
         #         ARTIFACTORY_PASSWORD: ((delivery-instana-io-internal-project-artifact-read-writer-creds.password))
         #       inputs:
         #         - name: pipeline-source
-        #         - name: agent-operator-image-amd64
         #       run:
         #         path: pipeline-source/ci/scripts/end-to-end-test.sh
         #     on_success:

--- a/ci/pr-pipeline.yml
+++ b/ci/pr-pipeline.yml
@@ -565,9 +565,10 @@ jobs:
     plan:
       - get: pipeline-source
         trigger: true
-        passed: [operator-olm-build]
-      - get: agent-operator-image-amd64
-        passed: [docker-build]
+        passed: [operator-olm-build, docker-build]
+      - load_var: git-commit
+        file: pipeline-source/.git/short_ref
+        reveal: true
       - <<: *gh-status-set-pending-e2e-gke-21
       - <<: *gh-status-set-pending-e2e-gke-27
       #      - <<: *gh-status-set-pending-e2e-openshift
@@ -591,6 +592,7 @@ jobs:
                       username: _json_key
                       password: ((project-berlin-tests-gcp-instana-qa))
                   params:
+                    GIT_COMMIT: ((.:git-commit))
                     CLUSTER_INFO: '{ "name": "project-berlin-21", "zone": "us-central1-c", "project": "instana-agent-qa" }'
                     CLUSTER_TYPE: gke
                     NAME: gke-21
@@ -603,7 +605,6 @@ jobs:
                     ARTIFACTORY_PASSWORD: ((delivery-instana-io-internal-project-artifact-read-writer-creds.password))
                   inputs:
                     - name: pipeline-source
-                    - name: agent-operator-image-amd64
                   run:
                     path: pipeline-source/ci/scripts/end-to-end-test.sh
                 on_success:
@@ -671,6 +672,7 @@ jobs:
                 config:
                   <<: *gke-e2e-test-config
                   params:
+                    GIT_COMMIT: ((.:git-commit))
                     CLUSTER_INFO: '{ "name": "project-berlin-27", "zone": "us-central1-c", "project": "instana-agent-qa" }'
                     CLUSTER_TYPE: gke
                     NAME: gke-27
@@ -686,7 +688,6 @@ jobs:
                     ARTIFACTORY_PASSWORD: ((delivery-instana-io-internal-project-artifact-read-writer-creds.password))
                   inputs:
                     - name: pipeline-source
-                    - name: agent-operator-image-amd64
                   run:
                     path: pipeline-source/ci/scripts/end-to-end-test.sh
                 on_success:
@@ -754,6 +755,7 @@ jobs:
         #     config:
         #       <<: *gke-e2e-test-config
         #       params:
+        #         GIT_COMMIT: ((.:git-commit))
         #         CLUSTER_INFO: '{ "name": "project-berlin-openshift-4-10-qa" }'
         #         CLUSTER_TYPE: openshift
         #         KUBECONFIG_SOURCE: ((project-berlin-test-kubeconfig-openshift4))
@@ -771,7 +773,6 @@ jobs:
         #         ARTIFACTORY_PASSWORD: ((delivery-instana-io-internal-project-artifact-read-writer-creds.password))
         #       inputs:
         #         - name: pipeline-source
-        #         - name: agent-operator-image-amd64
         #       run:
         #         path: pipeline-source/ci/scripts/end-to-end-test.sh
         #     on_success:

--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -269,7 +269,7 @@ pushd pipeline-source
 
     # upgrade the operator
     echo "Deploying the operator from feature branch"
-    IMG="$(cat ../agent-operator-image-amd64/repository):${BUILD_BRANCH}"
+    IMG="delivery.instana.io/int-docker-agent-local/instana-agent-operator/dev-build:${GIT_COMMIT}"
     export IMG
     echo "Create secret for $IMG"
     kubectl create secret -n instana-agent docker-registry delivery.instana \


### PR DESCRIPTION
Caching might cause old images to being pulled if branch names are used