### PR TITLE
Fix missing mocks package when `make run` on a fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build: gen-mocks setup generate fmt vet ## Build manager binary.
 	go build -o bin/manager *.go
 
 run: export DEBUG_MODE=true
-run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config (run the "install" target to install CRDs into the cluster)
+run: gen-mocks generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config (run the "install" target to install CRDs into the cluster)
 	go run ./
 
 docker-build: test container-build ## Build docker image with the manager.


### PR DESCRIPTION
Fixes the following type of error:
````
sh-5.2$ make run
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
/home/ferenc/github.com/instana/instana-agent-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
pkg/k8s/client/client_test.go:35:2: no required module provides package github.com/instana/instana-agent-operator/mocks; to add it:
        go get github.com/instana/instana-agent-operator/mocks
````