### PR TITLE
chore(deps): Upgrade golang to v1.24.0, add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Why
+
+<!--
+Please describe why you are proposing this code change.
+This should include at least a single text paragraph.
+When possible formulate this from the perspective of the product team.
+-->
+
+## What
+
+<!--
+Please explain what you did. For small/trivial changes a single paragraph is probably sufficient.
+For any larger changes this should include design choices.
+-->
+
+## References
+
+<!-- Please include links to other artifacts related to this code change. -->
+
+- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
+- [Documentation](http://example.com)
+- [CSP](http://example.com)
+- [Documentation PR](http://example.com)
+
+## Checklist
+
+<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->
+
+- [ ] Backwards compatible?
+- [ ] [Release notes](https://github.ibm.com/instana/docs/pull/13181/files) in public docs updated?
+- [ ] e2e test coverage added or updated?
+
+
+Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Build the manager binary, always build on amd64 platform
-FROM --platform=linux/amd64 golang:1.23 AS builder
+FROM --platform=linux/amd64 golang:1.24 AS builder
 
 ARG TARGETPLATFORM='linux/amd64'
 ARG VERSION=dev

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ ifneq ($(shell test -f $(GOLANGCI_LINT) && echo -n yes),yes)
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 endif
 golangci-lint: ## Download the golangci-lint linter locally if necessary.
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4)
 
 OPERATOR_SDK = $(shell command -v operator-sdk 2>/dev/null || echo "operator-sdk")
 # Test if operator-sdk is available on the system, otherwise download locally

--- a/ci/images/e2e-base-image/Dockerfile
+++ b/ci/images/e2e-base-image/Dockerfile
@@ -27,11 +27,11 @@ RUN dnf update -y && dnf install -y \
 
 # Set environment variables for Go
 ENV GOPATH=/go
-ENV GO_VERSION=1.23.2
+ENV GO_VERSION=1.24.0
 ENV PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
 
 # Install go
-RUN GO_SHA256="542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e go${GO_VERSION}.linux-amd64.tar.gz"  \
+RUN GO_SHA256="dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858 go${GO_VERSION}.linux-amd64.tar.gz"  \
     && curl -L --fail --show-error --silent "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "go${GO_VERSION}.linux-amd64.tar.gz" \
     && echo "${GO_SHA256}" | sha256sum --check \
     && rm -rf /usr/local/go \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/instana/instana-agent-operator
 // use full version x.y.z
 // see https://github.com/instana/instana-agent-operator/pull/218
 // and https://github.com/golang/go/issues/62278#issuecomment-1693538776
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
## Why

New golang was released. I noticed, that this repository did not have any template for creating PRs.

## What

Updated golang to v1.24.0 and added a PR template file.

## References

- [Go changelog](https://tip.golang.org/doc/go1.24)

## Checklist

- [x] Backwards compatible?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
