### PR TITLE
k8sensor/deployment: fix usage of enabled value

### DIFF
--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -219,7 +219,7 @@ func (d *deploymentBuilder) Build() (res optional.Optional[client.Object]) {
 		)
 	}()
 
-	switch (d.Spec.Agent.Key == "" && d.Spec.Agent.KeysSecret == "") || (d.Spec.Zone.Name == "" && d.Spec.Cluster.Name == "") {
+	switch (d.Spec.Agent.Key == "" && d.Spec.Agent.KeysSecret == "") || (d.Spec.Zone.Name == "" && d.Spec.Cluster.Name == "") || !pointer.DerefOrEmpty(d.Spec.K8sSensor.DeploymentSpec.Enabled.Enabled) {
 	case true:
 		return optional.Empty[client.Object]()
 	default:


### PR DESCRIPTION
## Why

The k8s_sensor.deployment.enabled wasn't working as expected since it wasn't used at all to stop the building of the deployment.

## What

Use the `Enabled` flag for deciding whether to build or not the k8sensor deployment.

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
