### PR TITLE
feat: Scale down controller-mananger to 1 replica

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: instana-agent-operator
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -294,6 +294,7 @@ func SetupOperatorDevBuild() e2etypes.StepFunc {
 		r.WithNamespace(cfg.Namespace())
 		agent := &appsv1.Deployment{}
 		err = r.Get(ctx, InstanaOperatorDeploymentName, cfg.Namespace(), agent)
+		replicas := agent.Spec.Replicas
 		if err != nil {
 			t.Fatal("Failed to get deployment-manager deployment", err)
 		}
@@ -307,7 +308,7 @@ func SetupOperatorDevBuild() e2etypes.StepFunc {
 
 		err = r.Patch(ctx, agent, k8s.Patch{
 			PatchType: types.MergePatchType,
-			Data:      []byte(`{"spec":{ "replicas": 2 }}`),
+			Data:      []byte(fmt.Sprintf(`{"spec":{ "replicas": %d }}`, *replicas)),
 		})
 		if err != nil {
 			t.Fatal("Failed to patch deployment to include pull secret and 0 replicas", err)

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -37,7 +37,7 @@ func TestInitialInstall(t *testing.T) {
 
 			expectedReplicas := new(int32)
 			*expectedReplicas = 1
-			if agent.Spec.Replicas != expectedReplicas {
+			if *agent.Spec.Replicas != *expectedReplicas {
 				t.Fatal("Unexpected number of replicas", *agent.Spec.Replicas, *expectedReplicas)
 			}
 			return ctx

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -38,7 +38,7 @@ func TestInitialInstall(t *testing.T) {
 			expectedReplicas := new(int32)
 			*expectedReplicas = 1
 			if agent.Spec.Replicas != expectedReplicas {
-				t.Fatal("Unexpected number of replicas", agent.Spec.Replicas, expectedReplicas)
+				t.Fatal("Unexpected number of replicas", *agent.Spec.Replicas, *expectedReplicas)
 			}
 			return ctx
 		}).

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/support/utils"
@@ -22,6 +23,25 @@ func TestInitialInstall(t *testing.T) {
 		Setup(SetupOperatorDevBuild()).
 		Setup(DeployAgentCr(&agent)).
 		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		Assess("check for single instance of instana-agent-controller-manager", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				t.Fatal("Cleanup: Error initializing client", err)
+			}
+			r.WithNamespace(cfg.Namespace())
+			agent := &appsv1.Deployment{}
+			err = r.Get(ctx, InstanaOperatorDeploymentName, cfg.Namespace(), agent)
+			if err != nil {
+				t.Fatal("Cleanup: Error fetching the operator deployment", err)
+			}
+
+			expectedReplicas := new(int32)
+			*expectedReplicas = 1
+			if agent.Spec.Replicas != expectedReplicas {
+				t.Fatal("Unexpected number of replicas", agent.Spec.Replicas, expectedReplicas)
+			}
+			return ctx
+		}).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).


### PR DESCRIPTION
## Why

We want to reduce the footprint of the existing operator deployment and there is no reason to keep multiple instances running any more.

## What

The controller-manager deployment was using 2 instances, but there is actually no need for multiple instances any more, as a failing pod would be restarted and would pick-up differences in the next reconciliation loop.

## References

[Slack discussion](https://instana.slack.com/archives/CHBMGV1FE/p1739782330389249)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/pull/13181/files) in public docs updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
