### PR TITLE
ci: Update go version to v1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:latest A
 ARG TARGETPLATFORM='linux/amd64'
 ARG VERSION=dev
 ARG GIT_COMMIT=unspecified
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.4
 WORKDIR /workspace
 ENV PATH="/usr/local/go/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 COPY installGolang.sh installGolang.sh

--- a/ci/images/e2e-base-image/Dockerfile
+++ b/ci/images/e2e-base-image/Dockerfile
@@ -27,11 +27,11 @@ RUN dnf update -y && dnf install -y \
 
 # Set environment variables for Go
 ENV GOPATH=/go
-ENV GO_VERSION=1.24.3
+ENV GO_VERSION=1.24.4
 ENV PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
 
 # Install go
-RUN GO_SHA256="3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8 go${GO_VERSION}.linux-amd64.tar.gz"  \
+RUN GO_SHA256="77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717 go${GO_VERSION}.linux-amd64.tar.gz"  \
     && curl -L --fail --show-error --silent "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o "go${GO_VERSION}.linux-amd64.tar.gz" \
     && echo "${GO_SHA256}" | sha256sum --check \
     && rm -rf /usr/local/go \


### PR DESCRIPTION
## Why

New stdlib available

## What

Upgraded to go v1.24.4

## References

[INSTA-36513](https://jsw.ibm.com/browse/INSTA-36513)
[INSTA-41675](https://jsw.ibm.com/browse/INSTA-41675)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [x] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] ~unit/e2e test coverage added or updated?~ n/a


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
