### PR TITLE
specify preflight version

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -926,6 +926,8 @@ jobs:
           inputs: [ pipeline-source ]
           params: { state: error, context: multiarch-operator-manifest-promotion/build-multiarch-manifest }
       - get: preflight
+        version:
+          tag: 1.12.1
         params:
           globs:
             - preflight-linux-amd64


### PR DESCRIPTION
## Why

Currently pipeline fails with 
```
"Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.13.0' is not supported. Supported versions are: ['1.12.0', '1.12.1'
```

## What

Concourse fetches the latest version that is not supported yet.


## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] ~[Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?~
- [ ] ~unit/e2e test coverage added or updated?~


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
