### PR TITLE
e2e: Add selective monitoring test for namespace labels

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,7 +6,7 @@
 
 set -e
 
-echo "Running pre-commit hook...\n"
+echo "Running pre-commit hook..."
 
 # Get list of staged .go files
 FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
@@ -38,7 +38,7 @@ for FILE in $FILES; do
   git add "$FILE"
 done
 
-echo "✅ Linted successfully.\n"
+echo "✅ Linted successfully."
 
 # Run copyright check on all staged files (not only .go files)
 ALL_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(go|sh|yml|yaml)$' || true)
@@ -49,7 +49,7 @@ for FILE in $ALL_FILES; do
 	exit 1
   fi
 done
-echo "✅ No missing copyrights.\n"
+echo "✅ No missing copyrights."
 
 
 

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -48,6 +48,7 @@ const AgentDaemonSetName string = "instana-agent"
 const AgentCustomResourceName string = "instana-agent"
 const K8sensorDeploymentName string = "instana-agent-k8sensor"
 const InstanaAgentConfigSecretName string = "instana-agent-config"
+const InstanaAgentStaticImage string = "containers.instana.io/instana/release/agent/static"
 
 func init() {
 	var instanaApiKey, containerRegistryUser, containerRegistryPassword, containerRegistryHost, endpointHost, operatorImageName, operatorImageTag string

--- a/e2e/java-demo-app/Dockerfile
+++ b/e2e/java-demo-app/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS build
+RUN microdnf update -y \
+  && microdnf install -y java-21-openjdk-devel \
+  && microdnf clean all
+WORKDIR /app
+COPY HelloWorldServer.java /app/
+RUN javac HelloWorldServer.java
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf update -y \
+  && microdnf install -y java-21-openjdk-headless \
+  && microdnf clean all
+ENV USER_UID=1001
+USER ${USER_UID}:${USER_UID}
+WORKDIR /app
+COPY --from=build --chown=${USER_UID}:${USER_UID} /app/*.class /app/
+EXPOSE 8080
+
+CMD ["java", "HelloWorldServer"]

--- a/e2e/java-demo-app/HelloWorldServer.java
+++ b/e2e/java-demo-app/HelloWorldServer.java
@@ -1,0 +1,54 @@
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class HelloWorldServer {
+    public static void main(String[] args) throws IOException {
+        // Create an HTTP server that listens on port 8080
+        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+        
+        // Create a context for the root path
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                String response = "Hello World from Java Demo App!";
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes());
+                }
+            }
+        });
+        
+        // Create a context for health checks
+        server.createContext("/health", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                String response = "OK";
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes());
+                }
+            }
+        });
+        
+        // Start the server
+        server.start();
+        
+        System.out.println("Server started on port 8080");
+        
+        // Keep the application running
+        while (true) {
+            try {
+                Thread.sleep(60000);
+                System.out.println("Server is still running...");
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                break;
+            }
+        }
+    }
+}

--- a/e2e/java-demo-app/README.md
+++ b/e2e/java-demo-app/README.md
@@ -1,0 +1,33 @@
+# Java Demo App for Kubernetes
+
+This is a simple Java application that runs a web server for testing monitoring tools in Kubernetes.
+
+## Building the Docker Image
+
+To build the Docker image:
+
+```bash
+docker build -t delivery.instana.io/int-docker-agent-local/instana-agent-operator/e2e/java-demo-app:latest .
+```
+
+If you need to push to a registry:
+
+```bash
+docker push delivery.instana.io/int-docker-agent-local/instana-agent-operator/e2e/java-demo-app:latest
+```
+
+## Deploying to Kubernetes
+
+1. Ensure to be logged in into the delivery.instana.io registry with docker
+
+```
+export NAMESPACE=selective-monitoring-no-label
+./deploy.sh
+```
+
+2. Verify the deployment:
+
+```bash
+kubectl get pods -l app=java-demo-app
+```
+

--- a/e2e/java-demo-app/deploy.sh
+++ b/e2e/java-demo-app/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# (c) Copyright IBM Corp. 2025
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Error: NAMESPACE variable is not set"
+    echo "Please set the NAMESPACE variable before running this script"
+    echo "Example: NAMESPACE=your-namespace ./deploy.sh"
+    exit 1
+fi
+
+kubectl create ns "${NAMESPACE}"
+
+mkdir -p .tmp
+jq '{auths: {"delivery.instana.io": .auths["delivery.instana.io"]}}' ~/.docker/config.json > .tmp/filtered-docker-config.json
+echo "Checking if secret delivery-instana-io-pull-secret exists in namespace ${NAMESPACE}..."
+if kubectl get secret delivery-instana-io-pull-secret -n ${NAMESPACE} >/dev/null 2>&1; then
+    echo "Updating existing secret delivery-instana-io-pull-secret..."
+    kubectl delete secret delivery-instana-io-pull-secret -n ${NAMESPACE}
+else
+    echo "Creating secret delivery-instana-io-pull-secret..."
+fi
+
+kubectl create secret generic delivery-instana-io-pull-secret \
+    --from-file=.dockerconfigjson=.tmp/filtered-docker-config.json \
+    --type=kubernetes.io/dockerconfigjson \
+    -n ${NAMESPACE}
+
+rm -rf .tmp
+
+kubectl apply -f deployment.yaml
+
+echo ""
+echo "To check if pods are deployed correctly, run:"
+echo "kubectl get pods -l app=java-demo-app -n ${NAMESPACE}"

--- a/e2e/java-demo-app/deployment.yaml
+++ b/e2e/java-demo-app/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: java-demo-app
+  labels:
+    app: java-demo-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java-demo-app
+  template:
+    metadata:
+      labels:
+        app: java-demo-app
+    spec:
+      imagePullSecrets:
+        - name: delivery-instana-io-pull-secret
+      containers:
+      - name: java-demo-app
+        image: delivery.instana.io/int-docker-agent-local/instana-agent-operator/e2e/java-demo-app:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir:
+          medium: Memory

--- a/e2e/java-demo-app/deployment.yaml
+++ b/e2e/java-demo-app/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: java-demo-app
+        e2etest: seletctive-monitoring
     spec:
       imagePullSecrets:
         - name: delivery-instana-io-pull-secret

--- a/e2e/java-demo-app/deployment.yaml
+++ b/e2e/java-demo-app/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: java-demo-app
-        e2etest: seletctive-monitoring
+        e2etest: selective-monitoring
     spec:
       imagePullSecrets:
         - name: delivery-instana-io-pull-secret

--- a/e2e/java-demo-app/deployment.yaml
+++ b/e2e/java-demo-app/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         e2etest: selective-monitoring
     spec:
       imagePullSecrets:
-        - name: delivery-instana-io-pull-secret
+        - name: delivery-instana
       containers:
       - name: java-demo-app
         image: delivery.instana.io/int-docker-agent-local/instana-agent-operator/e2e/java-demo-app:latest

--- a/e2e/java-demo-app/deployment.yaml
+++ b/e2e/java-demo-app/deployment.yaml
@@ -1,3 +1,7 @@
+#
+# (c) Copyright IBM Corp. 2025
+#
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,6 +24,15 @@ spec:
       - name: java-demo-app
         image: delivery.instana.io/int-docker-agent-local/instana-agent-operator/e2e/java-demo-app:latest
         imagePullPolicy: IfNotPresent
+        env:
+        - name: INSTANA_TEST_NAMESPACE_TYPE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANA_TEST_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/e2e/selective_monitoring_test.go
+++ b/e2e/selective_monitoring_test.go
@@ -137,7 +137,7 @@ func DeployJavaDemoAppInNamespaces() features.Func {
 					wait.WithTimeout(time.Minute*2),
 				)
 				if err != nil {
-					t.Logf(
+					t.Fatalf(
 						"Error waiting for deployment %s in namespace %s: %v",
 						deploymentName,
 						namespace,

--- a/e2e/selective_monitoring_test.go
+++ b/e2e/selective_monitoring_test.go
@@ -280,7 +280,7 @@ func VerifySelectiveMonitoring() features.Func {
 			podList, err := clientSet.CoreV1().Pods(ns).List(
 				ctx,
 				metav1.ListOptions{
-					LabelSelector: "app=java-demo-app,e2etest=seletctive-monitoring",
+					LabelSelector: "app=java-demo-app,e2etest=selective-monitoring",
 				},
 			)
 			if err != nil {

--- a/e2e/selective_monitoring_test.go
+++ b/e2e/selective_monitoring_test.go
@@ -10,13 +10,17 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	v1 "github.com/instana/instana-agent-operator/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/support/utils"
@@ -38,6 +42,7 @@ func TestSelectiveMonitoring(t *testing.T) {
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("verify selective monitoring works correctly", VerifySelectiveMonitoring()).
+		Teardown(CleanupNamespaces()).
 		Feature()
 
 	// Run the test
@@ -64,17 +69,79 @@ func NewAgentCrWithSelectiveMonitoring() v1.InstanaAgent {
 // DeployJavaDemoAppInNamespaces deploys the Java demo app in three different namespaces with appropriate labels.
 func DeployJavaDemoAppInNamespaces() features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		// Deploy in namespace without label
-		deployJavaDemoApp(ctx, t, "selective-monitoring-no-label", false, "")
+		// Define the namespaces and their configurations
+		namespaces := []struct {
+			name     string
+			addLabel bool
+			value    string
+		}{
+			{"selective-monitoring-no-label", false, ""},
+			{"selective-monitoring-opt-out", true, "false"},
+			{"selective-monitoring-opt-in", true, "true"},
+		}
 
-		// Deploy in namespace with opt-out label
-		deployJavaDemoApp(ctx, t, "selective-monitoring-opt-out", true, "false")
+		// Use a wait group to deploy all apps concurrently
+		var wg sync.WaitGroup
+		for _, ns := range namespaces {
+			wg.Add(1)
+			go func(namespace string, addLabel bool, labelValue string) {
+				defer wg.Done()
+				deployJavaDemoApp(ctx, t, namespace, addLabel, labelValue)
+			}(ns.name, ns.addLabel, ns.value)
+		}
 
-		// Deploy in namespace with opt-in label
-		deployJavaDemoApp(ctx, t, "selective-monitoring-opt-in", true, "true")
+		// Wait for all deployments to be created
+		wg.Wait()
+		t.Log("All demo apps have been deployed, now waiting for them to become ready")
+
+		// Create a client to interact with the Kube API
+		client, err := cfg.NewClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Wait for all deployments to be ready concurrently
+		var waitWg sync.WaitGroup
+		for _, ns := range namespaces {
+			waitWg.Add(1)
+			go func(namespace string) {
+				defer waitWg.Done()
+				deploymentName := "java-demo-app"
+
+				t.Logf(
+					"Waiting for deployment %s in namespace %s to become ready",
+					deploymentName,
+					namespace,
+				)
+
+				// Create a deployment reference
+				dep := appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: deploymentName, Namespace: namespace},
+				}
+
+				// Wait for the deployment to be ready
+				err := wait.For(
+					conditions.New(client.Resources()).
+						DeploymentConditionMatch(&dep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
+					wait.WithTimeout(time.Minute*2),
+				)
+				if err != nil {
+					t.Logf(
+						"Error waiting for deployment %s in namespace %s: %v",
+						deploymentName,
+						namespace,
+						err,
+					)
+					return
+				}
+
+				t.Logf("Deployment %s in namespace %s is ready", deploymentName, namespace)
+			}(ns.name)
+		}
 
 		// Wait for all deployments to be ready
-		time.Sleep(30 * time.Second)
+		waitWg.Wait()
+		t.Log("All demo app deployments are ready")
 
 		return ctx
 	}
@@ -88,10 +155,20 @@ func deployJavaDemoApp(
 	addLabel bool,
 	labelValue string,
 ) {
-	// Create namespace
-	p := utils.RunCommand(fmt.Sprintf("kubectl create ns %s", namespace))
+	// Delete the namespace if it exists and wait for it to be fully deleted
+	t.Logf("Ensuring clean namespace %s...", namespace)
+	p := utils.RunCommand(
+		fmt.Sprintf("kubectl delete ns %s --ignore-not-found --wait --timeout=30s", namespace),
+	)
 	if p.Err() != nil {
-		t.Logf("Namespace %s might already exist: %v", namespace, p.Err())
+		t.Logf("Error deleting namespace %s: %v", namespace, p.Err())
+	}
+
+	// Create namespace
+	t.Logf("Creating namespace %s...", namespace)
+	p = utils.RunCommand(fmt.Sprintf("kubectl create ns %s", namespace))
+	if p.Err() != nil {
+		t.Fatal("Error creating namespace:", p.Err())
 	}
 
 	// Add label if needed
@@ -146,18 +223,8 @@ func deployJavaDemoApp(
 	}
 
 	// Apply deployment
-	// Now that we know we're already in the e2e directory, use the correct relative path
 	deploymentPath := "java-demo-app/deployment.yaml"
 	t.Logf("Applying deployment from path: %s to namespace: %s", deploymentPath, namespace)
-
-	// Verify the file exists before applying
-	fileCheckCmd := fmt.Sprintf("ls -la %s", deploymentPath)
-	fileCheck := utils.RunCommand(fileCheckCmd)
-	t.Logf("File check result: %s", fileCheck.Out())
-
-	if fileCheck.Err() != nil {
-		t.Fatalf("Deployment file not found at path: %s", deploymentPath)
-	}
 
 	// Apply the deployment with the correct path
 	applyCmd := fmt.Sprintf("kubectl apply -f %s -n %s", deploymentPath, namespace)
@@ -172,19 +239,6 @@ func deployJavaDemoApp(
 		)
 	}
 	t.Logf("Successfully applied deployment to namespace %s", namespace)
-
-	// Wait for deployment to be ready
-	p = utils.RunCommand(
-		fmt.Sprintf(
-			"kubectl wait --for=condition=available deployment/java-demo-app -n %s --timeout=120s",
-			namespace,
-		),
-	)
-	if p.Err() != nil {
-		t.Fatal("Error waiting for Java demo app deployment:", p.Err())
-	}
-
-	t.Logf("Java demo app deployed successfully in namespace %s", namespace)
 }
 
 // VerifySelectiveMonitoring verifies that only the JVM in the opt-in namespace is monitored.
@@ -192,6 +246,12 @@ func VerifySelectiveMonitoring() features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		t.Log("Verifying selective monitoring...")
 		// TODO: Needs redefinement, the agent pod must run on the same worker node as the demo app to be monitored
+		// First notes: Selective monitoring is set to OPT_IN in the agent log
+		// 2025-08-18T14:04:59.606+00:00 | INFO  | instana-executor-thread-2-3      | lMachineUtilImpl | com.instana.agent-util - 1.0.12 | addToVmMapWithLogAndRequestDiscovery | adding new VM with PID 3537885, ContainerizedVirtualMachineImpl [pid=3537885, inContainerPid=1, containerFileSystem=/proc/3537885/root, parentPid=3537885, attachType=HOTSPOT_MODULAR, hasAttachFile=false, commandLine=HelloWorldServer, vmArgs=, name=OpenJDK 64-Bit Server VM (Red_Hat-21.0.8.0.9-1), vendor=OpenJDK, version=21.0.8, build=21.0.8+9-LTS, heapCapacity=-1, process=CrioProcessImpl [pid=3537885, parentPid=3537883, inContainerPid=1, containerId=3d9cc71389d96e80221057c69022b13eaa74b7dbb5e657846573086c0363b424, containerFileSystem=/proc/3537885/root, startTime=0, name=java, gatewayAddress='<lazy>, anyListenAddress='<lazy>, directory=/app, executable=/usr/lib/jvm/java-21-openjdk-21.0.8.0.9-1.el9.x86_64/bin/java, arguments=[HelloWorldServer], userName=<lazy>, groupName=<lazy>, procCred=null, environmentVariables={PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin, KUBERNETES_PORT_443_TCP=tcp://172.30.0.1:443, container=oci, KUBERNETES_PORT_443_TCP_ADDR=172.30.0.1, KUBERNETES_PORT=tcp://172.30.0.1:443, KUBERNETES_PORT_443_TCP_PROTO=tcp, TERM=xterm, USER_UID=1001, KUBERNETES_SERVICE_HOST=172.30.0.1, KUBERNETES_SERVICE_PORT=443, HOSTNAME=java-demo-app-79bcdf6476-wdtff, NSS_SDB_USE_CACHE=no, KUBERNETES_PORT_443_TCP_PORT=443, KUBERNETES_SERVICE_PORT_HTTPS=443, HOME=/}, stable=true]] //nolint:lll
+		// Grep for the agent logs:
+		// "HelloWorldServer" and "adding new VM with PID xxx". Isolate the used PID which is required for the next request.
+		// With the PID, check if the agent log contains a successful attachment for it.
+		// The log would be "Initial attach to JVM with PID xxx successful".
 
 		// Get agent pods
 		clientSet, err := kubernetes.NewForConfig(cfg.Client().RESTConfig())
@@ -277,7 +337,6 @@ func VerifySelectiveMonitoring() features.Func {
 }
 
 // CleanupNamespaces cleans up the namespaces created for the test.
-// This function is not used directly in the test but can be used for manual cleanup.
 func CleanupNamespaces() features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		namespaces := []string{
@@ -287,7 +346,7 @@ func CleanupNamespaces() features.Func {
 		}
 
 		for _, ns := range namespaces {
-			p := utils.RunCommand(fmt.Sprintf("kubectl delete ns %s", ns))
+			p := utils.RunCommand(fmt.Sprintf("kubectl delete ns %s --wait --timeout=30s", ns))
 			if p.Err() != nil {
 				t.Logf("Error deleting namespace %s: %v", ns, p.Err())
 			} else {

--- a/e2e/selective_monitoring_test.go
+++ b/e2e/selective_monitoring_test.go
@@ -1,0 +1,256 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/instana/instana-agent-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/support/utils"
+)
+
+// TestSelectiveMonitoring tests the selective monitoring feature of the Instana agent operator.
+// It deploys the agent in opt-in mode and verifies that only JVMs in namespaces with the
+// instana-workload-monitoring=true label are monitored.
+func TestSelectiveMonitoring(t *testing.T) {
+	// Create a new agent CR with selective monitoring enabled
+	agent := NewAgentCrWithSelectiveMonitoring()
+
+	// Define the test feature
+	selectiveMonitoringFeature := features.New("selective monitoring in opt-in mode").
+		Setup(SetupOperatorDevBuild()).
+		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		Setup(DeployAgentCr(&agent)).
+		Setup(DeployJavaDemoAppInNamespaces()).
+		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
+		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
+		Assess("verify selective monitoring works correctly", VerifySelectiveMonitoring()).
+		Feature()
+
+	// Run the test
+	testEnv.Test(t, selectiveMonitoringFeature)
+}
+
+// NewAgentCrWithSelectiveMonitoring creates a new agent CR with selective monitoring enabled in opt-in mode.
+func NewAgentCrWithSelectiveMonitoring() v1.InstanaAgent {
+	agent := NewAgentCr() // Use the existing function to create a base agent CR
+
+	// Set the INSTANA_SELECTIVE_MONITORING environment variable using the Kubernetes style format
+	if agent.Spec.Agent.Pod.Env == nil {
+		agent.Spec.Agent.Pod.Env = []corev1.EnvVar{}
+	}
+
+	agent.Spec.Agent.Pod.Env = append(agent.Spec.Agent.Pod.Env, corev1.EnvVar{
+		Name:  "INSTANA_SELECTIVE_MONITORING",
+		Value: "OPT_IN",
+	})
+
+	return agent
+}
+
+// DeployJavaDemoAppInNamespaces deploys the Java demo app in three different namespaces with appropriate labels.
+func DeployJavaDemoAppInNamespaces() features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		// Deploy in namespace without label
+		deployJavaDemoApp(ctx, t, "selective-monitoring-no-label", false, "")
+
+		// Deploy in namespace with opt-out label
+		deployJavaDemoApp(ctx, t, "selective-monitoring-opt-out", true, "false")
+
+		// Deploy in namespace with opt-in label
+		deployJavaDemoApp(ctx, t, "selective-monitoring-opt-in", true, "true")
+
+		// Wait for all deployments to be ready
+		time.Sleep(30 * time.Second)
+
+		return ctx
+	}
+}
+
+// deployJavaDemoApp deploys the Java demo app in the specified namespace with the specified label.
+func deployJavaDemoApp(ctx context.Context, t *testing.T, namespace string, addLabel bool, labelValue string) {
+	// Create namespace
+	p := utils.RunCommand(fmt.Sprintf("kubectl create ns %s", namespace))
+	if p.Err() != nil {
+		t.Logf("Namespace %s might already exist: %v", namespace, p.Err())
+	}
+
+	// Add label if needed
+	if addLabel {
+		p = utils.RunCommand(fmt.Sprintf("kubectl label ns %s instana-workload-monitoring=%s", namespace, labelValue))
+		if p.Err() != nil {
+			t.Fatal("Error labeling namespace:", p.Err())
+		}
+	}
+
+	// Check if the registry configuration exists
+	if InstanaTestCfg.ContainerRegistry == nil {
+		t.Fatal("Container registry configuration is not set in the test configuration")
+	}
+
+	// Secret name - use the same name as in SetupOperatorDevBuild()
+	secretName := InstanaTestCfg.ContainerRegistry.Name
+
+	// Check if secret exists in the target namespace
+	t.Logf("Checking if pull secret exists in namespace %s...", namespace)
+	p = utils.RunCommand(fmt.Sprintf("kubectl get secret %s -n %s", secretName, namespace))
+	secretExists := p.Err() == nil
+
+	// Delete secret if it exists
+	if secretExists {
+		t.Logf("Updating existing pull secret...")
+		p = utils.RunCommand(fmt.Sprintf("kubectl delete secret %s -n %s", secretName, namespace))
+		if p.Err() != nil {
+			t.Fatal("Error deleting existing pull secret:", p.Err())
+		}
+	} else {
+		t.Logf("Creating new pull secret...")
+	}
+
+	// Create docker-registry secret directly using kubectl with the same config values as in SetupOperatorDevBuild()
+	p = utils.RunCommand(fmt.Sprintf(
+		"kubectl create secret docker-registry %s --docker-server=%s --docker-username=%s --docker-password=%s -n %s",
+		InstanaTestCfg.ContainerRegistry.Name,
+		InstanaTestCfg.ContainerRegistry.Host,
+		InstanaTestCfg.ContainerRegistry.User,
+		InstanaTestCfg.ContainerRegistry.Password,
+		namespace))
+	if p.Err() != nil {
+		t.Fatal("Error creating pull secret:", p.Err())
+	}
+
+	// Apply deployment
+	deploymentPath := "e2e/java-demo-app/deployment.yaml"
+	p = utils.RunCommand(fmt.Sprintf("kubectl apply -f %s -n %s", deploymentPath, namespace))
+	if p.Err() != nil {
+		t.Fatal("Error applying deployment:", p.Err())
+	}
+
+	// Wait for deployment to be ready
+	p = utils.RunCommand(
+		fmt.Sprintf("kubectl wait --for=condition=available e2e/deployment/java-demo-app -n %s --timeout=120s", namespace),
+	)
+	if p.Err() != nil {
+		t.Fatal("Error waiting for Java demo app deployment:", p.Err())
+	}
+
+	t.Logf("Java demo app deployed successfully in namespace %s", namespace)
+}
+
+// VerifySelectiveMonitoring verifies that only the JVM in the opt-in namespace is monitored.
+func VerifySelectiveMonitoring() features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Log("Verifying selective monitoring...")
+
+		// Get agent pods
+		clientSet, err := kubernetes.NewForConfig(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Wait for the agent to have time to discover and attach to JVMs
+		t.Log("Waiting for agent to discover and attach to JVMs...")
+		time.Sleep(60 * time.Second)
+
+		podList, err := clientSet.CoreV1().Pods(cfg.Namespace()).List(
+			ctx,
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=instana-agent"},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(podList.Items) == 0 {
+			t.Fatal("No agent pods found")
+		}
+
+		// Check logs for JVM attachment
+		var buf bytes.Buffer
+		logReq := clientSet.CoreV1().Pods(cfg.Namespace()).GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{})
+		podLogs, err := logReq.Stream(ctx)
+		if err != nil {
+			t.Fatal("Could not stream logs", err)
+		}
+		defer podLogs.Close()
+
+		_, err = io.Copy(&buf, podLogs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		logs := buf.String()
+		t.Logf("Agent logs retrieved, checking for JVM attachment...")
+
+		// Check for successful JVM attachment in the opt-in namespace
+		optInAttached := strings.Contains(logs, "Initial attach to JVM") &&
+			strings.Contains(logs, "successful") &&
+			strings.Contains(logs, "selective-monitoring-opt-in")
+
+		// Check for absence of JVM attachment in the other namespaces
+		noLabelAttached := strings.Contains(logs, "Initial attach to JVM") &&
+			strings.Contains(logs, "successful") &&
+			strings.Contains(logs, "selective-monitoring-no-label")
+
+		optOutAttached := strings.Contains(logs, "Initial attach to JVM") &&
+			strings.Contains(logs, "successful") &&
+			strings.Contains(logs, "selective-monitoring-opt-out")
+
+		// Verify expectations
+		if !optInAttached {
+			t.Error("JVM in opt-in namespace should be monitored, but no attachment was found in logs")
+		} else {
+			t.Log("JVM in opt-in namespace is correctly monitored")
+		}
+
+		if noLabelAttached {
+			t.Error("JVM in no-label namespace should not be monitored, but attachment was found in logs")
+		} else {
+			t.Log("JVM in no-label namespace is correctly not monitored")
+		}
+
+		if optOutAttached {
+			t.Error("JVM in opt-out namespace should not be monitored, but attachment was found in logs")
+		} else {
+			t.Log("JVM in opt-out namespace is correctly not monitored")
+		}
+
+		return ctx
+	}
+}
+
+// CleanupNamespaces cleans up the namespaces created for the test.
+// This function is not used directly in the test but can be used for manual cleanup.
+func CleanupNamespaces() features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		namespaces := []string{
+			"selective-monitoring-no-label",
+			"selective-monitoring-opt-out",
+			"selective-monitoring-opt-in",
+		}
+
+		for _, ns := range namespaces {
+			p := utils.RunCommand(fmt.Sprintf("kubectl delete ns %s", ns))
+			if p.Err() != nil {
+				t.Logf("Error deleting namespace %s: %v", ns, p.Err())
+			} else {
+				t.Logf("Namespace %s deleted successfully", ns)
+			}
+		}
+
+		return ctx
+	}
+}
+
+// Made with Bob


### PR DESCRIPTION
## Why

Improve test coverage for selective monitoring on a namespace level.

## What

- Add a new test case with a real demo app to ensure we only monitor workload which we should.

- Added a Java demo application in e2e/java-demo-app/ with:
  - A simple HTTP server implementation
  - Dockerfile for containerization
  - Kubernetes deployment manifest

- Implemented a selective monitoring test that:
  - Deploys the Java app in three different namespaces with different labels
  - Configures the Instana agent with selective monitoring in opt-in mode
  - Verifies that only JVMs in opt-in namespaces are monitored

**Note**: Right now there is not a good way to see from the logs if a JVM got ignored correctly. For now the test is deploying all 3 apps at once, checks on which worker nodes they are running and than it checks all relevant agent logs.
The logs are searched for the INSTANA_TEST_POD_NAME env var which get's populated by the deployment itself. The name gets mapped back to the pod names found in a given namespace to decide, if we expect them to be ignored or to be monitored.
When a container is found, the PID is extracted, e.g. `adding new VM with PID 3537885` will pick `3537885`.
The PID can be used as an identifier to find an attachment log like `Performing initial attach to JVM with PID 3537885`.
Finally, a working attachment needs to be detected by searching for `Initial attach to JVM with PID 3537885 successful`.

The same happens for the other pod names, but if we find them, this means they were not correctly ignored and the test should fail.

## References

- [INSTA-10452](https://jsw.ibm.com/browse/INSTA-10452)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated? n/a
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
