### PR TITLE
go.mod: change version from 1.23 to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/instana/instana-agent-operator
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
1.23 is not a downloable release. Go mod should list the specific toolchain that can be downloaded as mentioned here: https://github.com/golang/go/issues/62278#issuecomment-1693538776 Otherwise opening the project having a different version installed will result in errors, e.g:

```
$ go version
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```