### PR TITLE
ci: Update preflight to supported version

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -930,7 +930,7 @@ jobs:
           params: { state: error, context: multiarch-operator-manifest-promotion/build-multiarch-manifest }
       - get: preflight
         version:
-          tag: 1.12.1
+          tag: 1.14.1
         params:
           globs:
             - preflight-linux-amd64


### PR DESCRIPTION
## Why

Release pipeline requires update to pass

## What

The release pipeline currently fails with:

```
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.12.1' is not supported. Supported versions are: ['1.13.2', '1.13.3', '1.14.0', '1.14.1']", "status": 400, "trace_id": "0xbd05ab3d6bbc039780bf7757d75047da"}
2025/08/28 14:11:47 could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.12.1' is not supported. Supported versions are: ['1.13.2', '1.13.3', '1.14.0', '1.14.1']", "status": 400, "trace_id": "0xbd05ab3d6bbc039780bf7757d75047da"}
```

Upgraded the preflight binary to the latest release

## References


## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated? n/a


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
