### PR TITLE
use directory for putting release-version

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -742,11 +742,11 @@ jobs:
         - put: agent-operator-git-source
           params:
             repository: agent-operator-git-source
-            tag_file: agent-operator-git-source/ci/version.txt
+            tag_file: agent-operator-git-source/ci/version
             force: true
         - put: release-version
           params:
-            file: agent-operator-git-source/ci/version.txt
+            directory: agent-operator-git-source/ci
         - put: gh-status
           inputs: [ agent-operator-git-source ]
           params: { state: success, context: tag-release }

--- a/ci/scripts/tag-new-release.sh
+++ b/ci/scripts/tag-new-release.sh
@@ -100,4 +100,4 @@ echo "Tagging repo with the new release tag ${new_release}"
 git config --global user.name "instanacd"
 git config --global user.email "instanacd@instana.com"
 git tag "${new_release}"
-echo "${new_release}" > ci/version.txt
+echo "${new_release}" > ci/version


### PR DESCRIPTION
## Why

* fixing pipeline

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
