### PR TITLE
[INSTA-24606] Change deployment and rbac naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ setup: ## Basic project setup, e.g. installing GitHook for checking license head
 	cd .git/hooks && ln -fs ../../.githooks/* .
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=instana-agent-clusterrole webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
@@ -103,7 +103,7 @@ test: gen-mocks manifests generate fmt vet lint envtest ## Run tests but ignore 
 
 .PHONY: e2e
 e2e:
-	go test -timeout=10m -count=1 -v github.com/instana/instana-agent-operator/e2e
+	go test -timeout=20m -count=1 -v github.com/instana/instana-agent-operator/e2e
 
 ##@ Build
 

--- a/bundle/manifests/manager-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/manager-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: instana-agent-clusterrole
 rules:
 - apiGroups:
   - agents.instana.io

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: instana-agent-controller-manager
   namespace: system
   labels:
     app.kubernetes.io/name: instana-agent-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: instana-agent-clusterrole
 rules:
 - nonResourceURLs:
   - /healthz

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: instana-agent-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: instana-agent-clusterrole
 subjects:
 - kind: ServiceAccount
   name: instana-agent-operator

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -75,7 +75,7 @@ func EnsureAgentNamespaceDeletion() env.Func {
 		}
 
 		// full purge of resources if anything would be left in the cluster
-		p = utils.RunCommand("kubectl delete crd/agents.instana.io clusterrole/instana-agent-k8sensor clusterrole/manager-role clusterrole/leader-election-role clusterrolebinding/leader-election-rolebinding clusterrolebinding/manager-rolebinding")
+		p = utils.RunCommand("kubectl delete crd/agents.instana.io clusterrole/instana-agent-k8sensor clusterrole/instana-agent-clusterrole clusterrole/leader-election-role clusterrolebinding/leader-election-rolebinding clusterrolebinding/instana-agent-clusterrolebinding")
 		if p.Err() != nil {
 			log.Warningf("Could not remove some artifacts, ignoring as they might not be present %s - %s - %s - %d", p.Command(), p.Err(), p.Out(), p.ExitCode())
 		}
@@ -317,7 +317,7 @@ func SetupOperatorDevBuild() e2etypes.StepFunc {
 
 func DeployAgentCr(agent *v1.InstanaAgent) e2etypes.StepFunc {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		// Wait for controller-manager deployment to ensure that CRD is installed correctly before proceeding.
+		// Wait for instana-agent-controller-manager deployment to ensure that CRD is installed correctly before proceeding.
 		// Technically, it could be categorized as "Assess" method, but the setup process requires to wait in between.
 		// Therefore, keeping the wait logic in this section.
 		client, err := cfg.NewClient()
@@ -400,8 +400,8 @@ func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 		connectionSuccessful := false
 		var buf *bytes.Buffer
 		for i := 0; i < 9; i++ {
-			t.Log("Sleeping 10 seconds")
-			time.Sleep(10 * time.Second)
+			t.Log("Sleeping 20 seconds")
+			time.Sleep(20 * time.Second)
 			t.Log("Fetching logs")
 			logReq := clientSet.CoreV1().Pods(cfg.Namespace()).GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{})
 			podLogs, err := logReq.Stream(ctx)

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -389,6 +389,25 @@ func WaitForAgentDaemonSetToBecomeReady(args ...string) e2etypes.StepFunc {
 	}
 }
 
+func EnsureOldControllerManagerDeploymentIsNotRunning() e2etypes.StepFunc {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Ensuring the old deployment %s is not running", InstanaOperatorOldDeploymentName)
+		client, err := cfg.NewClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		dep := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: InstanaOperatorOldDeploymentName, Namespace: cfg.Namespace()},
+		}
+		err = wait.For(conditions.New(client.Resources()).ResourceDeleted(&dep), wait.WithTimeout(time.Minute*5))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("Deployment %s is deleted", AgentDaemonSetName)
+		return ctx
+	}
+}
+
 func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		t.Log("Searching for successful backend connection in agent logs")

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -405,45 +405,45 @@ func EnsureOldControllerManagerDeploymentIsNotRunning() e2etypes.StepFunc {
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("Deployment %s is deleted", AgentDaemonSetName)
+		t.Logf("Deployment %s is deleted", InstanaOperatorOldDeploymentName)
 		return ctx
 	}
 }
 
 func EnsureOldClusterRoleIsGone() e2etypes.StepFunc {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		t.Logf("Ensuring the old clusterrole %s is not running", InstanaOperatorClusterRoleName)
+		t.Logf("Ensuring the old clusterrole %s is not running", InstanaOperatorOldClusterRoleName)
 		client, err := cfg.NewClient()
 		if err != nil {
 			t.Fatal(err)
 		}
 		clusterrole := rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: InstanaOperatorClusterRoleName},
+			ObjectMeta: metav1.ObjectMeta{Name: InstanaOperatorOldClusterRoleName},
 		}
 		err = wait.For(conditions.New(client.Resources()).ResourceDeleted(&clusterrole), wait.WithTimeout(time.Minute*2))
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("ClusteRole %s is deleted", InstanaOperatorClusterRoleName)
+		t.Logf("ClusteRole %s is deleted", InstanaOperatorOldClusterRoleName)
 		return ctx
 	}
 }
 
 func EnsureOldClusterRoleBindingIsGone() e2etypes.StepFunc {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		t.Logf("Ensuring the old clusterrolebinding %s is not running", InstanaOperatorClusterRoleBindingName)
+		t.Logf("Ensuring the old clusterrolebinding %s is not running", InstanaOperatorOldClusterRoleBindingName)
 		client, err := cfg.NewClient()
 		if err != nil {
 			t.Fatal(err)
 		}
 		clusterrolebinding := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: InstanaOperatorClusterRoleBindingName},
+			ObjectMeta: metav1.ObjectMeta{Name: InstanaOperatorOldClusterRoleBindingName},
 		}
 		err = wait.For(conditions.New(client.Resources()).ResourceDeleted(&clusterrolebinding), wait.WithTimeout(time.Minute*2))
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("ClusteRoleBinding %s is deleted", InstanaOperatorClusterRoleBindingName)
+		t.Logf("ClusteRoleBinding %s is deleted", InstanaOperatorOldClusterRoleBindingName)
 		return ctx
 	}
 }

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -40,6 +40,8 @@ var InstanaTestCfg InstanaTestConfig
 
 const InstanaNamespace string = "instana-agent"
 const InstanaOperatorOldDeploymentName string = "controller-manager"
+const InstanaOperatorClusterRoleName string = "instana-agent-clusterrole"
+const InstanaOperatorClusterRoleBindingName string = "instana-agent-clusterrolebinding"
 const InstanaOperatorDeploymentName string = "instana-agent-controller-manager"
 const AgentDaemonSetName string = "instana-agent"
 const AgentCustomResourceName string = "instana-agent"

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -40,8 +40,8 @@ var InstanaTestCfg InstanaTestConfig
 
 const InstanaNamespace string = "instana-agent"
 const InstanaOperatorOldDeploymentName string = "controller-manager"
-const InstanaOperatorClusterRoleName string = "instana-agent-clusterrole"
-const InstanaOperatorClusterRoleBindingName string = "instana-agent-clusterrolebinding"
+const InstanaOperatorOldClusterRoleName string = "manager-role"
+const InstanaOperatorOldClusterRoleBindingName string = "manager-rolebinding"
 const InstanaOperatorDeploymentName string = "instana-agent-controller-manager"
 const AgentDaemonSetName string = "instana-agent"
 const AgentCustomResourceName string = "instana-agent"

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -39,7 +39,8 @@ type OperatorImage struct {
 var InstanaTestCfg InstanaTestConfig
 
 const InstanaNamespace string = "instana-agent"
-const InstanaOperatorDeploymentName string = "controller-manager"
+const InstanaOperatorOldDeploymentName string = "controller-manager"
+const InstanaOperatorDeploymentName string = "instana-agent-controller-manager"
 const AgentDaemonSetName string = "instana-agent"
 const AgentCustomResourceName string = "instana-agent"
 const K8sensorDeploymentName string = "instana-agent-k8sensor"

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -1,6 +1,6 @@
 /*
- * (c) Copyright IBM Corp. 2024
- * (c) Copyright Instana Inc. 2024
+ * (c) Copyright IBM Corp. 2025
+ * (c) Copyright Instana Inc. 2025
  */
 
 package e2e
