### PR TITLE
chore: Add image-pre-pulling to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ pre-pull-images: ## Pre-pulls images on the target cluster (useful in slow netwo
 		echo "env variable INSTANA_API_KEY is undefined but should contain the agent download key"; \
 		exit 1; \
 	fi
-	kubectl create namespace $(NAMESPACE_PREPULLER) || true
+	kubectl apply -f ci/scripts/instana-agent-image-prepuller-ns.yaml || true
 	@echo "Creating Docker registry secret..."
 	@echo "Checking if secret containers-instana-io-pull-secret exists in namespace $(NAMESPACE_PREPULLER)..."
 	@if kubectl get secret containers-instana-io-pull-secret -n $(NAMESPACE_PREPULLER) >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -329,11 +329,11 @@ pre-pull-images: ## Pre-pulls images on the target cluster (useful in slow netwo
 	fi
 	@kubectl apply -f ci/scripts/instana-agent-image-prepuller.yaml -n $(NAMESPACE_PREPULLER)
 	@echo "Waiting for the instana-agent-prepuller daemonset"
-	@kubectl rollout status ds/instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER) --timeout=900s
+	@kubectl rollout status ds/instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER) --timeout=1800s
 	@echo "Cleaning up instana-agent-prepuller namespace"
 	kubectl delete ds instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER)
-	kubectl delete pods -n $(NAMESPACE_PREPULLER) -l name=instana-agent-image-prepuller --force --grace-period=0
-	kubectl delete ns -n $(NAMESPACE_PREPULLER)
+	kubectl delete pods -n $(NAMESPACE_PREPULLER) -l name=instana-agent-image-prepuller --force --grace-period=0 || true
+	kubectl delete ns $(NAMESPACE_PREPULLER)
 
 .PHONY: dev-run-ocp
 dev-run-ocp: namespace install create-cr run ## Creates a full dev deployment on OCP from scratch, also useful after purge

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ else
 endif
 
 NAMESPACE ?= instana-agent
+NAMESPACE_PREPULLER ?= instana-agent-image-prepuller
 
 INSTANA_AGENT_CLUSTER_WIDE_RESOURCES := \
 	"crd/agents.instana.io" \
@@ -300,6 +301,36 @@ create-pull-secret: ## Creates image pull secret for delivery.instana.io from yo
 	@rm -rf .tmp
 	@echo "Restarting operator deployment..."
 	@kubectl delete pods -l app.kubernetes.io/name=instana-agent-operator -n $(NAMESPACE)
+
+.PHONY: pre-pull-images
+pre-pull-images: ## Pre-pulls images on the target cluster (useful in slow network situations to run tests reliably)
+	@if [ "$(INSTANA_API_KEY)" == "" ]; then \
+		echo "env variable INSTANA_API_KEY is undefined but should contain the agent download key"; \
+		exit 1; \
+	fi
+	oc new-project $(NAMESPACE_PREPULLER) || true
+	@echo "Creating Docker registry secret..."
+	@echo "Checking if secret containers-instana-io-pull-secret exists in namespace $(NAMESPACE_PREPULLER)..."
+	@if kubectl get secret containers-instana-io-pull-secret -n $(NAMESPACE_PREPULLER) >/dev/null 2>&1; then \
+		echo "Updating existing secret containers-instana-io-pull-secret..."; \
+		kubectl delete secret containers-instana-io-pull-secret -n $(NAMESPACE_PREPULLER); \
+	fi
+	@kubectl create secret docker-registry containers-instana-io-pull-secret \
+		--docker-server=containers.instana.io \
+		--docker-username="_" \
+		--docker-password=$${INSTANA_API_KEY} \
+		-n $(NAMESPACE_PREPULLER)
+	@echo "Start instana-agent-image-prepuller daemonset..."
+	@echo "Checking if daemonset instana-agent-image-prepuller exists in namespace $(NAMESPACE_PREPULLER)..."
+	@if kubectl get ds instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER) >/dev/null 2>&1; then \
+		echo "Updating existing secret containers-instana-io-pull-secret..."; \
+		kubectl delete ds instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER); \
+		kubectl delete pods -n instana-agent-image-prepuller -l name=instana-agent-image-prepuller --force --grace-period=0; \
+	fi
+	@kubectl apply -f ci/scripts/instana-agent-image-prepuller.yaml -n $(NAMESPACE_PREPULLER)
+	@echo "Waiting for the instana-agent-prepuller daemonset"
+	@kubectl rollout status ds/instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER) --timeout=900s
+# if pods should be deleted without waiting for the pull to stop: kubectl delete pods -n instana-agent-image-prepuller -l name=instana-agent-image-prepuller --force --grace-period=0 && kubectl delete ns instana-agent-image-prepuller
 
 .PHONY: dev-run-ocp
 dev-run-ocp: namespace install create-cr run ## Creates a full dev deployment on OCP from scratch, also useful after purge

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ pre-pull-images: ## Pre-pulls images on the target cluster (useful in slow netwo
 		echo "env variable INSTANA_API_KEY is undefined but should contain the agent download key"; \
 		exit 1; \
 	fi
