### PR TITLE
Add 'agent.dependencyURLs' array and download listed URLs via initContainer to the agent's deployment folder

### DIFF
--- a/api/v1/inline_types.go
+++ b/api/v1/inline_types.go
@@ -164,6 +164,9 @@ type BaseAgentSpec struct {
 	// Sets the INSTANA_MVN_REPOSITORY_SHARED_PATH environment variable
 	// +kubebuilder:validation:Optional
 	MvnRepoSharedPath string `json:"instanaMvnRepoSharedPath,omitempty"`
+	// URLs to dependency files that will be fetched via an init container and shared with the agent pod
+	// +kubebuilder:validation:Optional
+	DependencyURLs []string `json:"dependencyURLs,omitempty"`
 	// Sets the AGENT_RELEASE_REPOSITORY_MIRROR_URL environment variable
 	// +kubebuilder:validation:Optional
 	MirrorReleaseRepoUrl string `json:"agentReleaseRepoMirrorUrl,omitempty"`

--- a/config/samples/instana_v1_instanaagent_with_dependency_urls.yaml
+++ b/config/samples/instana_v1_instanaagent_with_dependency_urls.yaml
@@ -1,0 +1,29 @@
+apiVersion: instana.io/v1
+kind: InstanaAgent
+metadata:
+  name: instana-agent
+  namespace: instana-agent
+spec:
+  zone:
+    name: edited-zone # (optional) name of the zone of the host
+  cluster:
+    name: my-cluster
+  agent:
+    key: replace-key # replace with your Instana agent key
+    endpointHost: ingress-red-saas.instana.io
+    endpointPort: "443"
+    # URLs to dependency files that will be fetched via an init container and shared with the agent pod
+    dependencyURLs:
+      - "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar"
+      - "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar"
+    env: {}
+    configuration_yaml: |
+      # You can leave this empty, or use this to configure your instana agent.
+      # See https://github.com/instana/instana-agent-operator/blob/main/config/samples/instana_v1_extended_instanaagent.yaml for the extended version.
+  opentelemetry:
+    grpc:
+      enabled: true
+    http:
+      enabled: true
+
+# Made with Bob

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,4 +2,5 @@
 resources:
 - instana_v1beta1_instanaagent.yaml
 - instana_v1_instanaagent.yaml
+- instana_v1_instanaagent_with_dependency_urls.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/dependency-urls.md
+++ b/docs/dependency-urls.md
@@ -1,0 +1,47 @@
+# DependencyURLs Feature
+
+The Instana Agent Operator now supports downloading external dependency files via an init container and sharing them with the agent pod. This is useful for scenarios where you need to provide additional runtime dependencies to the agent, such as JDBC drivers or other libraries.
+
+## How it works
+
+When the `dependencyURLs` property is defined in the agent specification, the operator will:
+
+1. Create an init container that downloads the files from the specified URLs
+2. Store the files in a shared volume (`instanadeploy`)
+3. Mount this volume to the agent container at `/opt/instana/agent/deploy`
+
+This allows you to provide external dependencies to the agent without having to build a custom agent image.
+
+## Usage
+
+To use this feature, add the `dependencyURLs` property to your InstanaAgent custom resource:
+
+```yaml
+apiVersion: instana.io/v1
+kind: InstanaAgent
+metadata:
+  name: instana-agent
+  namespace: instana-agent
+spec:
+  # ... other configuration ...
+  agent:
+    key: your-agent-key
+    endpointHost: ingress-red-saas.instana.io
+    endpointPort: "443"
+    dependencyURLs:
+      - "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar"
+      - "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar"
+    # ... other agent configuration ...
+```
+
+## Example
+
+A complete example is available in the samples directory: `config/samples/instana_v1_instanaagent_with_dependency_urls.yaml`
+
+## Notes
+
+- The files will be downloaded to `/opt/instana/agent/deploy/` in the agent container
+- The original filenames from the URLs will be preserved
+- You can specify multiple dependency URLs, and all files will be downloaded to the same directory
+- Make sure the URLs are accessible from the Kubernetes cluster where the agent is running
+- For security reasons, consider using HTTPS URLs and trusted sources

--- a/pkg/k8s/object/builders/agent/daemonset/dependency_urls_test.go
+++ b/pkg/k8s/object/builders/agent/daemonset/dependency_urls_test.go
@@ -1,0 +1,122 @@
+/*
+(c) Copyright IBM Corp. 2024, 2025
+*/
+
+package daemonset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
+	"github.com/instana/instana-agent-operator/pkg/pointer"
+)
+
+func TestDaemonSetBuilder_InitContainers_WithDependencyURLs(t *testing.T) {
+	// Create agent with dependencyURLs
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+				DependencyURLs: []string{
+					"https://example.com/test-file1.jar",
+					"https://example.com/test-file2.jar",
+				},
+			},
+			Cluster: instanav1.Name{
+				Name: "test-cluster",
+			},
+		},
+	}
+
+	// Create builder
+	builder := NewDaemonSetBuilder(agent, false, status.NewAgentStatusManager())
+
+	// Build the DaemonSet
+	result := builder.Build()
+	require.True(t, result.IsPresent())
+
+	// Get the DaemonSet
+	ds := result.Get().(*appsv1.DaemonSet).Spec.Template.Spec
+
+	// Verify init containers
+	assert.Equal(t, 1, len(ds.InitContainers))
+	assert.Equal(t, "init-dependency-downloader", ds.InitContainers[0].Name)
+	assert.Contains(t, ds.InitContainers[0].Command[2], "https://example.com/test-file1.jar")
+	assert.Contains(t, ds.InitContainers[0].Command[2], "https://example.com/test-file2.jar")
+
+	// Verify volume mounts
+	foundVolume := false
+	for _, volume := range ds.Volumes {
+		if volume.Name == "instanadeploy" {
+			foundVolume = true
+			assert.NotNil(t, volume.EmptyDir)
+			break
+		}
+	}
+	assert.True(t, foundVolume, "instanadeploy volume not found")
+
+	// Verify agent container has the volume mount
+	foundVolumeMount := false
+	for _, volumeMount := range ds.Containers[0].VolumeMounts {
+		if volumeMount.Name == "instanadeploy" {
+			foundVolumeMount = true
+			assert.Equal(t, "/opt/instana/agent/deploy", volumeMount.MountPath)
+			break
+		}
+	}
+	assert.True(t, foundVolumeMount, "instanadeploy volume mount not found in agent container")
+}
+
+func TestDaemonSetBuilder_InitContainers_WithoutDependencyURLs(t *testing.T) {
+	// Create agent without dependencyURLs
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Cluster: instanav1.Name{
+				Name: "test-cluster",
+			},
+		},
+	}
+
+	// Create builder
+	builder := NewDaemonSetBuilder(agent, false, status.NewAgentStatusManager())
+
+	// Build the DaemonSet
+	result := builder.Build()
+	require.True(t, result.IsPresent())
+
+	// Get the DaemonSet
+	ds := result.Get().(*appsv1.DaemonSet).Spec.Template.Spec
+
+	// Verify no init containers
+	assert.Equal(t, 0, len(ds.InitContainers))
+
+	// Verify no instanadeploy volume
+	foundVolume := false
+	for _, volume := range ds.Volumes {
+		if volume.Name == "instanadeploy" {
+			foundVolume = true
+			break
+		}
+	}
+	assert.False(t, foundVolume, "instanadeploy volume should not be present")
+}
+
+// Made with Bob


### PR DESCRIPTION

hint: AI generated code

## Why

Instana agent might require external Java dependencies, which can not be served by IBM directly nor shipped with the agent installation. Those additional dependencies were previously downloaded via manual initContainer into the agent's container. The manual initContainer was part of the static agent YAML deployment. Since this is deprecated and about to be removed end of 2025, this PR introduces the replacement option for external Java dependencies.

## What

Provide a new array option "dependencyURLs" to list external jar files, which get downloaded into the Agent's `/opt/instana/agent/deploy` folder.

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Old Documentation (MySQL)](https://www.ibm.com/docs/en/instana-observability/1.0.301?topic=technologies-monitoring-mysql#mysql-version-800-and-later-support)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
