### PR TITLE
use designated version dir

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -746,7 +746,7 @@ jobs:
             force: true
         - put: release-version
           params:
-            directory: agent-operator-git-source/ci
+            directory: version-output
         - put: gh-status
           inputs: [ agent-operator-git-source ]
           params: { state: success, context: tag-release }
@@ -799,6 +799,7 @@ jobs:
             - name: agent-operator-git-source
           outputs:
             - name: agent-operator-git-source
+            - name: version-output
           params:
             BRANCH: ((branch))
             TRIGGER_TYPE: ((.:trigger-type))

--- a/ci/scripts/tag-new-release.sh
+++ b/ci/scripts/tag-new-release.sh
@@ -8,6 +8,9 @@
 set -e
 set -o pipefail
 
+# Create version-output directory
+mkdir -p ../version-output
+
 echo "Running on branch $BRANCH"
 cd agent-operator-git-source
 git pull -r
@@ -101,3 +104,4 @@ git config --global user.name "instanacd"
 git config --global user.email "instanacd@instana.com"
 git tag "${new_release}"
 echo "${new_release}" > ci/version
+echo "${new_release}" > ../version-output/version


### PR DESCRIPTION
## Why
* use designated dir with a single file

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
