### PR TITLE
INSTA-32046: Add nodes/proxy role, without it kubelet requests fail o…

### DIFF
--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -161,7 +161,7 @@ func (r *InstanaAgentReconciler) reconcile(
 // adding role property required to manage instana-agent-k8sensor ClusterRole
 // +kubebuilder:rbac:urls=/version;/healthz;/metrics;/metrics/cadvisor;/stats/summary,verbs=get
 // +kubebuilder:rbac:groups=extensions,resources=deployments;replicasets;ingresses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=configmaps;events;services;endpoints;namespaces;nodes;pods;pods/log;replicationcontrollers;resourcequotas;persistentvolumes;persistentvolumeclaims;nodes/metrics;nodes/stats,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=configmaps;events;services;endpoints;namespaces;nodes;pods;pods/log;replicationcontrollers;resourcequotas;persistentvolumes;persistentvolumeclaims;nodes/metrics;nodes/stats;nodes/proxy,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;replicasets;statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch

--- a/pkg/k8s/object/builders/agent/rbac/clusterrole.go
+++ b/pkg/k8s/object/builders/agent/rbac/clusterrole.go
@@ -72,6 +72,7 @@ func (c *clusterRoleBuilder) Build() optional.Optional[client.Object] {
 						"nodes",
 						"nodes/stats",
 						"nodes/metrics",
+						"nodes/proxy",
 						"pods",
 					},
 					Verbs: constants.ReaderVerbs(),

--- a/pkg/k8s/object/builders/agent/rbac/clusterrole_test.go
+++ b/pkg/k8s/object/builders/agent/rbac/clusterrole_test.go
@@ -75,6 +75,7 @@ func TestClusterRoleBuilder_Build(t *testing.T) {
 						"nodes",
 						"nodes/stats",
 						"nodes/metrics",
+						"nodes/proxy",
 						"pods",
 					},
 					Verbs: constants.ReaderVerbs(),

--- a/pkg/k8s/object/builders/k8s-sensor/rbac/clusterrole.go
+++ b/pkg/k8s/object/builders/k8s-sensor/rbac/clusterrole.go
@@ -75,6 +75,7 @@ func (c *clusterRoleBuilder) Build() optional.Optional[client.Object] {
 						"nodes",
 						"nodes/metrics",
 						"nodes/stats",
+						"nodes/proxy",
 						"pods",
 						"pods/log",
 						"replicationcontrollers",

--- a/pkg/k8s/object/builders/k8s-sensor/rbac/clusterrole_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/rbac/clusterrole_test.go
@@ -79,6 +79,7 @@ func TestClusterRoleBuilder_Build(t *testing.T) {
 						"nodes",
 						"nodes/metrics",
 						"nodes/stats",
+						"nodes/proxy",
 						"pods",
 						"pods/log",
 						"replicationcontrollers",


### PR DESCRIPTION

## Why
Currently some of our customers using OC clusters are unable to get kubelet information. 

## What

<!--
Please explain what you did. For small/trivial changes a single paragraph is probably sufficient.
For any larger changes this should include design choices.
-->
Add `nodes/proxy` to clusterroles

## References

<!-- Please include links to other artifacts related to this code change. -->

- [INSTA-32046](https://jsw.ibm.com/browse/INSTA-32046)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [x] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
