### PR TITLE
Add nix flake for reproducible dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ backend.cfg
 
 e2e/.env
 .tmp
+
+# direnv
+.direnv

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Prerequisites:
 * Something like [Docker](https://www.docker.com/) or [Podman](https://podman.io/)
 * Instana Agent key
 
+There's also the possibility of using the nix flake which provides a devShell with the right version of go, gopls and gotools as well as the operator-sdk.
+
+In order to use it you will need to install:
+* [nix](https://nixos.org/)
+* [direnv](https://direnv.net/)
+
+Afterwards you only need to run once:
+```
+direnv allow
+```
+
+In order to tell direnv to allow the flake to be activated anytime you're inside the repository.
+
 Developing (and running) the Operator is easiest in two ways:
 
 ### **Option 1:** Running Go Operator locally against a **Minikube** cluster

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
-  description = "A nix-flake-based Go development environment";
+  description =
+    "A nix-flake-based Go/Kubernetes Controller development environment using operator-sdk";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
@@ -42,6 +43,9 @@
 
             # goimports, godoc, etc.
             gotools
+
+            # SDK for building Kubernetes applications
+            operator-sdk
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "A nix-flake-based Go development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      regex = "go[[:space:]]+([0-9]+\\.[0-9]+)(\\.[0-9]+)?";
+      # Read and get all the lines of the go.mod files and filter the empty []
+      lines = builtins.filter (line: line != [ ])
+        (builtins.split "\n" (builtins.readFile ./go.mod));
+      # Get the line that has the `go xx.xx.xx` or `go xx.xx`
+      matchingLines =
+        builtins.filter (line: builtins.match regex line != null) lines;
+      # Get the version string i.e: "1.23"
+      versionString = builtins.elemAt
+        (builtins.match regex (builtins.concatStringsSep " " matchingLines)) 0;
+      # Get the string as "1_23"
+      versionForOverlay = builtins.replaceStrings [ "." ] [ "_" ] versionString;
+
+      supportedSystems =
+        [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f:
+        nixpkgs.lib.genAttrs supportedSystems (system:
+          f {
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            };
+          });
+    in {
+      overlays.default = final: prev: { go = final."go_${versionForOverlay}"; };
+
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # go (version is specified by overlay)
+            go
+
+            # gopls (go language server)
+            gopls
+
+            # goimports, godoc, etc.
+            gotools
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Why

Helps providing a reproducible go development environment in MacOS and Linux, removing some friction with newcomers and easing collaboration.

## What

Added a nix flake that uses the version of go specified in the `go.mod` file so anytime there's an update to the go.mod version then the go version used for development is automatically updated.

In addition make use of direnv to automatically switch to use the devShell from the flake whenever one is inside one of the repository directories.

Added gopls (language server), go-tools (go-imports, godoc, etc..) and operator-sdk to the devShell.

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
