### PR TITLE
fix: Adjust permissions of operator to control pdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,10 @@ setup-ocp-mirror: ## Setup ocp internal registry and define ImageContentSourcePo
 .PHONY: dev-run-ocp
 dev-run-ocp: namespace install create-cr run ## Creates a full dev deployment on OCP from scratch, also useful after purge
 
+.PHONY: logs
+logs: ## Tail operator logs
+	kubectl logs -f deployment/instana-agent-controller-manager -n $(NAMESPACE)
+
 ##@ OLM
 
 # Generate bundle manifests and metadata, then validate generated files.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,6 +148,13 @@ rules:
   - watch
 - apiGroups:
   - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy
   resourceNames:
   - instana-agent-k8sensor
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,6 +148,16 @@ rules:
   - watch
 - apiGroups:
   - policy
+  resourceNames:
+  - instana-agent-k8sensor
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - patch
+- apiGroups:
+  - policy
   resources:
   - podsecuritypolicies
   verbs:

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,6 +84,7 @@ func Add(mgr manager.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
+		Owns(&v1.PodDisruptionBudget{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		WithEventFilter(filterPredicate()).
@@ -203,6 +205,7 @@ func (r *InstanaAgentReconciler) reconcile(
 // +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=policy,resourceNames=instana-agent-k8sensor,resources=podsecuritypolicies,verbs=use
+// +kubebuilder:rbac:groups=policy,resourceNames=instana-agent-k8sensor,resources=poddisruptionbudgets,verbs=create;patch;delete
 
 func (r *InstanaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	res ctrl.Result,

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -206,6 +206,7 @@ func (r *InstanaAgentReconciler) reconcile(
 // +kubebuilder:rbac:groups=security.openshift.io,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=policy,resourceNames=instana-agent-k8sensor,resources=podsecuritypolicies,verbs=use
 // +kubebuilder:rbac:groups=policy,resourceNames=instana-agent-k8sensor,resources=poddisruptionbudgets,verbs=create;patch;delete
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=watch;list
 
 func (r *InstanaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	res ctrl.Result,

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestInitialInstall(t *testing.T) {
-	agent := NewAgentCr(t)
+	agent := NewAgentCr()
 	initialInstallFeature := features.New("initial install dev-operator-build").
 		Setup(SetupOperatorDevBuild()).
 		Setup(DeployAgentCr(&agent)).
@@ -51,7 +51,7 @@ func TestInitialInstall(t *testing.T) {
 	testEnv.Test(t, initialInstallFeature)
 }
 func TestUpdateInstall(t *testing.T) {
-	agent := NewAgentCr(t)
+	agent := NewAgentCr()
 	installLatestFeature := features.New("deploy latest released instana-agent-operator").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			const latestOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/latest/download/instana-agent-operator.yaml"

--- a/e2e/install_with_pdb_test.go
+++ b/e2e/install_with_pdb_test.go
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/helpers"
+	v1 "k8s.io/api/policy/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestInstallWithK8sensorPodDisruptionBudget(t *testing.T) {
+	agent := NewAgentCr(t)
+	enabled := true
+	agent.Spec.K8sSensor.PodDisruptionBudget.Enabled = &enabled
+	f := features.New("install dev-operator-build and enable k8sensor podDisruptionBudget").
+		Setup(SetupOperatorDevBuild()).
+		Setup(DeployAgentCr(&agent)).
+		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
+		Assess("check if instana-agent-controller-manager was able to deploy a podDisruptionBudget for the k8sensor", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				t.Fatal("Cleanup: Error initializing client", err)
+			}
+			r.WithNamespace(cfg.Namespace())
+			pdb := &v1.PodDisruptionBudget{}
+			h := helpers.NewHelpers(&agent)
+			err = r.Get(ctx, h.K8sSensorResourcesName(), cfg.Namespace(), pdb)
+			if err != nil {
+				t.Fatal("Error fetching the pod disruption budget", err)
+			}
+			if pdb.Spec.MinAvailable.IntValue() != 2 {
+				t.Fatal("The poddisruptionbudget found was not defining 2 MinAvailable instances", pdb.Spec.MinAvailable)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	// test feature
+	testEnv.Test(t, f)
+}

--- a/e2e/install_with_pdb_test.go
+++ b/e2e/install_with_pdb_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestInstallWithK8sensorPodDisruptionBudget(t *testing.T) {
-	agent := NewAgentCr(t)
+	agent := NewAgentCr()
 	enabled := true
 	agent.Spec.K8sSensor.PodDisruptionBudget.Enabled = &enabled
 	f := features.New("install dev-operator-build and enable k8sensor podDisruptionBudget").

--- a/e2e/multi_backend_test.go
+++ b/e2e/multi_backend_test.go
@@ -108,7 +108,7 @@ func TestMultiBackendSupportInlineSecret(t *testing.T) {
 }
 
 func TestRemovalOfAdditionalBackend(t *testing.T) {
-	agent := NewAgentCr(t)
+	agent := NewAgentCr()
 
 	agent.Spec.Agent.AdditionalBackends = append(agent.Spec.Agent.AdditionalBackends, instanav1.BackendSpec{
 		EndpointHost: "test1.instana.ibm.com",
@@ -158,7 +158,7 @@ func TestRemovalOfAdditionalBackend(t *testing.T) {
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Feature()
 
-	agent2 := NewAgentCr(t)
+	agent2 := NewAgentCr()
 	agent2.Spec.Agent.AdditionalBackends = []instanav1.BackendSpec{}
 	agent2.Spec.Agent.AdditionalBackends = append(agent2.Spec.Agent.AdditionalBackends, instanav1.BackendSpec{
 		EndpointHost: "test2.instana.ibm.com",

--- a/e2e/namespace_configmap_test.go
+++ b/e2e/namespace_configmap_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestNamespaceLabelConfigmap(t *testing.T) {
-	agent := NewAgentCr(t)
+	agent := NewAgentCr()
 	installAndCheckNamespaceLabels := features.New("check namespace configmap in agent pods").
 		Setup(SetupOperatorDevBuild()).
 		Setup(DeployAgentCr(&agent)).

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
-	agent := NewAgentCr(t)
+	agent := NewAgentCr()
 	installLatestFeature := features.New("deploy instana-agent-operator with the generic resource names (controller-manager, manager-role and manager-rolebinding)").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			const oldResourceNamesOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/download/v2.1.14/instana-agent-operator.yaml"


### PR DESCRIPTION
## Why

When the agent CR contains a podDisruptionBudget setting, the operator fails to reconcile due to missing permissions.
Additionally, the operator must own the resource in order to reconcile e.g. on manual deletions.

## What

Reproducible by defining this setting:

```yaml
...
spec:
  k8s_sensor:
    podDisruptionBudget:
      enabled: true
```

## References

- TS019400543

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
