### PR TITLE
feat: support multiple configurations via configmaps

### DIFF
--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +39,7 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
 	"github.com/instana/instana-agent-operator/pkg/multierror"
 	"github.com/instana/instana-agent-operator/pkg/recovery"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -132,6 +134,9 @@ func (r *InstanaAgentReconciler) reconcile(
 
 	k8SensorBackends := r.getK8SensorBackends(agent)
 
+	clientConfig, _ := rest.InClusterConfig()
+	clientSet, _ := kubernetes.NewForConfig(clientConfig)
+
 	if applyResourcesRes := r.applyResources(
 		ctx,
 		agent,
@@ -140,6 +145,7 @@ func (r *InstanaAgentReconciler) reconcile(
 		statusManager,
 		keysSecret,
 		k8SensorBackends,
+		clientSet.CoreV1(),
 	); applyResourcesRes.suppliesReconcileResult() {
 		return applyResourcesRes
 	}

--- a/pkg/k8s/object/builders/agent/secrets/config_merger.go
+++ b/pkg/k8s/object/builders/agent/secrets/config_merger.go
@@ -35,7 +35,7 @@ func NewConfigMergerBuilder(client v1.CoreV1Interface) DefaultConfigMerger {
 	}
 }
 
-func (c *DefaultConfigMerger) MergeConfigurationYaml(agentConfiguration string) []byte {
+func (c DefaultConfigMerger) MergeConfigurationYaml(agentConfiguration string) []byte {
 	agentData := make(map[string]interface{})
 	err := yaml.Unmarshal([]byte([]byte(agentConfiguration)), agentData)
 	config := []byte{}
@@ -57,7 +57,7 @@ func (c *DefaultConfigMerger) MergeConfigurationYaml(agentConfiguration string) 
 	return config
 }
 
-func (c *DefaultConfigMerger) mergeConfig(agentData, configMapData map[string]interface{}) map[string]interface{} {
+func (c DefaultConfigMerger) mergeConfig(agentData, configMapData map[string]interface{}) map[string]interface{} {
 	for key, configMapValue := range configMapData {
 		if agentValue, ok := agentData[key]; ok {
 			agentValueKind := reflect.TypeOf(agentValue).Kind()
@@ -73,7 +73,7 @@ func (c *DefaultConfigMerger) mergeConfig(agentData, configMapData map[string]in
 	return agentData
 }
 
-func (c *DefaultConfigMerger) fetchConfigMaps() []apiV1.ConfigMap {
+func (c DefaultConfigMerger) fetchConfigMaps() []apiV1.ConfigMap {
 	configMaps := []apiV1.ConfigMap{}
 	c.logger.Info(fmt.Sprintf("Fetching agent configmaps with label '%s'", ConfigMapLabel))
 	configMapList, err := c.k8sClient.ConfigMaps("").List(context.TODO(), metav1.ListOptions{LabelSelector: ConfigMapLabel})

--- a/pkg/k8s/object/builders/agent/secrets/config_merger.go
+++ b/pkg/k8s/object/builders/agent/secrets/config_merger.go
@@ -1,0 +1,83 @@
+/*
+(c) Copyright IBM Corp. 2024
+*/
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
+	apiV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const ConfigMapLabel = "instana.io/agent-config=true"
+
+type ConfigMerger struct {
+	logger    logr.Logger
+	k8sClient v1.CoreV1Interface
+}
+
+func NewConfigMergerBuilder(client v1.CoreV1Interface) *ConfigMerger {
+	return &ConfigMerger{
+		logger:    logf.Log.WithName("instana-agent-config-merger"),
+		k8sClient: client,
+	}
+}
+
+func (c *ConfigMerger) MergeConfigurationYaml(agentConfiguration string) []byte {
+	operator_data := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte([]byte(agentConfiguration)), operator_data)
+	config := []byte{}
+	if err != nil {
+		c.logger.Error(err, "Failed to load agent configuration")
+	} else {
+		config_maps := c.fetchConfigMaps()
+		for _, config_map := range config_maps {
+			config_map_data := make(map[string]interface{})
+			err := yaml.Unmarshal([]byte(config_map.Data["configuration_yaml"]), &config_map_data)
+			if err != nil {
+				c.logger.Error(err, "Failed to parse agent configuration YAML")
+			} else {
+				operator_data = c.mergeConfig(operator_data, config_map_data)
+			}
+		}
+		config, err = yaml.Marshal(operator_data)
+	}
+	return config
+}
+
+func (c *ConfigMerger) mergeConfig(operator_data, config_map_data map[string]interface{}) map[string]interface{} {
+	for key, cm_value := range config_map_data {
+		if op_value, ok := operator_data[key]; ok {
+			op_value_kind := reflect.TypeOf(op_value).Kind()
+			if op_value_kind == reflect.Array || op_value_kind == reflect.Slice {
+				operator_data[key] = append(op_value.([]interface{}), cm_value.([]interface{})...)
+			} else {
+				c.mergeConfig(operator_data[key].(map[string]interface{}), cm_value.(map[string]interface{}))
+			}
+		} else {
+			operator_data[key] = cm_value
+		}
+	}
+	return operator_data
+}
+
+func (c *ConfigMerger) fetchConfigMaps() []apiV1.ConfigMap {
+	config_maps := []apiV1.ConfigMap{}
+	c.logger.Info(fmt.Sprintf("Fetching agent configmaps with label '%s'", ConfigMapLabel))
+	config_map_list, err := c.k8sClient.ConfigMaps("").List(context.TODO(), metav1.ListOptions{LabelSelector: ConfigMapLabel})
+	if err != nil {
+		c.logger.Error(err, fmt.Sprintf("Failed to fetch agent configmaps with label '%s'", ConfigMapLabel))
+	} else {
+		config_maps = config_map_list.Items
+		c.logger.Info(fmt.Sprintf("Found %d configmaps with label '%s'", len(config_maps), ConfigMapLabel))
+	}
+	return config_maps
+}

--- a/pkg/k8s/object/builders/agent/secrets/config_merger_test.go
+++ b/pkg/k8s/object/builders/agent/secrets/config_merger_test.go
@@ -1,0 +1,133 @@
+/*
+(c) Copyright IBM Corp. 2024
+*/
+
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apiV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type CoreV1Mock struct {
+	coreV1.CoreV1Interface
+	mock.Mock
+}
+
+type ConfigMapMock struct {
+	coreV1.ConfigMapInterface
+	mock.Mock
+}
+
+func (mock *CoreV1Mock) ConfigMaps(namespace string) coreV1.ConfigMapInterface {
+	args := mock.Called()
+	return args.Get(0).(*ConfigMapMock)
+}
+
+func (mock *ConfigMapMock) List(ctx context.Context, opts metaV1.ListOptions) (*apiV1.ConfigMapList, error) {
+	args := mock.Called()
+	return args.Get(0).(*apiV1.ConfigMapList), nil
+}
+
+func TestMergeConfigurationYamlWithNoConfigMaps(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMapsList := new(apiV1.ConfigMapList)
+	configMapsList.Items = []apiV1.ConfigMap{}
+	configMaps.On("List").Return(configMapsList).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("c: d\n")
+
+	assert.Equal(t, "c: d\n", string(config_bytes))
+}
+
+func TestMergeConfigurationYamlWithOtherConfigMapData(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMapsList := new(apiV1.ConfigMapList)
+	configMapsList.Items = []apiV1.ConfigMap{{Data: map[string]string{"a": "b"}}}
+	configMaps.On("List").Return(configMapsList).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("c: d\n")
+
+	assert.Equal(t, "c: d\n", string(config_bytes))
+}
+
+func TestMergeConfigurationYamlWithEmptyConfigMapData(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMapsList := new(apiV1.ConfigMapList)
+	configMapsList.Items = []apiV1.ConfigMap{{Data: map[string]string{"configuration_yaml": ""}}}
+	configMaps.On("List").Return(configMapsList).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("c: d\n")
+
+	assert.Equal(t, "c: d\n", string(config_bytes))
+}
+
+func TestMergeConfigurationYamlWithNewTopLevelKey(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMapsList := new(apiV1.ConfigMapList)
+	configMapsList.Items = []apiV1.ConfigMap{{Data: map[string]string{"configuration_yaml": "a:\n b:\n  - 1\n"}}}
+	configMaps.On("List").Return(configMapsList).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("c: d\n")
+
+	assert.Equal(t, "a:\n    b:\n        - 1\nc: d\n", string(config_bytes))
+}
+
+func TestMergeConfigurationYamlWithNewListItem(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMapsList := new(apiV1.ConfigMapList)
+	configMapsList.Items = []apiV1.ConfigMap{{Data: map[string]string{"configuration_yaml": "a:\n b:\n  - 2\n"}}}
+	configMaps.On("List").Return(configMapsList).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("a:\n b:\n  - 1\nc: d\n")
+
+	assert.Equal(t, "a:\n    b:\n        - 1\n        - 2\nc: d\n", string(config_bytes))
+}
+
+func TestMergeConfigurationYamlWithMultipleNewListItems(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMapsList := new(apiV1.ConfigMapList)
+	configMapsList.Items = []apiV1.ConfigMap{{Data: map[string]string{"configuration_yaml": "a:\n b:\n  - 2\n  - 3\n"}}}
+	configMaps.On("List").Return(configMapsList).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("a:\n b:\n  - 1\nc: d\n")
+
+	assert.Equal(t, "a:\n    b:\n        - 1\n        - 2\n        - 3\nc: d\n", string(config_bytes))
+}
+
+func TestMergeConfigurationYamlForFailedRetrieval(t *testing.T) {
+	client := new(CoreV1Mock)
+	configMaps := new(ConfigMapMock)
+	client.On("ConfigMaps").Return(configMaps).Once()
+	configMaps.On("List").Return(&apiV1.ConfigMapList{}, errors.New("Failed")).Once()
+
+	merger := NewConfigMergerBuilder(client)
+	config_bytes := merger.MergeConfigurationYaml("a:\n b:\n  - 1\nc: d\n")
+
+	assert.Equal(t, "a:\n    b:\n        - 1\nc: d\n", string(config_bytes))
+}


### PR DESCRIPTION
## Description
Currently the operator supports only one definition of configuration YAML in the `InstanaAgent` custom resource. This PR adds support for defining multiple configurations and merging them.

## Problem
Consider the the problem of deploying the operator to monitor multiple DB2 instances in a cluster. To configure the DB2 plugin, the following configuration is needed:

```
com.instana.plugin.db2:
  remote:
    - ...
 ```
Note that this supports a list of configurations, one for each DB2 instance. This configuration may not be known at deployment time for the operator. Automation for deploying each DB2 instance must update this configuration by inserting its own details into the list, however, this will result in consistency problems if multiple automation instances try to update their details at the same time.

## Solution
* The problem described above is solved by allowing configuration sections to be defined in a `ConfigMap` with the special label `instana.io/agent-config=true`. The operator uses the Kubernetes API to find all such resources in the cluster, and merges their configuration into the `configuration_yaml` field read from `InstanaAgent` custom resource.
* The merge strategy for the `configuration_yaml` data is as follows:
    1. If the field is present in a config map but not present in the custom resource, then the field is copied from the config map into the custom resource.
    2. If the field is present in a config map and present in the custom resource, and if the type of the field is a list then the list entries from the config map are appended to the corresponding list in the custom resource.
    3. If the field is present in a config map and present in the custom resource, and if the type of the field is **not** a list, no change is made to the custom resource.
    4. If the field is present in the custom resource but not present in the config map, no change is made to the custom resource.
 
## Example
* Consider the `InstanaAgent` custom resource with the following YAML in the `configuration_yaml` field:
```
key1: value1
```
* Consider one `ConfigMap` with the following YAML in its `configuration_yaml` field under `data`:
```
key2: value2
com.instana.plugin.db2:
  remote:
    - host: host1
```
* Consider another `ConfigMap` with the following YAML in its `configuration_yaml` field under `data`:
```
com.instana.plugin.db2:
  remote:
    - host: host2
```
* The configuration YAML, as loaded by the operator, will be as follows:
```
key1: value1
key2: value2
com.instana.plugin.db2:
  remote:
    - host: host1
    - host: host2
```