### PR TITLE
fix: Handle missing proxy credentials correctly for k8sensor

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,8 @@ For any larger changes this should include design choices.
 <!-- Please tick of these checklist items if applicable (or remove if not applicable). -->
 
 - [ ] Backwards compatible?
-- [ ] [Release notes](https://github.ibm.com/instana/docs/pull/13181/files) in public docs updated?
-- [ ] e2e test coverage added or updated?
+- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
+- [ ] unit/e2e test coverage added or updated?
 
 
 Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.

--- a/pkg/k8s/object/builders/common/env/env_builder.go
+++ b/pkg/k8s/object/builders/common/env/env_builder.go
@@ -207,10 +207,23 @@ func (e *envBuilder) httpsProxyEnv() *corev1.EnvVar {
 		return nil
 	}
 
+	if e.agent.Spec.Agent.ProxyUser == "" || e.agent.Spec.Agent.ProxyPassword == "" {
+		return &corev1.EnvVar{
+			Name: "HTTPS_PROXY",
+			Value: fmt.Sprintf(
+				"%s://%s:%s",
+				optional.Of(e.agent.Spec.Agent.ProxyProtocol).GetOrDefault("http"),
+				e.agent.Spec.Agent.ProxyHost,
+				optional.Of(e.agent.Spec.Agent.ProxyPort).GetOrDefault("80"),
+			),
+		}
+	}
+
 	return &corev1.EnvVar{
 		Name: "HTTPS_PROXY",
 		Value: fmt.Sprintf(
-			"http://%s%s:%s",
+			"%s://%s%s:%s",
+			optional.Of(e.agent.Spec.Agent.ProxyProtocol).GetOrDefault("http"),
 			e.agent.Spec.Agent.ProxyUser+":"+e.agent.Spec.Agent.ProxyPassword+"@",
 			e.agent.Spec.Agent.ProxyHost,
 			optional.Of(e.agent.Spec.Agent.ProxyPort).GetOrDefault("80"),

--- a/pkg/k8s/object/builders/common/env/env_builder_test.go
+++ b/pkg/k8s/object/builders/common/env/env_builder_test.go
@@ -133,7 +133,7 @@ func TestEnvBuilderBuild(t *testing.T) {
 				{Name: "INSTANA_AGENT_HTTP_LISTEN", Value: "INSTANA_AGENT_HTTP_LISTEN"},
 				{Name: "INSTANA_KUBERNETES_REDACT_SECRETS", Value: "INSTANA_KUBERNETES_REDACT_SECRETS"},
 				{Name: "AGENT_ZONE", Value: "INSTANA_AGENT_SPEC_CLUSTER_NAME"},
-				{Name: "HTTPS_PROXY", Value: "http://INSTANA_AGENT_PROXY_USER:INSTANA_AGENT_PROXY_PASSWORD@INSTANA_AGENT_PROXY_HOST:80"},
+				{Name: "HTTPS_PROXY", Value: "INSTANA_AGENT_PROXY_PROTOCOL://INSTANA_AGENT_PROXY_USER:INSTANA_AGENT_PROXY_PASSWORD@INSTANA_AGENT_PROXY_HOST:80"},
 				{Name: "BACKEND_URL", Value: "https://$(BACKEND)"},
 				{Name: "NO_PROXY", Value: "kubernetes.default.svc"},
 				{Name: "CONFIG_PATH", Value: "/opt/instana/agent/etc/instana-config-yml"},

--- a/pkg/k8s/object/builders/common/env/env_builder_test.go
+++ b/pkg/k8s/object/builders/common/env/env_builder_test.go
@@ -181,6 +181,45 @@ func TestEnvBuilderBuild(t *testing.T) {
 			},
 			expected: []corev1.EnvVar{},
 		},
+		{
+			name: "Should allow http proxy without credentials, but different port",
+			zone: &instanav1.Zone{},
+			agent: &instanav1.InstanaAgent{
+				Spec: instanav1.InstanaAgentSpec{
+					Agent: instanav1.BaseAgentSpec{
+						ProxyHost: "INSTANA_AGENT_PROXY_HOST",
+						ProxyPort: "8080",
+					},
+				},
+			},
+			envVars: []EnvVar{
+				HTTPSProxyEnv,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "HTTPS_PROXY", Value: "http://INSTANA_AGENT_PROXY_HOST:8080"},
+			},
+		},
+		{
+			name: "Should allow http proxy with credentials, and different protocol",
+			zone: &instanav1.Zone{},
+			agent: &instanav1.InstanaAgent{
+				Spec: instanav1.InstanaAgentSpec{
+					Agent: instanav1.BaseAgentSpec{
+						ProxyHost:     "INSTANA_AGENT_PROXY_HOST",
+						ProxyPort:     "443",
+						ProxyUser:     "testuser",
+						ProxyPassword: "testpassword",
+						ProxyProtocol: "https",
+					},
+				},
+			},
+			envVars: []EnvVar{
+				HTTPSProxyEnv,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "HTTPS_PROXY", Value: "https://testuser:testpassword@INSTANA_AGENT_PROXY_HOST:443"},
+			},
+		},
 	} {
 		t.Run(
 			test.name, func(t *testing.T) {


### PR DESCRIPTION
## Why

In case no credentials were defined, the HTTP proxy settings were rendered broken for the k8sensor. This change fixes this behavior and adds more unit tests.

## What

Add an additional check if credentials are present, remove them if not instead of render empty strings and keep the auth format.
Additionally, other the protocol setting should be translated into the env variable

## References

<!-- Please include links to other artifacts related to this code change. -->

- INSTA-28191
- TS018624533

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/pull/13181/files) in public docs updated?
- [x] unit test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
