### PR TITLE
chore: Add opentelemetry default settings to example

### DIFF
--- a/config/samples/instana_v1_instanaagent.yaml
+++ b/config/samples/instana_v1_instanaagent.yaml
@@ -16,3 +16,8 @@ spec:
     configuration_yaml: |
       # You can leave this empty, or use this to configure your instana agent.
       # See https://github.com/instana/instana-agent-operator/blob/main/config/samples/instana_v1_extended_instanaagent.yaml for the extended version.
+  opentelemetry:
+    grpc:
+      enabled: true
+    http:
+      enabled: true


### PR DESCRIPTION
When not defined, there is no default value shown on the OCP install page.