### PR TITLE
chore: Setup ocp mirror script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,10 @@ pre-pull-images: ## Pre-pulls images on the target cluster (useful in slow netwo
 	kubectl delete pods -n $(NAMESPACE_PREPULLER) -l name=instana-agent-image-prepuller --force --grace-period=0 || true
 	kubectl delete ns $(NAMESPACE_PREPULLER)
 
+.PHONY: setup-ocp-mirror
+setup-ocp-mirror: ## Setup ocp internal registry and define ImageContentSourcePolicy to pull from internal registry
+	./ci/scripts/setup-ocp-mirror.sh
+
 .PHONY: dev-run-ocp
 dev-run-ocp: namespace install create-cr run ## Creates a full dev deployment on OCP from scratch, also useful after purge
 

--- a/ci/scripts/setup-ocp-mirror.sh
+++ b/ci/scripts/setup-ocp-mirror.sh
@@ -69,8 +69,8 @@ spec:
     - ${HOST}/instana/k8sensor
     source: icr.io/instana/k8sensor
   - mirrors:
-    - $HOST/instana/instana-agent-operator
-    source: delivery.instana.io/dev-sandbox-docker-all/konrad/instana-agent-operator
+    - ${HOST}/instana/instana-agent-operator
+    source: ${OPERATOR_IMAGE_NAME}
 EOF
 
 

--- a/ci/scripts/setup-ocp-mirror.sh
+++ b/ci/scripts/setup-ocp-mirror.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+#
+# (c) Copyright IBM Corp. 2024
+# (c) Copyright Instana Inc.
+#
+
+echo "Setting up ocp mirror and ImageContentSourcePolicy to pull from internal registry"
+oc patch configs.imageregistry.operator.openshift.io/cluster --type merge -p '{"spec":{"defaultRoute":true}}'
+HOST=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+echo "Current registry host: ${HOST}"
+
+echo "Creating project instana"
+oc get project instana || oc new-project instana
+# oc extract secret/$(oc get ingresscontroller -n openshift-ingress-operator default -o json | jq '.spec.defaultCertificate.name // "router-certs-default"' -r) -n openshift-ingress --confirm
+skopeo login -u kubeadmin -p "$(oc whoami -t)" "${HOST}" --tls-verify=false
+set -x
+skopeo copy docker://icr.io/instana/instana-agent-operator:latest "docker://${HOST}/instana/instana-agent-operator:latest" --dest-tls-verify=false
+skopeo copy docker://containers.instana.io/instana/release/agent/static:latest "docker://${HOST}/instana/instana-agent-static:latest" --dest-tls-verify=false
+skopeo copy docker://icr.io/instana/agent:latest "docker://${HOST}/instana/agent:latest" --dest-tls-verify=false
+skopeo copy docker://icr.io/instana/k8sensor:latest "docker://${HOST}/instana/k8sensor:latest" --dest-tls-verify=false
+set +x
+
+# cat <<EOF > image-content-source-policy.yaml
+# apiVersion: operator.openshift.io/v1alpha1
+# kind: ImageContentSourcePolicy
+# metadata:
+#   name: registry-mirror
+# spec:
+#   repositoryDigestMirrors:
+#   - mirrors:
+#     - ${HOST}/instana/instana-agent-operator
+#     source: icr.io/instana/instana-agent-operator
+#     pullFromMirror: "all"
+#   - mirrors:
+#     - ${HOST}/instana/agent
+#     source: icr.io/instana/agent
+#     pullFromMirror: "all"
+#   - mirrors:
+#     - ${HOST}/instana/instana-agent-static
+#     source: containers.instana.io/instana/release/agent/static
+#     pullFromMirror: "all"
+#   - mirrors:
+#     - ${HOST}/instana/k8sensor
+#     source: icr.io/instana/k8sensor
+#     pullFromMirror: "all"
+# EOF
+
+# only available since OCP v4.13
+cat <<EOF > image-tag-mirror-set.yaml
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: instana-image-tag-mirror-set
+spec:
+  imageTagMirrors:
+  - mirrors:
+    - ${HOST}/instana/instana-agent-operator
+    source: icr.io/instana/instana-agent-operator
+  - mirrors:
+    - ${HOST}/instana/agent
+    source: icr.io/instana/agent
+  - mirrors:
+    - ${HOST}/instana/instana-agent-static
+    source: containers.instana.io/instana/release/agent/static
+  - mirrors:
+    - ${HOST}/instana/k8sensor
+    source: icr.io/instana/k8sensor
+EOF
+
+
+#oc apply -f image-content-source-policy.yaml
+# rm -f image-content-source-policy.yaml
+oc apply -f image-tag-mirror-set.yaml
+rm -f image-tag-mirror-set.yaml
+
+oc policy add-role-to-group system:image-puller system:serviceaccounts:instana-agent -n instana


### PR DESCRIPTION
## Why

If network connection is slow or even no public internet connection is available, the ocp internal registry can be leveraged to store images. Using an ImageTagMirrorSet let the cluster pull from the internal registry without changing the image names.

## What
Leverages OCP ImageTagMirrorSet and cluster internal registry to speed up pulls of large images. Purely an internal change for easy setup of test environments, there are no customer facing changes involved.


## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
