### PR TITLE
Remote Agent: Update liveness probe logic to prevent restart loop

### DIFF
--- a/pkg/k8s/object/builders/remote-agent/deployment/deployment.go
+++ b/pkg/k8s/object/builders/remote-agent/deployment/deployment.go
@@ -23,7 +23,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
@@ -33,7 +32,6 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/env"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/helpers"
-	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/ports"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/volume"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/transformations"
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
@@ -265,10 +263,10 @@ func (d *deploymentBuilder) build() *appsv1.Deployment {
 							Env:             d.getEnvVars(),
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Host: "127.0.0.1",
-										Path: "/status",
-										Port: intstr.FromInt32(ports.InstanaAgentAPIPortConfig.Port),
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"sh", "-c", "curl -f http://127.0.0.1:42699/status || exit 1",
+										},
 									},
 								},
 								InitialDelaySeconds: 600,


### PR DESCRIPTION
## Why

<!--

-->
When the existing remote agent is created without an instana agent, the liveness probe fails as 127.0.0.1:42699 is unreachable. 

## What

<!--

-->
As the remote agent does not need to expose ports for use, the liveness probe now execs a command inside the container to check status of the remote agent

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-47551)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
