### PR TITLE
fix: Do not panic if number of volumes and mounts do not match

### DIFF
--- a/pkg/k8s/object/builders/common/volume/volume_builder.go
+++ b/pkg/k8s/object/builders/common/volume/volume_builder.go
@@ -70,12 +70,7 @@ func (v *volumeBuilder) Build(volumes ...Volume) ([]corev1.Volume, []corev1.Volu
 }
 
 func (v *volumeBuilder) BuildFromUserConfig() ([]corev1.Volume, []corev1.VolumeMount) {
-	volumeSpecs := v.instanaAgent.Spec.Agent.Pod.Volumes
-	volumeMounts := v.instanaAgent.Spec.Agent.Pod.VolumeMounts
-	if len(volumeSpecs) != len(volumeMounts) {
-		panic(errors.New("Number of additional volumes and volume mounts do not match"))
-	}
-	return volumeSpecs, volumeMounts
+	return v.instanaAgent.Spec.Agent.Pod.Volumes, v.instanaAgent.Spec.Agent.Pod.VolumeMounts
 }
 
 func (v *volumeBuilder) getBuilder(volume Volume) (*corev1.Volume, *corev1.VolumeMount) {


### PR DESCRIPTION
Mounting the same secret multiple times is valid in Kubernetes, we should not panic here. Example:

```
  spec:
    agent:
      pod:
        volumeMounts:
        - mountPath: /opt/instana/agent/etc/application.jks
          name: jks-mount
          subPath: application.jks
        - mountPath: /custom-secrets
          name: jks-mount
        volumes:
        - name: jks-mount
          secret:
            secretName: keystore-secret-name
```
