### PR TITLE
chore: Align agent memory requests with helm chart

### DIFF
--- a/api/v1/inline_types.go
+++ b/api/v1/inline_types.go
@@ -170,7 +170,7 @@ type ResourceRequirements corev1.ResourceRequirements
 
 func (r ResourceRequirements) GetOrDefault() corev1.ResourceRequirements {
 	requestsDefaulter := map_defaulter.NewMapDefaulter((*map[corev1.ResourceName]resource.Quantity)(&r.Requests))
-	requestsDefaulter.SetIfEmpty(corev1.ResourceMemory, resource.MustParse("512Mi"))
+	requestsDefaulter.SetIfEmpty(corev1.ResourceMemory, resource.MustParse("768Mi"))
 	requestsDefaulter.SetIfEmpty(corev1.ResourceCPU, resource.MustParse("0.5"))
 
 	limitsDefaulter := map_defaulter.NewMapDefaulter((*map[corev1.ResourceName]resource.Quantity)(&r.Limits))

--- a/api/v1/inline_types_test.go
+++ b/api/v1/inline_types_test.go
@@ -328,7 +328,7 @@ func TestDaemonSetBuilder_getResourceRequirements(t *testing.T) {
 				for _, providedCpuLimit := range []string{"", "4.5"} {
 					tests = append(
 						tests, testParams{
-							expectedMemRequest: optional.Of(providedMemRequest).GetOrDefault("512Mi"),
+							expectedMemRequest: optional.Of(providedMemRequest).GetOrDefault("768Mi"),
 							expectedCpuRequest: optional.Of(providedCpuRequest).GetOrDefault("0.5"),
 							expectedMemLimit:   optional.Of(providedMemLimit).GetOrDefault("768Mi"),
 							expectedCpuLimit:   optional.Of(providedCpuLimit).GetOrDefault("1.5"),


### PR DESCRIPTION
The agent should request 768Mi of memory to stay consistent with the current helm chart values.