### PR TITLE
chore: Do not pin go patch level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,6 @@
 module github.com/instana/instana-agent-operator
 
-// use full version x.y.z
-// see https://github.com/instana/instana-agent-operator/pull/218
-// and https://github.com/golang/go/issues/62278#issuecomment-1693538776
-go 1.24.0
+go 1.24
 
 require (
 	github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
## Why

When reading https://github.com/golang/go/issues/62278#issuecomment-1693538776 I noticed that this is only recommended for development versions which are not released yet. This is no longer valid, by default the recommendation is to not use the patch level. If you need to pin to a explicit version, toolchain should be used since 1.21 instead, like `toolchain go1.24.3`. Setting just `go 1.24` will avoid failures if developers do not install the latest patch level yet, but allow the build to pick the most recent patch level.

Go 1.24.3 should be picked up that way on rebuild

## What

Remove patch level from go.mod

## References

- https://github.com/golang/go/issues/62278#issuecomment-1693538776 

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] ~unit/e2e test coverage added or updated?~ n/a


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
