### PR TITLE
Feature golanci lint

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,19 +1,57 @@
 #!/bin/sh
 
-STATUS=0
+#
+# (c) Copyright IBM Corp. 2024, 2025
+#
 
-if git rev-parse --verify HEAD >/dev/null 2>&1; then
-    against=HEAD
-else
-    against=$(git hash-object -t tree /dev/null)
+set -e
+
+echo "Running pre-commit hook...\n"
+
+# Get list of staged .go files
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+
+# Path to golangci-lint binary
+LINTER="./bin/golangci-lint"
+
+# Check if the binary exists
+if [ ! -x "$LINTER" ]; then
+  echo "❌ Aborted: golangci-lint not found at $LINTER"
+  echo "Run: `make golangci-lint` add the linter before committing."
+  exit 1
 fi
 
-# Select all changed files, by name only, filter deleted files
-for f in $(git diff --relative --cached --name-only --diff-filter=d "$against" | grep '\.\(go\|sh\)$'); do
-  if ! head -n5 "${f}" | grep -q '(c) Copyright IBM Corp.'; then
-	echo "Missing copyright header in \"$f\""
-	STATUS=1
+# Run linter if there was files to lint
+echo "🔎 Linting/Formatting staged files..."
+if [ -n "$FILES" ]; then
+  echo "Running linter to fix any issues:"
+  $LINTER run --fix --new-from-rev=HEAD --timeout 5m
+  echo "Running linter to spot any unsolvable issues:"
+  if ! $LINTER run --new-from-rev=HEAD --timeout 5m; then
+    echo "❌ Abortred: Lint errors found"
+    exit 1
   fi
+fi
+
+# In case formatting has been enabled, add files back
+for FILE in $FILES; do
+  git add "$FILE"
 done
 
-exit $STATUS
+echo "✅ Linted successfully.\n"
+
+# Run copyright check on all staged files (not only .go files)
+ALL_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(go|sh|yml|yaml)$' || true)
+echo "🔎 Checking for copyright headers in staged files..."
+for FILE in $ALL_FILES; do
+  if ! head -n5 "$FILE" | grep -q '(c) Copyright IBM Corp.'; then
+	echo "❌ Aborted: Missing copyright in file: $FILE"
+	exit 1
+  fi
+done
+echo "✅ No missing copyrights.\n"
+
+
+
+echo "🎉 Pre-commit hook run successfully."
+exit 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,23 @@
-linters-settings:
-  misspell:
-    locale: US
+#
+# (c) Copyright IBM Corp. 2025
+#
 
-linters:
-  disable-all: true
+version: "2"
+formatters:
   enable:
+    - gofmt
     - goimports
-    - gosimple
+    - golines
+linters:
+  default: none
+  settings:
+    lll:
+      line-length: 120
+  enable:
     - govet
     - ineffassign
     - unused
     - misspell
     - exhaustive
     - errcheck
-
-service:
-  golangci-lint-version: 1.56.2 # use the fixed version to not introduce new linters unexpectedly
-
+    - lll

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-setup: ## Basic project setup, e.g. installing GitHook for checking license headers
-	cd .git/hooks && ln -fs ../../.githooks/* .
+setup: ## sets git hooks path to .githook
+	git config core.hooksPath .githooks
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=instana-agent-clusterrole webhook paths="./..." output:crd:artifacts:config=config/crd/bases
@@ -111,7 +111,7 @@ vet: ## Run go vet against code
 	go vet ./...
 
 lint: golangci-lint ## Run the golang-ci linter
-	$(GOLANGCI_LINT) run --timeout 5m
+	$(GOLANGCI_LINT) run --new-from-rev=HEAD --timeout 5m
 
 EXCLUDED_TEST_DIRS = mocks e2e
 EXCLUDE_PATTERN = $(shell echo $(EXCLUDED_TEST_DIRS) | sed 's/ /|/g')
@@ -353,7 +353,7 @@ envtest: ## Download envtest-setup locally if necessary.
 
 .PHONY: golanci-lint
 golangci-lint: ## Download the golangci-lint linter locally if necessary.
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
 .PHONY: operator-sdk
 operator-sdk: ## Download the Operator SDK binary locally if necessary.


### PR DESCRIPTION
Note: this is a piece of a larger pull-request that just had too many changes. To simplify the pull-request review, I'll be breaking down these steps to more comprehensive chunks.

## Why

Know a better approach to add git hooks to the project and the linter that the hook uses is outdated. 

## What

- Changed to use git cli to set the githooks.
- updated golanci-linter binary to v2
- updated formatting rules
- make lints as usual, but git hooks fixes linting issues and restages them on files the commit will touch.

## Checklist

- [x] Backwards compatible?
