### PR TITLE
Fix: Bind only enabled ports on agent pods

### DIFF
--- a/api/v1/inline_types.go
+++ b/api/v1/inline_types.go
@@ -368,21 +368,27 @@ type OpenTelemetry struct {
 }
 
 func (otlp OpenTelemetry) GrpcIsEnabled() bool {
-	switch otlp.GRPC {
-	case nil:
-		return true
-	default:
-		return pointer.DerefOrDefault(otlp.GRPC.Enabled, true)
+	if otlp.GRPC == nil {
+		// Tolerate legacy setting, if GRPC was not enabled explicitly, check if legacy setting was explicitly set to false
+		// otlp.Enabled.Enabled == false and otlp.GRPC == nil -> should evaulate to false, as otherwise existing opt-outs would be ignored
+		if otlp.Enabled.Enabled == nil {
+			return true
+		}
+		return pointer.DerefOrDefault(otlp.Enabled.Enabled, true)
 	}
+	return pointer.DerefOrDefault(otlp.GRPC.Enabled, true)
 }
 
 func (otlp OpenTelemetry) HttpIsEnabled() bool {
-	switch otlp.HTTP {
-	case nil:
-		return true
-	default:
-		return pointer.DerefOrDefault(otlp.HTTP.Enabled, true)
+	if otlp.HTTP == nil {
+		// Tolerate legacy setting, if HTTP was not enabled explicitly, check if legacy setting was explicitly set to false
+		// otlp.Enabled.Enabled == false and otlp.HTTP == nil -> should evaulate to false, as otherwise existing opt-outs would be ignored
+		if otlp.Enabled.Enabled == nil {
+			return true
+		}
+		return pointer.DerefOrDefault(otlp.Enabled.Enabled, true)
 	}
+	return pointer.DerefOrDefault(otlp.HTTP.Enabled, true)
 }
 
 func (otlp OpenTelemetry) IsEnabled() bool {

--- a/api/v1/inline_types.go
+++ b/api/v1/inline_types.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/instana/instana-agent-operator/pkg/map_defaulter"
-	"github.com/instana/instana-agent-operator/pkg/pointer"
 )
 
 type AgentMode string
@@ -368,27 +367,29 @@ type OpenTelemetry struct {
 }
 
 func (otlp OpenTelemetry) GrpcIsEnabled() bool {
-	if otlp.GRPC == nil {
-		// Tolerate legacy setting, if GRPC was not enabled explicitly, check if legacy setting was explicitly set to false
-		// otlp.Enabled.Enabled == false and otlp.GRPC == nil -> should evaulate to false, as otherwise existing opt-outs would be ignored
-		if otlp.Enabled.Enabled == nil {
-			return true
-		}
-		return pointer.DerefOrDefault(otlp.Enabled.Enabled, true)
+	// explicit opt-out or opt-in via new setting
+	if otlp.GRPC != nil && otlp.GRPC.Enabled != nil {
+		return *otlp.GRPC.Enabled
 	}
-	return pointer.DerefOrDefault(otlp.GRPC.Enabled, true)
+	// explicit opt-out via legacy setting
+	if otlp.Enabled.Enabled != nil && !*otlp.Enabled.Enabled {
+		return false
+	}
+	// enabled by default
+	return true
 }
 
 func (otlp OpenTelemetry) HttpIsEnabled() bool {
-	if otlp.HTTP == nil {
-		// Tolerate legacy setting, if HTTP was not enabled explicitly, check if legacy setting was explicitly set to false
-		// otlp.Enabled.Enabled == false and otlp.HTTP == nil -> should evaulate to false, as otherwise existing opt-outs would be ignored
-		if otlp.Enabled.Enabled == nil {
-			return true
-		}
-		return pointer.DerefOrDefault(otlp.Enabled.Enabled, true)
+	// explicit opt-out or opt-in via new setting
+	if otlp.HTTP != nil && otlp.HTTP.Enabled != nil {
+		return *otlp.HTTP.Enabled
 	}
-	return pointer.DerefOrDefault(otlp.HTTP.Enabled, true)
+	// explicit opt-out via legacy setting
+	if otlp.Enabled.Enabled != nil && !*otlp.Enabled.Enabled {
+		return false
+	}
+	// enabled by default
+	return true
 }
 
 func (otlp OpenTelemetry) IsEnabled() bool {

--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -270,7 +270,6 @@ function verify_multi_backend_config_generation_and_injection() {
 
     echo "Check if the right backend was mounted in Backend-1.cfg"
     echo "Exec into pod ${pod_name} and see if etc/instana/com.instana.agent.main.sender.Backend-1.cfg is present"
-    kubectl exec -n ${NAMESPACE} "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg
     kubectl exec -n ${NAMESPACE} "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg | grep "host=first-backend.instana.io"
 
     echo "Check if the right backend was mounted in Backend-2.cfg"

--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -252,7 +252,7 @@ function verify_multi_backend_config_generation_and_injection() {
         if kubectl exec -n ${NAMESPACE} "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg; then
             echo "Could cat file"
             exec_successful=true
-            continue
+            break
         fi
         set -e
         ((timeout+=POD_WAIT_INTERVAL))

--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -268,12 +268,12 @@ function verify_multi_backend_config_generation_and_injection() {
         exit 1
     fi
 
-    echo "Check if the right backend was mounted"
+    echo "Check if the right backend was mounted in Backend-1.cfg"
     echo "Exec into pod ${pod_name} and see if etc/instana/com.instana.agent.main.sender.Backend-1.cfg is present"
     kubectl exec -n ${NAMESPACE} "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg
     kubectl exec -n ${NAMESPACE} "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg | grep "host=first-backend.instana.io"
 
-    echo "Check if the right backend was mounted"
+    echo "Check if the right backend was mounted in Backend-2.cfg"
     kubectl exec -n ${NAMESPACE}  "${pod_name}" -- cat /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-2.cfg | grep "host=second-backend.instana.io"
     kubectl -n ${NAMESPACE} get agent instana-agent -o yaml
 }

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset.go
@@ -105,7 +105,6 @@ func (d *daemonSetBuilder) getEnvVars() []corev1.EnvVar {
 func (d *daemonSetBuilder) getContainerPorts() []corev1.ContainerPort {
 	return d.GetContainerPorts(
 		ports.AgentAPIsPort,
-		ports.AgentSocketPort,
 		ports.OpenTelemetryLegacyPort,
 		ports.OpenTelemetryGRPCPort,
 		ports.OpenTelemetryHTTPPort,

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset_test.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset_test.go
@@ -194,7 +194,6 @@ func TestDaemonSetBuilder_getContainerPorts(t *testing.T) {
 	portsBuilder := mocks.NewMockPortsBuilder(ctrl)
 	portsBuilder.EXPECT().GetContainerPorts(
 		ports.AgentAPIsPort,
-		ports.AgentSocketPort,
 		ports.OpenTelemetryLegacyPort,
 		ports.OpenTelemetryGRPCPort,
 		ports.OpenTelemetryHTTPPort,

--- a/pkg/k8s/object/builders/common/ports/instana_agent_port.go
+++ b/pkg/k8s/object/builders/common/ports/instana_agent_port.go
@@ -28,8 +28,6 @@ type InstanaAgentPort string
 const (
 	AgentAPIsPort                 InstanaAgentPort = "agent-apis"
 	AgentAPIsPortNumber           int32            = 42699
-	AgentSocketPort               InstanaAgentPort = "agent-socket"
-	AgentSocketPortNumber         int32            = 42666
 	OpenTelemetryLegacyPort       InstanaAgentPort = "otlp-legacy"
 	OpenTelemetryLegacyPortNumber int32            = 55680
 	OpenTelemetryGRPCPort         InstanaAgentPort = "otlp-grpc"
@@ -46,8 +44,6 @@ func (p InstanaAgentPort) PortNumber() int32 {
 	switch p {
 	case AgentAPIsPort:
 		return AgentAPIsPortNumber
-	case AgentSocketPort:
-		return AgentSocketPortNumber
 	case OpenTelemetryLegacyPort:
 		return OpenTelemetryLegacyPortNumber
 	case OpenTelemetryGRPCPort:
@@ -68,8 +64,6 @@ func (p InstanaAgentPort) IsEnabled(openTelemetrySettings instanav1.OpenTelemetr
 	case OpenTelemetryHTTPPort:
 		return openTelemetrySettings.HttpIsEnabled()
 	case AgentAPIsPort:
-		fallthrough
-	case AgentSocketPort:
 		fallthrough
 	default:
 		return true

--- a/pkg/k8s/object/builders/common/ports/instana_agent_port.go
+++ b/pkg/k8s/object/builders/common/ports/instana_agent_port.go
@@ -56,16 +56,12 @@ func (p InstanaAgentPort) PortNumber() int32 {
 }
 
 func (p InstanaAgentPort) IsEnabled(openTelemetrySettings instanav1.OpenTelemetry) bool {
-	switch p {
-	case OpenTelemetryLegacyPort:
-		fallthrough
-	case OpenTelemetryGRPCPort:
+	if p == OpenTelemetryLegacyPort || p == OpenTelemetryGRPCPort {
 		return openTelemetrySettings.GrpcIsEnabled()
-	case OpenTelemetryHTTPPort:
-		return openTelemetrySettings.HttpIsEnabled()
-	case AgentAPIsPort:
-		fallthrough
-	default:
-		return true
 	}
+	if p == OpenTelemetryHTTPPort {
+		return openTelemetrySettings.HttpIsEnabled()
+	}
+	// AgentAPIsPort is always enabled
+	return true
 }

--- a/pkg/k8s/object/builders/common/ports/ports_builder.go
+++ b/pkg/k8s/object/builders/common/ports/ports_builder.go
@@ -49,5 +49,10 @@ func (p *portsBuilder) GetServicePorts(ports ...InstanaAgentPort) []corev1.Servi
 }
 
 func (p *portsBuilder) GetContainerPorts(ports ...InstanaAgentPort) []corev1.ContainerPort {
-	return list.NewListMapTo[InstanaAgentPort, corev1.ContainerPort]().MapTo(ports, toContainerPort)
+	enabledPorts := list.NewListFilter[InstanaAgentPort]().Filter(
+		ports, func(port InstanaAgentPort) bool {
+			return port.IsEnabled(p.InstanaAgent.Spec.OpenTelemetry)
+		},
+	)
+	return list.NewListMapTo[InstanaAgentPort, corev1.ContainerPort]().MapTo(enabledPorts, toContainerPort)
 }

--- a/pkg/k8s/object/builders/common/ports/ports_test.go
+++ b/pkg/k8s/object/builders/common/ports/ports_test.go
@@ -49,14 +49,6 @@ func TestInstanaAgentPortMappings(t *testing.T) {
 		},
 
 		{
-			name:                  string(ports.AgentSocketPort),
-			port:                  ports.AgentSocketPort,
-			openTelemetrySettings: instanav1.OpenTelemetry{Enabled: instanav1.Enabled{Enabled: &enabled}, GRPC: &instanav1.Enabled{Enabled: &enabled}},
-			expectedPortNumber:    ports.AgentSocketPortNumber,
-			expectEnabled:         true,
-		},
-
-		{
 			name:                  string(ports.OpenTelemetryLegacyPort) + "_not_enabled",
 			port:                  ports.OpenTelemetryLegacyPort,
 			openTelemetrySettings: instanav1.OpenTelemetry{Enabled: instanav1.Enabled{Enabled: &enabled}, GRPC: &instanav1.Enabled{Enabled: &disabled}},
@@ -142,12 +134,6 @@ func TestPortsBuilderGetServicePorts(t *testing.T) {
 			Protocol:   corev1.ProtocolTCP,
 		},
 		{
-			Name:       string(ports.AgentSocketPort),
-			Port:       ports.AgentSocketPortNumber,
-			TargetPort: intstr.FromString(string(ports.AgentSocketPort)),
-			Protocol:   corev1.ProtocolTCP,
-		},
-		{
 			Name:       string(ports.OpenTelemetryGRPCPort),
 			Port:       ports.OpenTelemetryGRPCPortNumber,
 			TargetPort: intstr.FromString(string(ports.OpenTelemetryGRPCPort)),
@@ -169,7 +155,6 @@ func TestPortsBuilderGetServicePorts(t *testing.T) {
 	actual := pb.
 		GetServicePorts(
 			ports.AgentAPIsPort,
-			ports.AgentSocketPort,
 			ports.OpenTelemetryGRPCPort,
 			ports.OpenTelemetryHTTPPort,
 		)
@@ -187,11 +172,6 @@ func TestPortsBuilderGetContainerPorts(t *testing.T) {
 			Protocol:      corev1.ProtocolTCP,
 		},
 		{
-			Name:          string(ports.AgentSocketPort),
-			ContainerPort: ports.AgentSocketPortNumber,
-			Protocol:      corev1.ProtocolTCP,
-		},
-		{
 			Name:          string(ports.OpenTelemetryGRPCPort),
 			ContainerPort: ports.OpenTelemetryGRPCPortNumber,
 			Protocol:      corev1.ProtocolTCP,
@@ -202,7 +182,6 @@ func TestPortsBuilderGetContainerPorts(t *testing.T) {
 		NewPortsBuilder(&instanav1.InstanaAgent{}).
 		GetContainerPorts(
 			ports.AgentAPIsPort,
-			ports.AgentSocketPort,
 			ports.OpenTelemetryGRPCPort,
 		)
 

--- a/pkg/k8s/object/builders/common/ports/ports_test.go
+++ b/pkg/k8s/object/builders/common/ports/ports_test.go
@@ -140,6 +140,12 @@ func TestPortsBuilderGetServicePorts(t *testing.T) {
 			Protocol:   corev1.ProtocolTCP,
 		},
 		{
+			Name:       string(ports.OpenTelemetryLegacyPort),
+			Port:       ports.OpenTelemetryLegacyPortNumber,
+			TargetPort: intstr.FromString(string(ports.OpenTelemetryLegacyPort)),
+			Protocol:   corev1.ProtocolTCP,
+		},
+		{
 			Name:       string(ports.OpenTelemetryHTTPPort),
 			Port:       ports.OpenTelemetryHTTPPortNumber,
 			TargetPort: intstr.FromString(string(ports.OpenTelemetryHTTPPort)),
@@ -156,6 +162,7 @@ func TestPortsBuilderGetServicePorts(t *testing.T) {
 		GetServicePorts(
 			ports.AgentAPIsPort,
 			ports.OpenTelemetryGRPCPort,
+			ports.OpenTelemetryLegacyPort,
 			ports.OpenTelemetryHTTPPort,
 		)
 
@@ -176,13 +183,40 @@ func TestPortsBuilderGetContainerPorts(t *testing.T) {
 			ContainerPort: ports.OpenTelemetryGRPCPortNumber,
 			Protocol:      corev1.ProtocolTCP,
 		},
+		{
+			Name:          string(ports.OpenTelemetryHTTPPort),
+			ContainerPort: ports.OpenTelemetryHTTPPortNumber,
+			Protocol:      corev1.ProtocolTCP,
+		},
+		{
+			Name:          string(ports.OpenTelemetryLegacyPort),
+			ContainerPort: ports.OpenTelemetryLegacyPortNumber,
+			Protocol:      corev1.ProtocolTCP,
+		},
 	}
 
+	enabled := true
 	actual := ports.
-		NewPortsBuilder(&instanav1.InstanaAgent{}).
+		NewPortsBuilder(&instanav1.InstanaAgent{
+			Spec: instanav1.InstanaAgentSpec{
+				OpenTelemetry: instanav1.OpenTelemetry{
+					Enabled: instanav1.Enabled{
+						Enabled: &enabled,
+					},
+					GRPC: &instanav1.Enabled{
+						Enabled: &enabled,
+					},
+					HTTP: &instanav1.Enabled{
+						Enabled: &enabled,
+					},
+				},
+			},
+		}).
 		GetContainerPorts(
 			ports.AgentAPIsPort,
 			ports.OpenTelemetryGRPCPort,
+			ports.OpenTelemetryHTTPPort,
+			ports.OpenTelemetryLegacyPort,
 		)
 
 	assertions.Equal(expected, actual)

--- a/pkg/k8s/object/builders/common/ports/ports_test.go
+++ b/pkg/k8s/object/builders/common/ports/ports_test.go
@@ -254,6 +254,6 @@ func TestPortsBuilderGetPorts(t *testing.T) {
 			)
 
 		assertions.Equal(test.expectedContainerPorts, actualContainerPorts, test.openTelemetrySettings)
-		assertions.Equal(test.expectedServicePorts, actualServicePorts)
+		assertions.Equal(test.expectedServicePorts, actualServicePorts, test.openTelemetrySettings)
 	}
 }


### PR DESCRIPTION
Card: [INSTA-12524](https://jsw.ibm.com/browse/INSTA-12524)

- Remove obsolete agent-socket port 42666
- Do only bind ports which are enabled on the Daemonset

```
spec:
  agent:
    configuration_yaml: |
      # You can leave this empty, or use this to configure your instana agent.
      # See https://github.com/instana/instana-agent-operator/blob/main/config/samples/instana_v1_extended_instanaagent.yaml for the extended version.
    endpointHost: xxx
    endpointPort: "443"
    env: {}
    key: xxx
  cluster:
    name: konrad
  opentelemetry:
    grpc:
      enabled: false
    http:
      enabled: true
```

If grpc is enabled, bind 42699 (agent apis) and 55680 (oltp-legacy) and 4317 (otlp-grpc) ports. 

If http is enabled, bind 42699 (agent apis) and 4318 (oltp-http) ports.

By default, bind all ports.