### PR TITLE
ci: Add missing reslock timeout bump

### DIFF
--- a/ci/scripts/reslock.sh
+++ b/ci/scripts/reslock.sh
@@ -30,7 +30,7 @@ echo "RESLOCK_LOCK_OWNER=${RESLOCK_LOCK_OWNER}"
 
 curl -s "https://${RESLOCK_GITHUB_TOKEN}@raw.github.ibm.com/instana/reslock/main/run.sh" > run.sh
 if [ "${RESLOCK_COMMAND}" == "claim" ]; then
-    bash run.sh claim k8s-clusters "${RESLOCK_RESOURCE_NAME}" -t 30m -w
+    bash run.sh claim k8s-clusters "${RESLOCK_RESOURCE_NAME}" -t 45m -w
 else
     bash run.sh "${RESLOCK_COMMAND}" k8s-clusters "${RESLOCK_RESOURCE_NAME}"
 fi


### PR DESCRIPTION
## Why

Forgot to increase the reslock timeout in https://github.com/instana/instana-agent-operator/pull/283

## What

Reslock ensures that we don't use shared resources at the same time between pipelines.

## References


## Checklist

- [x] Backwards compatible?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