-	oc new-project $(NAMESPACE_PREPULLER) || true
+	kubectl create namespace $(NAMESPACE_PREPULLER) || true
 	@echo "Creating Docker registry secret..."
 	@echo "Checking if secret containers-instana-io-pull-secret exists in namespace $(NAMESPACE_PREPULLER)..."
 	@if kubectl get secret containers-instana-io-pull-secret -n $(NAMESPACE_PREPULLER) >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -325,12 +325,15 @@ pre-pull-images: ## Pre-pulls images on the target cluster (useful in slow netwo
 	@if kubectl get ds instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER) >/dev/null 2>&1; then \
 		echo "Updating existing secret containers-instana-io-pull-secret..."; \
 		kubectl delete ds instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER); \
-		kubectl delete pods -n instana-agent-image-prepuller -l name=instana-agent-image-prepuller --force --grace-period=0; \
+		kubectl delete pods -n $(NAMESPACE_PREPULLER) -l name=instana-agent-image-prepuller --force --grace-period=0; \
 	fi
 	@kubectl apply -f ci/scripts/instana-agent-image-prepuller.yaml -n $(NAMESPACE_PREPULLER)
 	@echo "Waiting for the instana-agent-prepuller daemonset"
 	@kubectl rollout status ds/instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER) --timeout=900s
-# if pods should be deleted without waiting for the pull to stop: kubectl delete pods -n instana-agent-image-prepuller -l name=instana-agent-image-prepuller --force --grace-period=0 && kubectl delete ns instana-agent-image-prepuller
+	@echo "Cleaning up instana-agent-prepuller namespace"
+	kubectl delete ds instana-agent-image-prepuller -n $(NAMESPACE_PREPULLER)
+	kubectl delete pods -n $(NAMESPACE_PREPULLER) -l name=instana-agent-image-prepuller --force --grace-period=0
+	kubectl delete ns -n $(NAMESPACE_PREPULLER)
 
 .PHONY: dev-run-ocp
 dev-run-ocp: namespace install create-cr run ## Creates a full dev deployment on OCP from scratch, also useful after purge

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -543,6 +543,7 @@ jobs:
                   - |
                     cd pipeline-source
                     bash ./ci/scripts/cluster-authentication.sh
+                    make pre-pull-images
                     make e2e
             on_success:
               put: gh-status
@@ -652,6 +653,7 @@ jobs:
                   - |
                     cd pipeline-source
                     bash ./ci/scripts/cluster-authentication.sh
+                    make pre-pull-images
                     make e2e
             on_success:
               put: gh-status

--- a/ci/pr-pipeline.yml
+++ b/ci/pr-pipeline.yml
@@ -624,6 +624,7 @@ jobs:
                       - |
                         cd pipeline-source
                         bash ./ci/scripts/cluster-authentication.sh
+                        make pre-pull-images
                         make e2e
                 on_success:
                   put: gh-status
@@ -737,6 +738,7 @@ jobs:
                       - |
                         cd pipeline-source
                         bash ./ci/scripts/cluster-authentication.sh
+                        make pre-pull-images
                         make e2e
                 on_success:
                   put: gh-status

--- a/ci/scripts/instana-agent-image-prepuller-ns.yaml
+++ b/ci/scripts/instana-agent-image-prepuller-ns.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: instana-agent-image-prepuller
+  annotations:
+    openshift.io/sa.scc.uid-range: 1000/1000
+    openshift.io/sa.scc.supplemental-groups: 1000/1000

--- a/ci/scripts/instana-agent-image-prepuller.yaml
+++ b/ci/scripts/instana-agent-image-prepuller.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: instana-agent-image-prepuller
+spec:
+  selector:
+    matchLabels:
+      name: instana-agent-image-prepuller
+  template:
+    metadata:
+      labels:
+        name: instana-agent-image-prepuller
+    spec:
+      imagePullSecrets:
+      - name: containers-instana-io-pull-secret
+      containers:
+      - name: wait-container
+        image: icr.io/instana/instana-agent-operator:latest
+        command: ["/bin/sh", "-c", "echo 'All images pre-pulled successfully'; sleep 600"]
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      initContainers:
+      - name: pull-operator
+        image: icr.io/instana/instana-agent-operator:latest
+        command: ["/bin/sh", "-c", "echo 'Pulled operator image'"]
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: pull-dynamic-agent
+        image: icr.io/instana/agent:latest
+        command: ["/bin/sh", "-c", "echo 'Pulled dynamic agent image'"]
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: pull-k8sensor
+        image: icr.io/instana/k8sensor:latest
+        command: ["/ko-app/k8sensor", "--help"]
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: pull-static-agent
+        image: containers.instana.io/instana/release/agent/static:latest
+        command: ["/bin/sh", "-c", "echo 'Pulled static agent image'"]
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault

--- a/ci/scripts/instana-agent-image-prepuller.yaml
+++ b/ci/scripts/instana-agent-image-prepuller.yaml
@@ -22,6 +22,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          runAsUser: 1000
+          runAsGroup: 1000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -34,6 +36,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          runAsUser: 1000
+          runAsGroup: 1000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -45,6 +49,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          runAsUser: 1000
+          runAsGroup: 1000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -56,6 +62,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          runAsUser: 1000
+          runAsGroup: 1000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -67,6 +75,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          runAsUser: 1000
+          runAsGroup: 1000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault


### PR DESCRIPTION
## Why

Some clusters have slow network connection and it's hard to write reliable e2e tests if image pulling can take a few seconds to multiple minutes.

## What

`make pre-pull-images` will deploy a new daemonset to pull down images.

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
