### PR TITLE
Undo temp e2e change

### DIFF
--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -456,9 +456,6 @@ func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// there is a reconcile restart happening with latest -> dev upgrade
-		// due to the env var ordering. The sleep allows for new pods to start up before fetching the pod list
-		t.Log("Sleep for 20 seconds to allow for old pods to be terminated")
 		time.Sleep(20 * time.Second)
 		podList, err := clientSet.CoreV1().Pods(cfg.Namespace()).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=instana-agent"})
 		if err != nil {


### PR DESCRIPTION
## Why

- reverts change from pervious release needed for e2e to pass due to change in env vars ordering

## What

- remove the wait before fetching agent pdos

## Checklist

- [x] Backwards compatible?
- [ ] ~[Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?~
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
