### PR TITLE
Always pick up the latest changes for running e2e tests

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -64,8 +64,6 @@ resources:
     icon: github
     source:
       <<: *instana-operator-git-repo-config
-      paths:
-        - ci/**
 
   - name: agent-operator-git-source
     type: git


### PR DESCRIPTION
* we use resource pipeline-source for running the e2e tests, but we only fetch new code if the `ci/` changes which is problematic
* the code change ensures we always fetch the latest changes of the repository, not just changes coming from the `ci/`