### PR TITLE
ci: Increase e2e timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test: gen-mocks manifests generate fmt vet lint envtest ## Run tests but ignore 
 
 .PHONY: e2e
 e2e: ## Run end-to-end tests
-	go test -timeout=30m -count=1 -failfast -v github.com/instana/instana-agent-operator/e2e
+	go test -timeout=45m -count=1 -failfast -v github.com/instana/instana-agent-operator/e2e
 
 ##@ Build
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Example:
         "OPERATOR_IMAGE_TAG": "xxx"
     },
     "wca.enable": false,
-    "go.testTimeout": "600s",
+    "go.testTimeout": "900s",
     "go.testFlags": ["-v"]
 }
 ```

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -495,7 +495,7 @@ jobs:
         - do:
           - put: metadata
           - task: reslock-claim-gke-lowest
-            timeout: 60m
+            timeout: 75m
             config:
               platform: linux
               image_resource:
@@ -511,7 +511,7 @@ jobs:
               run:
                 path: pipeline-source/ci/scripts/reslock.sh
           - task: run-e2e-test-gke-lowest
-            timeout: 40m
+            timeout: 55m
             attempts: 1
             config: &gke-e2e-test-config
               platform: linux
@@ -609,7 +609,7 @@ jobs:
         - do:
           - put: metadata
           - task: reslock-claim-gke-latest
-            timeout: 60m
+            timeout: 75m
             config:
               platform: linux
               image_resource:
@@ -625,7 +625,7 @@ jobs:
               run:
                 path: pipeline-source/ci/scripts/reslock.sh
           - task: run-e2e-test-gke-latest
-            timeout: 40m
+            timeout: 55m
             attempts: 1
             config:
               <<: *gke-e2e-test-config
@@ -723,7 +723,7 @@ jobs:
         #     params:
         #       claim: openshift-4.11
         #   - task: run-e2e-test-openshift-4.11
-        #     timeout: 40m
+        #     timeout: 55m
         #     attempts: 1
         #     config:
         #       <<: *gke-e2e-test-config

--- a/ci/pr-pipeline.yml
+++ b/ci/pr-pipeline.yml
@@ -578,7 +578,7 @@ jobs:
           - do:
               - put: metadata
               - task: reslock-claim-gke-lowest
-                timeout: 60m
+                timeout: 75m
                 config:
                   platform: linux
                   image_resource:
@@ -594,7 +594,7 @@ jobs:
                   run:
                     path: pipeline-source/ci/scripts/reslock.sh
               - task: run-e2e-test-gke-lowest
-                timeout: 40m
+                timeout: 55m
                 attempts: 1
                 config: &gke-e2e-test-config
                   platform: linux
@@ -696,7 +696,7 @@ jobs:
           - do:
               - put: metadata
               - task: reslock-claim-gke-latest
-                timeout: 60m
+                timeout: 75m
                 config:
                   platform: linux
                   image_resource:
@@ -712,7 +712,7 @@ jobs:
                   run:
                     path: pipeline-source/ci/scripts/reslock.sh
               - task: run-e2e-test-gke-latest
-                timeout: 40m
+                timeout: 55m
                 attempts: 1
                 config:
                   <<: *gke-e2e-test-config


### PR DESCRIPTION
## Why

Growing number of tests lead to timeouts in e2e tests in CI from time to time.

## What

Increased timeouts

## References


## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
