### PR TITLE
pre-commit-config: Update detect-secrets to support latest python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,9 @@ repos:
     # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
     # You are encouraged to use static refs such as tags, instead of branch name
     #
-    # Running "pre-commit autoupdate" automatically updates rev to latest tag
-    rev: 0.13.1+ibm.62.dss
+    # For now only rev `557ec90` has the fix for boxsdk breaking changes:
+    # https://github.com/IBM/detect-secrets/commit/557ec9088975712f75f11731cedbb7c61c8897ae
+    rev: 557ec90
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.


### PR DESCRIPTION
## Why

There was a known issue in detect-secret where it would run into a dependency issue when running in a newer Python version.

See issue:
https://github.com/IBM/detect-secrets/issues/173

It was fixed in a recent PR: https://github.com/IBM/detect-secrets/pull/174

## What

Update rev of detect-secrets pre-commit hook to fix an issue with the previous version.

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
