### PR TITLE
[INSTA-17884] feat: Increase default k8sensor pollrate to 10s

### DIFF
--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -140,7 +140,7 @@ func (d *deploymentBuilder) build() *appsv1.Deployment {
 							Image:           d.Spec.K8sSensor.ImageSpec.Image(),
 							ImagePullPolicy: d.Spec.K8sSensor.ImageSpec.PullPolicy,
 							Command:         []string{"/ko-app/k8sensor"},
-							Args:            []string{"10s"},
+							Args:            []string{"-pollrate", "10s"},
 							Env:             d.getEnvVars(),
 							VolumeMounts:    mounts,
 							Resources:       d.Spec.K8sSensor.DeploymentSpec.Pod.ResourceRequirements.GetOrDefault(),

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -139,6 +139,8 @@ func (d *deploymentBuilder) build() *appsv1.Deployment {
 							Name:            "instana-agent",
 							Image:           d.Spec.K8sSensor.ImageSpec.Image(),
 							ImagePullPolicy: d.Spec.K8sSensor.ImageSpec.PullPolicy,
+							Command:         []string{"/ko-app/k8sensor"},
+							Args:            []string{"10s"},
 							Env:             d.getEnvVars(),
 							VolumeMounts:    mounts,
 							Resources:       d.Spec.K8sSensor.DeploymentSpec.Pod.ResourceRequirements.GetOrDefault(),


### PR DESCRIPTION
The previous value was 1 second.
And the intention with this change is to optimizing data volume, and also match the Kubernetes UIs granularity, that doesn't go below 10 seconds. Read more in INSTA-17881.