### PR TITLE
Add multi-backend k8sensor support

### DIFF
--- a/api/v1/inline_types.go
+++ b/api/v1/inline_types.go
@@ -281,7 +281,7 @@ type BackendSpec struct {
 	EndpointHost string `json:"endpointHost"`
 	// +kubebuilder:validation:Required
 	EndpointPort string `json:"endpointPort"`
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	Key string `json:"key"`
 }
 

--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -205,16 +205,14 @@ function install_cr() {
     kubectl apply -f ${path_to_crd}
 }
 
-function install_cr_multi_backend_external_keyssecret() {
-    echo "=== install_cr_multi_backend_external_keyssecret ==="
+function install_cr_multi_backend() {
+    echo "=== install_cr_multi_backend ==="
 
     # install the Custom Resource
-    path_to_crd="config/samples/instana_v1_instanaagent_multiple_backends_external_keyssecret.yaml"
-    path_to_keyssecret="config/samples/external_secret_instana_agent_key.yaml"
+    path_to_crd="config/samples/instana_v1_instanaagent_multiple_backends.yaml"
 
-    echo "Install the keysSecret and CR"
+    echo "Install the multi-backend CR"
     # credentials are invalid here, but that's okay, we just test the operator behavior, not the agent
-    kubectl apply -f ${path_to_keyssecret}
     kubectl apply -f ${path_to_crd}
 }
 
@@ -314,8 +312,8 @@ pushd pipeline-source
     wait_for_running_cr_state
     echo "Upgrade has been successful"
 
-    echo "Install CR to connect to an additional backend with external keysSecret"
-    install_cr_multi_backend_external_keyssecret
+    echo "Install CR to connect to an additional backend for both k8sensor and instana-agent"
+    install_cr_multi_backend
     wait_for_running_pod app.kubernetes.io/name=instana-agent instana-agent
     verify_multi_backend_config_generation_and_injection
 popd

--- a/ci/scripts/end-to-end-test.sh
+++ b/ci/scripts/end-to-end-test.sh
@@ -216,6 +216,19 @@ function install_cr_multi_backend() {
     kubectl apply -f ${path_to_crd}
 }
 
+function install_cr_multi_backend_external_keyssecret() {
+    echo "=== install_cr_multi_backend_external_keyssecret ==="
+
+    # install the Custom Resource
+    path_to_crd="config/samples/instana_v1_instanaagent_multiple_backends_external_keyssecret.yaml"
+    path_to_keyssecret="config/samples/external_secret_instana_agent_key.yaml"
+
+    echo "Install the keysSecret and CR"
+    # credentials are invalid here, but that's okay, we just test the operator behavior, not the agent
+    kubectl apply -f ${path_to_keyssecret}
+    kubectl apply -f ${path_to_crd}
+}
+
 function verify_multi_backend_config_generation_and_injection() {
     echo "=== function verify_multi_backend_config_generation_and_injection ==="
     local timeout=0
@@ -312,6 +325,13 @@ pushd pipeline-source
     wait_for_running_cr_state
     echo "Upgrade has been successful"
 
+    echo "Install CR to connect to an additional backend for both k8sensor and instana-agent"
+    install_cr_multi_backend
+    wait_for_running_pod app.kubernetes.io/name=instana-agent instana-agent
+    verify_multi_backend_config_generation_and_injection
+
+    echo "Install CR to connect to an additional backend with external keysSecret"
+    install_cr_multi_backend_external_keyssecret
     echo "Install CR to connect to an additional backend for both k8sensor and instana-agent"
     install_cr_multi_backend
     wait_for_running_pod app.kubernetes.io/name=instana-agent instana-agent

--- a/config/samples/external_secret_instana_agent_key.yaml
+++ b/config/samples/external_secret_instana_agent_key.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 stringData:
   key: xxx
-  key-2: yyy
+  key-1: yyy
 kind: Secret
 metadata:
   labels:

--- a/config/samples/external_secret_instana_agent_key.yaml
+++ b/config/samples/external_secret_instana_agent_key.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 stringData:
   key: xxx
+  key-2: yyy
 kind: Secret
 metadata:
   labels:

--- a/config/samples/instana_v1_extended_instanaagent.yaml
+++ b/config/samples/instana_v1_extended_instanaagent.yaml
@@ -12,6 +12,15 @@ spec:
   agent:
     # replace with your Instana agent key
     key: replace-key
+    # Rather than specifying the agent key and optionally the download key, you can "bring your
+    # own secret" creating it in the namespace in which you install the `instana-agent` and
+    # specify its name in the `keysSecret` field. The secret you create must contains
+    # a field called `key` and optionally one called `downloadKey`, which contain, respectively,
+    # the values you'd otherwise set in `.agent.key` and `agent.downloadKey`.
+    # If you are using multiple backends, the fields in the secret should be called
+    # `key`, `key-1`, `key-2`, etc for each reporting backend.
+    # The order of the keys and the backends listed in additionalBackends below need to match.
+    # keysSecret: null
     endpointHost: ingress-red-saas.instana.io
     endpointPort: "443"
     # The minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available

--- a/config/samples/instana_v1_extended_instanaagent.yaml
+++ b/config/samples/instana_v1_extended_instanaagent.yaml
@@ -20,6 +20,7 @@ spec:
     # If you are using multiple backends, the fields in the secret should be called
     # `key`, `key-1`, `key-2`, etc for each reporting backend.
     # The order of the keys and the backends listed in additionalBackends below need to match.
+    # If the keySecret is defined, the key specified for each backend is ignored.
     # keysSecret: null
     endpointHost: ingress-red-saas.instana.io
     endpointPort: "443"

--- a/config/samples/instana_v1_instanaagent_multiple_backends.yaml
+++ b/config/samples/instana_v1_instanaagent_multiple_backends.yaml
@@ -9,10 +9,10 @@ spec:
   cluster:
     name: my-cluster
   agent:
+    key: xxx
     endpointHost: first-backend.instana.io
     endpointPort: "443"
     env: {}
-    keysSecret: instana-agent-key
     additionalBackends:
     - endpointHost: second-backend.instana.io
       endpointPort: "443"

--- a/config/samples/instana_v1_instanaagent_multiple_backends_external_keyssecret.yaml
+++ b/config/samples/instana_v1_instanaagent_multiple_backends_external_keyssecret.yaml
@@ -1,0 +1,21 @@
+apiVersion: instana.io/v1
+kind: InstanaAgent
+metadata:
+  name: instana-agent
+  namespace: instana-agent
+spec:
+  zone:
+    name: edited-zone # (optional) name of the zone of the host
+  cluster:
+    name: my-cluster
+  agent:
+    endpointHost: first-backend.instana.io
+    endpointPort: "443"
+    env: {}
+    keysSecret: instana-agent-key
+    additionalBackends:
+    - endpointHost: second-backend.instana.io
+      endpointPort: "443"
+    configuration_yaml: |
+      # You can leave this empty, or use this to configure your instana agent.
+      # See https://github.com/instana/instana-agent-operator/blob/main/config/samples/instana_v1_extended_instanaagent.yaml for the extended version.

--- a/controllers/apply.go
+++ b/controllers/apply.go
@@ -94,7 +94,7 @@ func (r *InstanaAgentReconciler) applyResources(
 	builders := append(
 		getDaemonSetBuilders(agent, isOpenShift, statusManager),
 		headlessservice.NewHeadlessServiceBuilder(agent),
-		agentsecrets.NewConfigBuilder(agent, statusManager, keysSecret),
+		agentsecrets.NewConfigBuilder(agent, statusManager, keysSecret, k8SensorBackends),
 		agentsecrets.NewContainerBuilder(agent, keysSecret),
 		tlssecret.NewSecretBuilder(agent),
 		service.NewServiceBuilder(agent),

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -86,30 +86,6 @@ type InstanaAgentReconciler struct {
 	scheme   *runtime.Scheme
 }
 
-func NewK8SensorBackend(
-	resourceSuffix string,
-	endpointKey string,
-	downloadKey string,
-	endpointHost string,
-	endpointPort string,
-) *K8SensorBackend {
-	return &K8SensorBackend{
-		resourceSuffix: resourceSuffix,
-		endpointKey:    endpointKey,
-		downloadKey:    downloadKey,
-		endpointHost:   endpointHost,
-		endpointPort:   endpointPort,
-	}
-}
-
-type K8SensorBackend struct {
-	resourceSuffix string
-	endpointKey    string
-	downloadKey    string
-	endpointHost   string
-	endpointPort   string
-}
-
 func (r *InstanaAgentReconciler) reconcile(
 	ctx context.Context,
 	req ctrl.Request,

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -86,6 +86,30 @@ type InstanaAgentReconciler struct {
 	scheme   *runtime.Scheme
 }
 
+func NewK8SensorBackend(
+	resourceSuffix string,
+	endpointKey string,
+	downloadKey string,
+	endpointHost string,
+	endpointPort string,
+) *K8SensorBackend {
+	return &K8SensorBackend{
+		resourceSuffix: resourceSuffix,
+		endpointKey:    endpointKey,
+		downloadKey:    downloadKey,
+		endpointHost:   endpointHost,
+		endpointPort:   endpointPort,
+	}
+}
+
+type K8SensorBackend struct {
+	resourceSuffix string
+	endpointKey    string
+	downloadKey    string
+	endpointHost   string
+	endpointPort   string
+}
+
 func (r *InstanaAgentReconciler) reconcile(
 	ctx context.Context,
 	req ctrl.Request,
@@ -130,6 +154,8 @@ func (r *InstanaAgentReconciler) reconcile(
 		}
 	}
 
+	k8SensorBackends := r.getK8SensorBackends(agent)
+
 	if applyResourcesRes := r.applyResources(
 		ctx,
 		agent,
@@ -137,6 +163,7 @@ func (r *InstanaAgentReconciler) reconcile(
 		operatorUtils,
 		statusManager,
 		keysSecret,
+		k8SensorBackends,
 	); applyResourcesRes.suppliesReconcileResult() {
 		return applyResourcesRes
 	}

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -25,6 +25,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 )
 
@@ -43,11 +44,11 @@ func (r *InstanaAgentReconciler) isOpenShift(ctx context.Context, operatorUtils 
 	return isOpenShiftRes, reconcileContinue()
 }
 
-func (r *InstanaAgentReconciler) getK8SensorBackends(agent *instanav1.InstanaAgent) []K8SensorBackend {
-	k8SensorBackends := make([]K8SensorBackend, 0, len(agent.Spec.Agent.AdditionalBackends)+1)
+func (r *InstanaAgentReconciler) getK8SensorBackends(agent *instanav1.InstanaAgent) []backends.K8SensorBackend {
+	k8SensorBackends := make([]backends.K8SensorBackend, 0, len(agent.Spec.Agent.AdditionalBackends)+1)
 	k8SensorBackends = append(
 		k8SensorBackends,
-		*NewK8SensorBackend("", agent.Spec.Agent.Key, agent.Spec.Agent.DownloadKey, agent.Spec.Agent.EndpointHost, agent.Spec.Agent.EndpointPort),
+		*backends.NewK8SensorBackend("", agent.Spec.Agent.Key, agent.Spec.Agent.DownloadKey, agent.Spec.Agent.EndpointHost, agent.Spec.Agent.EndpointPort),
 	)
 
 	if len(agent.Spec.Agent.AdditionalBackends) == 0 {
@@ -57,7 +58,7 @@ func (r *InstanaAgentReconciler) getK8SensorBackends(agent *instanav1.InstanaAge
 	for i, additionalBackend := range agent.Spec.Agent.AdditionalBackends {
 		k8SensorBackends = append(
 			k8SensorBackends,
-			*NewK8SensorBackend("-additional-backend-"+strconv.Itoa(i+1), additionalBackend.Key, "", additionalBackend.EndpointHost, additionalBackend.EndpointPort),
+			*backends.NewK8SensorBackend("-"+strconv.Itoa(i+1), additionalBackend.Key, "", additionalBackend.EndpointHost, additionalBackend.EndpointPort),
 		)
 	}
 	return k8SensorBackends

--- a/pkg/k8s/object/builders/agent/secrets/config.go
+++ b/pkg/k8s/object/builders/agent/secrets/config.go
@@ -126,7 +126,7 @@ func (c *configBuilder) backendConfig() (map[string][]byte, error) {
 	// render additional backends configuration
 	var backendKey string
 	for i, backend := range c.backends {
-		if (c.Spec.Agent.KeysSecret == "" && backend.EndpointKey == "") || backend.EndpointHost == "" {
+		if (c.keysSecret.Name == "" && backend.EndpointKey == "") || backend.EndpointHost == "" {
 			// skip backend as it would be broken anyways, should be caught by the schema validator anyways, but better be safe than sorry
 			c.logger.Error(fmt.Errorf("backend not defined: backend key (plaintext or through secret) or endpoint missing"), "skipping additional backend due to missing values")
 			continue
@@ -137,6 +137,10 @@ func (c *configBuilder) backendConfig() (map[string][]byte, error) {
 			backendKey = string(keyValueFromSecret)
 		} else if backend.EndpointKey != "" {
 			backendKey = string(backend.EndpointKey)
+		}
+
+		if backendKey == "" {
+			continue
 		}
 
 		lines := []string{

--- a/pkg/k8s/object/builders/agent/secrets/config.go
+++ b/pkg/k8s/object/builders/agent/secrets/config.go
@@ -5,13 +5,13 @@
 package secrets
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
 	commonbuilder "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/builder"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
@@ -29,17 +29,20 @@ type configBuilder struct {
 	statusManager status.AgentStatusManager
 	keysSecret    *corev1.Secret
 	logger        logr.Logger
+	backends      []backends.K8SensorBackend
 }
 
 func NewConfigBuilder(
 	agent *instanav1.InstanaAgent,
 	statusManager status.AgentStatusManager,
-	keysSecret *corev1.Secret) commonbuilder.ObjectBuilder {
+	keysSecret *corev1.Secret,
+	backends []backends.K8SensorBackend) commonbuilder.ObjectBuilder {
 	return &configBuilder{
 		InstanaAgent:  agent,
 		statusManager: statusManager,
 		keysSecret:    keysSecret,
 		logger:        logf.Log.WithName("instana-agent-config-secret-builder"),
+		backends:      backends,
 	}
 }
 
@@ -121,18 +124,19 @@ func (c *configBuilder) backendConfig() (map[string][]byte, error) {
 	config := map[string][]byte{}
 
 	// render additional backends configuration
-	for i, backend := range c.Spec.Agent.AdditionalBackends {
-		if (c.Spec.Agent.KeysSecret == "" && backend.Key == "") || backend.EndpointHost == "" {
+	var backendKey string
+	for i, backend := range c.backends {
+		if (c.Spec.Agent.KeysSecret == "" && backend.EndpointKey == "") || backend.EndpointHost == "" {
 			// skip backend as it would be broken anyways, should be caught by the schema validator anyways, but better be safe than sorry
 			c.logger.Error(fmt.Errorf("backend not defined: backend key (plaintext or through secret) or endpoint missing"), "skipping additional backend due to missing values")
 			continue
 		}
 
-		var backendKey string
-		if keyValueFromSecret, ok := c.keysSecret.Data["key"]; ok {
+		backendKey = ""
+		if keyValueFromSecret, ok := c.keysSecret.Data["key"+backend.ResourceSuffix]; ok {
 			backendKey = string(keyValueFromSecret)
-		} else if c.Spec.Agent.Key != "" {
-			backendKey = string(c.Spec.Agent.Key)
+		} else if backend.EndpointKey != "" {
+			backendKey = string(backend.EndpointKey)
 		}
 
 		lines := []string{
@@ -160,48 +164,8 @@ func (c *configBuilder) backendConfig() (map[string][]byte, error) {
 			)
 		}
 
-		config["com.instana.agent.main.sender.Backend-"+strconv.Itoa(i+2)+".cfg"] = []byte(strings.Join(lines, "\n") + "\n")
+		config["com.instana.agent.main.sender.Backend-"+strconv.Itoa(i+1)+".cfg"] = []byte(strings.Join(lines, "\n") + "\n")
 	}
-
-	if c.Spec.Agent.EndpointHost == "" {
-		return config, errors.New("agent endpoint host has not been set")
-	}
-
-	var agentKey string
-	if keyValueFromSecret, ok := c.keysSecret.Data["key"]; ok {
-		agentKey = string(keyValueFromSecret)
-	} else if c.Spec.Agent.Key != "" {
-		agentKey = string(c.Spec.Agent.Key)
-	} else {
-		return config, errors.New("agent key has not been set")
-	}
-
-	backendLines := []string{
-		toInlineVariable("host", c.Spec.Agent.EndpointHost),
-		toInlineVariable("port", c.Spec.Agent.EndpointPort, "443"),
-		toInlineVariable("protocol", "HTTP/2"),
-		toInlineVariable("key", agentKey),
-	}
-	if c.Spec.Agent.ProxyHost != "" {
-		backendLines = append(
-			backendLines,
-			toInlineVariable("proxy.type", c.Spec.Agent.ProxyProtocol, "HTTP"),
-			toInlineVariable("proxy.host", c.Spec.Agent.ProxyHost),
-			toInlineVariable("proxy.port", c.Spec.Agent.ProxyPort, "80"),
-		)
-	}
-	if c.Spec.Agent.ProxyUseDNS {
-		backendLines = append(backendLines, toInlineVariable("proxy.dns", "true"))
-	}
-	if c.Spec.Agent.ProxyUser != "" {
-		backendLines = append(backendLines, toInlineVariable("proxy.user", c.Spec.Agent.ProxyUser))
-	}
-	if c.Spec.Agent.ProxyPassword != "" {
-		backendLines = append(backendLines, toInlineVariable("proxy.password", c.Spec.Agent.ProxyPassword))
-	}
-
-	config["com.instana.agent.main.sender.Backend-1.cfg"] = []byte(strings.Join(backendLines, "\n") + "\n")
-
 	return config, nil
 }
 

--- a/pkg/k8s/object/builders/agent/secrets/keys-secret/secret_test.go
+++ b/pkg/k8s/object/builders/agent/secrets/keys-secret/secret_test.go
@@ -27,13 +27,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
 	"github.com/instana/instana-agent-operator/pkg/optional"
 )
 
 func TestSecretBuilder_IsNamespaced_ComponentName(t *testing.T) {
 	assertions := require.New(t)
 
-	s := NewSecretBuilder(&instanav1.InstanaAgent{}, "", "", "")
+	s := NewSecretBuilder(&instanav1.InstanaAgent{}, make([]backends.K8SensorBackend, 0))
 
 	assertions.True(s.IsNamespaced())
 	assertions.Equal("instana-agent", s.ComponentName())
@@ -77,7 +78,11 @@ func TestSecretBuilder_Build(t *testing.T) {
 							},
 						}
 
-						sb := NewSecretBuilder(&agent, key, downloadKey, "")
+						backend := backends.NewK8SensorBackend("", key, downloadKey, "", "")
+						var backends [1]backends.K8SensorBackend
+						backends[0] = *backend
+
+						sb := NewSecretBuilder(&agent, backends[:])
 
 						actual := sb.Build()
 

--- a/pkg/k8s/object/builders/agent/secrets/keys-secret/secret_test.go
+++ b/pkg/k8s/object/builders/agent/secrets/keys-secret/secret_test.go
@@ -1,3 +1,19 @@
+/*
+(c) Copyright IBM Corp. 2024
+(c) Copyright Instana Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package keys_secret
 
 import (
@@ -17,7 +33,7 @@ import (
 func TestSecretBuilder_IsNamespaced_ComponentName(t *testing.T) {
 	assertions := require.New(t)
 
-	s := NewSecretBuilder(&instanav1.InstanaAgent{})
+	s := NewSecretBuilder(&instanav1.InstanaAgent{}, "", "", "")
 
 	assertions.True(s.IsNamespaced())
 	assertions.Equal("instana-agent", s.ComponentName())
@@ -61,7 +77,7 @@ func TestSecretBuilder_Build(t *testing.T) {
 							},
 						}
 
-						sb := NewSecretBuilder(&agent)
+						sb := NewSecretBuilder(&agent, key, downloadKey, "")
 
 						actual := sb.Build()
 

--- a/pkg/k8s/object/builders/common/backends/backends.go
+++ b/pkg/k8s/object/builders/common/backends/backends.go
@@ -1,0 +1,30 @@
+/*
+(c) Copyright IBM Corp. 2024
+(c) Copyright Instana Inc. 2024
+*/
+
+package backend
+
+func NewK8SensorBackend(
+	ResourceSuffix string,
+	EndpointKey string,
+	DownloadKey string,
+	EndpointHost string,
+	EndpointPort string,
+) *K8SensorBackend {
+	return &K8SensorBackend{
+		ResourceSuffix: ResourceSuffix,
+		EndpointKey:    EndpointKey,
+		DownloadKey:    DownloadKey,
+		EndpointHost:   EndpointHost,
+		EndpointPort:   EndpointPort,
+	}
+}
+
+type K8SensorBackend struct {
+	ResourceSuffix string
+	EndpointKey    string
+	DownloadKey    string
+	EndpointHost   string
+	EndpointPort   string
+}

--- a/pkg/k8s/object/builders/k8s-sensor/configmap/configmap.go
+++ b/pkg/k8s/object/builders/k8s-sensor/configmap/configmap.go
@@ -17,6 +17,16 @@ import (
 type configMapBuilder struct {
 	*instanav1.InstanaAgent
 	helpers.Helpers
+	endpointHost       string
+	endpointPort       string
+	resourceNameSuffix string
+}
+
+func (c *configMapBuilder) getResourceName() string {
+	if c.resourceNameSuffix == "" {
+		return c.K8sSensorResourcesName()
+	}
+	return c.K8sSensorResourcesName() + c.resourceNameSuffix
 }
 
 func (c *configMapBuilder) IsNamespaced() bool {
@@ -35,19 +45,22 @@ func (c *configMapBuilder) Build() optional.Optional[client.Object] {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      c.K8sSensorResourcesName(),
+				Name:      c.getResourceName(),
 				Namespace: c.Namespace,
 			},
 			Data: map[string]string{
-				constants.BackendKey: fmt.Sprintf("%s:%s", c.Spec.Agent.EndpointHost, c.Spec.Agent.EndpointPort),
+				constants.BackendKey: fmt.Sprintf("%s:%s", c.endpointHost, c.endpointPort),
 			},
 		},
 	)
 }
 
-func NewConfigMapBuilder(agent *instanav1.InstanaAgent) builder.ObjectBuilder {
+func NewConfigMapBuilder(agent *instanav1.InstanaAgent, endpointHost string, endpointPort string, resourceNameSuffix string) builder.ObjectBuilder {
 	return &configMapBuilder{
-		InstanaAgent: agent,
-		Helpers:      helpers.NewHelpers(agent),
+		InstanaAgent:       agent,
+		Helpers:            helpers.NewHelpers(agent),
+		endpointHost:       endpointHost,
+		endpointPort:       endpointPort,
+		resourceNameSuffix: resourceNameSuffix,
 	}
 }

--- a/pkg/k8s/object/builders/k8s-sensor/configmap/configmap.go
+++ b/pkg/k8s/object/builders/k8s-sensor/configmap/configmap.go
@@ -1,3 +1,8 @@
+/*
+(c) Copyright IBM Corp. 2024
+(c) Copyright Instana Inc. 2024
+*/
+
 package configmap
 
 import (
@@ -8,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/builder"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/helpers"
@@ -17,16 +23,7 @@ import (
 type configMapBuilder struct {
 	*instanav1.InstanaAgent
 	helpers.Helpers
-	endpointHost       string
-	endpointPort       string
-	resourceNameSuffix string
-}
-
-func (c *configMapBuilder) getResourceName() string {
-	if c.resourceNameSuffix == "" {
-		return c.K8sSensorResourcesName()
-	}
-	return c.K8sSensorResourcesName() + c.resourceNameSuffix
+	backends []backends.K8SensorBackend
 }
 
 func (c *configMapBuilder) IsNamespaced() bool {
@@ -37,6 +34,14 @@ func (c *configMapBuilder) ComponentName() string {
 	return constants.ComponentK8Sensor
 }
 
+func (c *configMapBuilder) getConfigMapData() map[string]string {
+	data := make(map[string]string, len(c.backends))
+	for _, backend := range c.backends {
+		data[constants.BackendKey+backend.ResourceSuffix] = fmt.Sprintf("%s:%s", backend.EndpointHost, backend.EndpointPort)
+	}
+	return data
+}
+
 func (c *configMapBuilder) Build() optional.Optional[client.Object] {
 	return optional.Of[client.Object](
 		&corev1.ConfigMap{
@@ -45,22 +50,17 @@ func (c *configMapBuilder) Build() optional.Optional[client.Object] {
 				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      c.getResourceName(),
+				Name:      c.K8sSensorResourcesName(),
 				Namespace: c.Namespace,
 			},
-			Data: map[string]string{
-				constants.BackendKey: fmt.Sprintf("%s:%s", c.endpointHost, c.endpointPort),
-			},
-		},
-	)
+			Data: c.getConfigMapData(),
+		})
 }
 
-func NewConfigMapBuilder(agent *instanav1.InstanaAgent, endpointHost string, endpointPort string, resourceNameSuffix string) builder.ObjectBuilder {
+func NewConfigMapBuilder(agent *instanav1.InstanaAgent, backends []backends.K8SensorBackend) builder.ObjectBuilder {
 	return &configMapBuilder{
-		InstanaAgent:       agent,
-		Helpers:            helpers.NewHelpers(agent),
-		endpointHost:       endpointHost,
-		endpointPort:       endpointPort,
-		resourceNameSuffix: resourceNameSuffix,
+		InstanaAgent: agent,
+		Helpers:      helpers.NewHelpers(agent),
+		backends:     backends,
 	}
 }

--- a/pkg/k8s/object/builders/k8s-sensor/configmap/configmap_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/configmap/configmap_test.go
@@ -37,7 +37,7 @@ import (
 func TestConfigMapBuilderIsNamespacedComponentName(t *testing.T) {
 	assertions := require.New(t)
 
-	cmb := NewConfigMapBuilder(nil)
+	cmb := NewConfigMapBuilder(nil, "", "", "")
 
 	assertions.True(cmb.IsNamespaced())
 	assertions.Equal(constants.ComponentK8Sensor, cmb.ComponentName())
@@ -87,6 +87,8 @@ func TestConfigMapBuilderBuild(t *testing.T) {
 	cmb := &configMapBuilder{
 		InstanaAgent: agent,
 		Helpers:      helpers,
+		endpointHost: endpointHost,
+		endpointPort: endpointPort,
 	}
 
 	actual := cmb.Build()

--- a/pkg/k8s/object/builders/k8s-sensor/configmap/configmap_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/configmap/configmap_test.go
@@ -30,6 +30,7 @@ import (
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
 	"github.com/instana/instana-agent-operator/mocks"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
 	"github.com/instana/instana-agent-operator/pkg/optional"
 )
@@ -37,7 +38,7 @@ import (
 func TestConfigMapBuilderIsNamespacedComponentName(t *testing.T) {
 	assertions := require.New(t)
 
-	cmb := NewConfigMapBuilder(nil, "", "", "")
+	cmb := NewConfigMapBuilder(nil, make([]backends.K8SensorBackend, 0))
 
 	assertions.True(cmb.IsNamespaced())
 	assertions.Equal(constants.ComponentK8Sensor, cmb.ComponentName())
@@ -84,11 +85,13 @@ func TestConfigMapBuilderBuild(t *testing.T) {
 	helpers := mocks.NewMockHelpers(ctrl)
 	helpers.EXPECT().K8sSensorResourcesName().Return(sensorResourcesName)
 
+	backend := backends.NewK8SensorBackend("", "", "", endpointHost, endpointPort)
+	var backends [1]backends.K8SensorBackend
+	backends[0] = *backend
 	cmb := &configMapBuilder{
 		InstanaAgent: agent,
 		Helpers:      helpers,
-		endpointHost: endpointHost,
-		endpointPort: endpointPort,
+		backends:     backends[:],
 	}
 
 	actual := cmb.Build()


### PR DESCRIPTION
For each k8sensor backend we get a secret (that stores agent key), configmap (that stores agent endpoint) created and a deployment. Example:
```
✗ k get secrets
NAME                                 TYPE                             DATA   AGE
delivery.instana                     kubernetes.io/dockerconfigjson   1      44h
instana-agent                        Opaque                           1      17h <-- relevant secret
instana-agent-additional-backend-1   Opaque                           1      17h <-- relevant secret
instana-agent-config                 Opaque                           6      17h
```

```
✗ k get cm
NAME                                          DATA   AGE
instana-agent-dependents                      1      17h
instana-agent-k8sensor                        1      17h <-- relevant cm
instana-agent-k8sensor-additional-backend-1   1      17h <-- relevant cm
kube-root-ca.crt                              1      44h
manager-config                                1      44h
```

```
✗ k get deploy
NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
controller-manager                            2/2     2            2           44h
instana-agent-k8sensor                        3/3     3            3           17h
instana-agent-k8sensor-additional-backend-1   3/3     3            3           17h
```

Example deployment:
```
✗ k describe deploy instana-agent-k8sensor
Name:                   instana-agent-k8sensor
Namespace:              instana-agent
CreationTimestamp:      Wed, 25 Sep 2024 17:53:39 +0200
Labels:                 agent.instana.io/generation=1
                        app=k8sensor
                        app.kubernetes.io/component=k8sensor
                        app.kubernetes.io/instance=instana-agent
                        app.kubernetes.io/managed-by=instana-agent-operator
                        app.kubernetes.io/name=instana-agent
                        app.kubernetes.io/part-of=instana
                        app.kubernetes.io/version=v0.0.1-dev
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               app=k8sensor,app.kubernetes.io/component=k8sensor,app.kubernetes.io/instance=instana-agent,app.kubernetes.io/name=instana-agent
Replicas:               3 desired | 3 updated | 3 total | 3 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app=k8sensor
                    app.kubernetes.io/component=k8sensor
                    app.kubernetes.io/instance=instana-agent
                    app.kubernetes.io/managed-by=instana-agent-operator
                    app.kubernetes.io/name=instana-agent
                    app.kubernetes.io/part-of=instana
                    instana/agent-mode=KUBERNETES
  Service Account:  instana-agent-k8sensor
  Containers:
   instana-agent:
    Image:      icr.io/instana/k8sensor:latest
    Port:       42699/TCP
    Host Port:  0/TCP
    Limits:
      cpu:     1500m
      memory:  768Mi
    Requests:
      cpu:     500m
      memory:  512Mi
    Environment:
      BACKEND:        <set to the key 'backend' of config map 'instana-agent-k8sensor'>  Optional: false  #### relevant part
      AGENT_KEY:      <set to the key 'key' in secret 'instana-agent'>                   Optional: false  #### relevant part
      BACKEND_URL:    https://$(BACKEND)
      AGENT_ZONE:     mc-test-operator
      POD_UID:         (v1:metadata.uid)
      POD_NAMESPACE:   (v1:metadata.namespace)
      POD_NAME:        (v1:metadata.name)
      POD_IP:          (v1:status.podIP)
      CONFIG_PATH:    /opt/instana/agent/etc/instana-config-yml
    Mounts:
      /opt/instana/agent/etc/instana-config-yml from config (rw)
  Volumes:
   config:
    Type:          Secret (a volume populated by a Secret)
    SecretName:    instana-agent-config
    Optional:      false
  Node-Selectors:  <none>
  Tolerations:     <none>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   instana-agent-k8sensor-7577b67cb7 (3/3 replicas created)
Events:          <none>
```


```
✗ k describe deploy instana-agent-k8sensor-additional-backend-1
Name:                   instana-agent-k8sensor-additional-backend-1
Namespace:              instana-agent
CreationTimestamp:      Wed, 25 Sep 2024 17:53:39 +0200
Labels:                 agent.instana.io/generation=1
                        app=k8sensor
                        app.kubernetes.io/component=k8sensor
                        app.kubernetes.io/instance=instana-agent
                        app.kubernetes.io/managed-by=instana-agent-operator
                        app.kubernetes.io/name=instana-agent
                        app.kubernetes.io/part-of=instana
                        app.kubernetes.io/version=v0.0.1-dev
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               app=k8sensor,app.kubernetes.io/component=k8sensor,app.kubernetes.io/instance=instana-agent,app.kubernetes.io/name=instana-agent
Replicas:               3 desired | 3 updated | 3 total | 3 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app=k8sensor
                    app.kubernetes.io/component=k8sensor
                    app.kubernetes.io/instance=instana-agent
                    app.kubernetes.io/managed-by=instana-agent-operator
                    app.kubernetes.io/name=instana-agent
                    app.kubernetes.io/part-of=instana
                    instana/agent-mode=KUBERNETES
  Service Account:  instana-agent-k8sensor
  Containers:
   instana-agent:
    Image:      icr.io/instana/k8sensor:latest
    Port:       42699/TCP
    Host Port:  0/TCP
    Limits:
      cpu:     1500m
      memory:  768Mi
    Requests:
      cpu:     500m
      memory:  512Mi
    Environment:
      BACKEND:        <set to the key 'backend' of config map 'instana-agent-k8sensor-additional-backend-1'>  Optional: false #### relevant part
      AGENT_KEY:      <set to the key 'key' in secret 'instana-agent-additional-backend-1'>                   Optional: false #### relevant part
      BACKEND_URL:    https://$(BACKEND)
      AGENT_ZONE:     mc-test-operator
      POD_UID:         (v1:metadata.uid)
      POD_NAMESPACE:   (v1:metadata.namespace)
      POD_NAME:        (v1:metadata.name)
      POD_IP:          (v1:status.podIP)
      CONFIG_PATH:    /opt/instana/agent/etc/instana-config-yml
    Mounts:
      /opt/instana/agent/etc/instana-config-yml from config (rw)
  Volumes:
   config:
    Type:          Secret (a volume populated by a Secret)
    SecretName:    instana-agent-config
    Optional:      false
  Node-Selectors:  <none>
  Tolerations:     <none>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   instana-agent-k8sensor-additional-backend-1-d7946db79 (3/3 replicas created)
Events:          <none>
```