### PR TITLE
fix: Adjust logic when to render configuration-opentelemetry.yaml

### DIFF
--- a/pkg/k8s/object/builders/agent/secrets/config.go
+++ b/pkg/k8s/object/builders/agent/secrets/config.go
@@ -87,7 +87,7 @@ func (c *configBuilder) data() (map[string][]byte, error) {
 	if c.Spec.Agent.ConfigurationYaml != "" {
 		data["configuration.yaml"] = []byte(c.Spec.Agent.ConfigurationYaml)
 	}
-	if otlp := c.Spec.OpenTelemetry; otlp.IsEnabled() {
+	if otlp := c.Spec.OpenTelemetry; !otlp.GrpcIsEnabled() || !otlp.HttpIsEnabled() {
 		mrshl, _ := yaml.Marshal(map[string]instanav1.OpenTelemetry{"com.instana.plugin.opentelemetry": otlp})
 		data["configuration-opentelemetry.yaml"] = mrshl
 	}

--- a/pkg/k8s/object/builders/agent/secrets/config_test.go
+++ b/pkg/k8s/object/builders/agent/secrets/config_test.go
@@ -395,3 +395,333 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 		)
 	}
 }
+
+func TestAgentSecretConfigBuildForOtel(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		agent    instanav1.InstanaAgent
+		expected map[string][]byte
+	}{
+		{
+			name: "otel undefined -> no config (defaults)",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":       []byte("test-cluster"),
+				"configuration.yaml": []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "http enabled and grpc enabled -> no config (defaults)",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						GRPC: &instanav1.Enabled{
+							Enabled: pointer.To(true),
+						},
+						HTTP: &instanav1.Enabled{
+							Enabled: pointer.To(true),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":       []byte("test-cluster"),
+				"configuration.yaml": []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "http disabled and grpc disabled -> config both explicitly off",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						GRPC: &instanav1.Enabled{
+							Enabled: pointer.To(false),
+						},
+						HTTP: &instanav1.Enabled{
+							Enabled: pointer.To(false),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":                                 []byte("test-cluster"),
+				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc:\n        enabled: false\n    http:\n        enabled: false\n"),
+				"configuration.yaml":                           []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "http undefined and grpc enabled -> no config (defaults)",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						GRPC: &instanav1.Enabled{
+							Enabled: pointer.To(true),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":       []byte("test-cluster"),
+				"configuration.yaml": []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "http undefined and grpc disabled -> http config omitted (defaults) and grpc disabled",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						GRPC: &instanav1.Enabled{
+							Enabled: pointer.To(false),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":                                 []byte("test-cluster"),
+				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc:\n        enabled: false\n"),
+				"configuration.yaml":                           []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "http enabled and grpc undefined -> no config (defaults)",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						HTTP: &instanav1.Enabled{
+							Enabled: pointer.To(true),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":       []byte("test-cluster"),
+				"configuration.yaml": []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "http disabled and grpc undefined -> http config disabled and grpc omitted (defaults)",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						HTTP: &instanav1.Enabled{
+							Enabled: pointer.To(false),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":                                 []byte("test-cluster"),
+				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    http:\n        enabled: false\n"),
+				"configuration.yaml":                           []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "legacy on -> no config (defaults)",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						Enabled: instanav1.Enabled{
+							Enabled: pointer.To(true),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":       []byte("test-cluster"),
+				"configuration.yaml": []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+		{
+			name: "legacy off -> legacy off config",
+			agent: instanav1.InstanaAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instana-agent",
+					Namespace: "instana-agent",
+				},
+				Spec: instanav1.InstanaAgentSpec{
+					Cluster: instanav1.Name{
+						Name: "test-cluster",
+					},
+					Agent: instanav1.BaseAgentSpec{
+						EndpointHost:      "main-backend-host",
+						EndpointPort:      "main-backend-port",
+						Key:               "main-backend-key",
+						ConfigurationYaml: "configuration-yaml-value",
+					},
+					OpenTelemetry: instanav1.OpenTelemetry{
+						Enabled: instanav1.Enabled{
+							Enabled: pointer.To(false),
+						},
+					},
+				},
+			},
+			expected: map[string][]byte{
+				"cluster_name":                                 []byte("test-cluster"),
+				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    enabled: false\n"),
+				"configuration.yaml":                           []byte("configuration-yaml-value"),
+				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
+				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\n"),
+			},
+		},
+	} {
+		t.Run(
+			test.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+
+				statusManager := mocks.NewMockAgentStatusManager(ctrl)
+				statusManager.EXPECT().SetAgentSecretConfig(gomock.Any()).AnyTimes()
+
+				keysSecret := &corev1.Secret{}
+
+				builder := NewConfigBuilder(&test.agent, statusManager, keysSecret, []backend.K8SensorBackend{
+					{
+						ResourceSuffix: "",
+						EndpointHost:   "main-backend-host",
+						EndpointPort:   "main-backend-port",
+						EndpointKey:    "main-backend-key",
+					},
+				})
+
+				actual := builder.Build().Get()
+
+				expected := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "instana-agent-config",
+						Namespace: "instana-agent",
+					},
+					Type: corev1.SecretTypeOpaque,
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					Data: test.expected,
+				}
+
+				assert.Equal(t, expected, actual)
+			},
+		)
+	}
+}

--- a/pkg/k8s/object/builders/agent/secrets/config_test.go
+++ b/pkg/k8s/object/builders/agent/secrets/config_test.go
@@ -114,9 +114,8 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 			},
 			keysSecret: &corev1.Secret{},
 			expected: map[string][]byte{
-				"cluster_name":                                 []byte(objectMeta.Name),
-				"configuration.yaml":                           []byte("configuration-yaml-value"),
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
+				"cluster_name":       []byte(objectMeta.Name),
+				"configuration.yaml": []byte("configuration-yaml-value"),
 				"configuration-prometheus-remote-write.yaml":   []byte("com.instana.plugin.prometheus:\n    remote_write:\n        enabled: true\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
@@ -166,7 +165,6 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 			},
 			keysSecret: &corev1.Secret{},
 			expected: map[string][]byte{
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 				"com.instana.agent.main.sender.Backend-2.cfg":  []byte("host=additional-backend-2-host\nport=additional-backend-2-port\nprotocol=HTTP/2\nkey=additional-backend-2-key\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
 				"com.instana.agent.main.sender.Backend-3.cfg":  []byte("host=additional-backend-3-host\nport=additional-backend-3-port\nprotocol=HTTP/2\nkey=additional-backend-3-key\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
@@ -219,7 +217,6 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=main-backend-key\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
 				"com.instana.agent.main.sender.Backend-2.cfg":  []byte("host=additional-backend-2-host\nport=additional-backend-2-port\nprotocol=HTTP/2\nkey=additional-backend-2-key\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
@@ -239,7 +236,6 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 			},
 			keysSecret: &corev1.Secret{},
 			expected: map[string][]byte{
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
 				"configuration-prometheus-remote-write.yaml":   []byte("com.instana.plugin.prometheus:\n    remote_write:\n        enabled: true\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 			},
@@ -276,7 +272,6 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=key-from-secret\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
 			},
@@ -334,7 +329,6 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 				"com.instana.agent.main.sender.Backend-1.cfg":  []byte("host=main-backend-host\nport=main-backend-port\nprotocol=HTTP/2\nkey=key-from-secret\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
 				"com.instana.agent.main.sender.Backend-3.cfg":  []byte("host=additional-backend-3-host\nport=additional-backend-3-port\nprotocol=HTTP/2\nkey=additional-backend-3-key\nproxy.type=HTTP\nproxy.host=proxy-host-value\nproxy.port=proxy-port-value\nproxy.dns=true\nproxy.user=proxy-user-value\nproxy.password=proxy-password-value\n"),
@@ -374,7 +368,6 @@ func TestAgentSecretConfigBuild(t *testing.T) {
 				},
 			},
 			expected: map[string][]byte{
-				"configuration-opentelemetry.yaml":             []byte("com.instana.plugin.opentelemetry:\n    grpc: {}\n"),
 				"configuration-disable-kubernetes-sensor.yaml": []byte("com.instana.plugin.kubernetes:\n    enabled: false\n"),
 			},
 		},


### PR DESCRIPTION
When opentelemetry is disabled explicitly, the operator should create a config file to disable the feature on the agent.