### PR TITLE
chore(deps): Downgrade operator-sdk to v1.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ operator-sdk: ## Download the Operator SDK binary locally if necessary.
 		echo "Operator SDK binary found in $(OPERATOR_SDK)"; \
 	else \
 		echo "DOwnload Operator SDK for $(OS)/$(ARCH) to $(OPERATOR_SDK)"; \
-		curl -Lo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.23.0/operator-sdk_${OS}_${ARCH}; \
+		curl -Lo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.16.0/operator-sdk_${OS}_${ARCH}; \
 		chmod +x $(OPERATOR_SDK); \
 	fi
 


### PR DESCRIPTION
## Why

The file bundle/manifests/instana-agent-operator.clusterserviceversion.yaml is lacking the relatedImages section otherwise.

## What

Downgraded dependency to last good known version

## References

- https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/1132
- https://github.com/redhat-openshift-ecosystem/certified-operators/pull/6520

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated? n/a


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