@@ -16,35 +16,21 @@ import (
 	"sigs.k8s.io/e2e-framework/support/utils"
 )
 
-func TestInitialInstall(t *testing.T) {
+func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
 	agent := NewAgentCr(t)
-	initialInstallFeature := features.New("initial install dev-operator-build").
-		Setup(SetupOperatorDevBuild()).
-		Setup(DeployAgentCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
-		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
-		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
-		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).
-		Feature()
-
-	// test feature
-	testEnv.Test(t, initialInstallFeature)
-}
-func TestUpdateInstall(t *testing.T) {
-	agent := NewAgentCr(t)
-	installLatestFeature := features.New("deploy latest released instana-agent-operator").
+	installLatestFeature := features.New("deploy instana-agent-operator with the generic resource names (controller-manager, manager-role and manager-rolebinding)").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			const latestOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/latest/download/instana-agent-operator.yaml"
-			t.Logf("Installing latest available operator from %s", latestOperatorYamlUrl)
+			const latestOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/download/v2.1.14/instana-agent-operator.yaml"
+			t.Logf("Installing latest operator with the old, generic resource names from %s", latestOperatorYamlUrl)
 			p := utils.RunCommand(
 				fmt.Sprintf("kubectl apply -f %s", latestOperatorYamlUrl),
 			)
 			if p.Err() != nil {
-				t.Fatal("Error while applying latest operator yaml", p.Command(), p.Err(), p.Out(), p.ExitCode())
+				t.Fatal("Error while applying the old operator yaml", p.Command(), p.Err(), p.Out(), p.ExitCode())
 			}
 			return ctx
 		}).
-		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorOldDeploymentName)). //TODO: revert after the 2.1.15 release
+		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorOldDeploymentName)).
 		Setup(DeployAgentCr(&agent)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -20,10 +20,10 @@ func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
 	agent := NewAgentCr(t)
 	installLatestFeature := features.New("deploy instana-agent-operator with the generic resource names (controller-manager, manager-role and manager-rolebinding)").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			const latestOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/download/v2.1.14/instana-agent-operator.yaml"
-			t.Logf("Installing latest operator with the old, generic resource names from %s", latestOperatorYamlUrl)
+			const oldResourceNamesOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/download/v2.1.14/instana-agent-operator.yaml"
+			t.Logf("Installing latest operator with the old, generic resource names from %s", oldResourceNamesOperatorYamlUrl)
 			p := utils.RunCommand(
-				fmt.Sprintf("kubectl apply -f %s", latestOperatorYamlUrl),
+				fmt.Sprintf("kubectl apply -f %s", oldResourceNamesOperatorYamlUrl),
 			)
 			if p.Err() != nil {
 				t.Fatal("Error while applying the old operator yaml", p.Command(), p.Err(), p.Out(), p.ExitCode())

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -71,6 +71,7 @@ func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
 			t.Log("Assessing reconciliation now")
 			return ctx
 		}).
+		Assess("confirm the old deployment is gone", EnsureOldControllerManagerDeploymentIsNotRunning()).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady("instana-agent-k8sensor")).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -72,6 +72,8 @@ func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
 			return ctx
 		}).
 		Assess("confirm the old deployment is gone", EnsureOldControllerManagerDeploymentIsNotRunning()).
+		Assess("confirm the old clusterrole is gone", EnsureOldClusterRoleIsGone()).
+		Assess("confirm the old clusterrolebinding is gone", EnsureOldClusterRoleBindingIsGone()).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady("instana-agent-k8sensor")).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -52,6 +52,7 @@ type InstanaAgentClient interface {
 	GetAsResult(ctx context.Context, key k8sClient.ObjectKey, obj k8sClient.Object, opts ...k8sClient.GetOption) result.Result[k8sClient.Object]
 	Status() k8sClient.SubResourceWriter
 	Patch(ctx context.Context, obj k8sClient.Object, patch k8sClient.Patch, opts ...k8sClient.PatchOption) error
+	Delete(ctx context.Context, obj k8sClient.Object, opts ...k8sClient.DeleteOption) error
 }
 
 type instanaAgentClient struct {
@@ -117,6 +118,14 @@ func (c *instanaAgentClient) Apply(
 			append(opts, k8sClient.ForceOwnership, k8sClient.FieldOwner(FieldOwnerName))...,
 		),
 	)
+}
+
+func (c *instanaAgentClient) Delete(
+	ctx context.Context,
+	obj k8sClient.Object,
+	opts ...k8sClient.DeleteOption,
+) error {
+	return c.k8sClient.Delete(ctx, obj, opts...)
 }
 
 func (c *instanaAgentClient) GetAsResult(


### PR DESCRIPTION
* our operator is named `controller-manager`, and RBAC `manager-role` and `manager-rolebinding` which can conflict with other operators running in the cluster
* use instana-specific resource names
* add logic for cleaning up the old resource on the upgrades
   * use the same `LeaderElectionID`
   * delete the old deployment if it matches the name and it has the label  `"app.kubernetes.io/name: instana-agent-operator"`
   * delete the old manager-role if it matches the name and one of the APIGroups are `instana.io` since we did not set the label on this resource
   * delete the old manager-rolebinding if it matches the name and the ServiceAccount