### PR TITLE
use absolute paths for storing version

### DIFF
--- a/ci/scripts/tag-new-release.sh
+++ b/ci/scripts/tag-new-release.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
 #
-# (c) Copyright IBM Corp. 2024
+# (c) Copyright IBM Corp. 2024, 2025
 # (c) Copyright Instana Inc.
 #
 
 set -e
 set -o pipefail
 
-# Create version-output directory
-mkdir -p ../version-output
+# Store the absolute path to version-output directory
+VERSION_OUTPUT_DIR=$(pwd)/../version-output
+mkdir -p $VERSION_OUTPUT_DIR
+echo "VERSION_OUTPUT_DIR=$VERSION_OUTPUT_DIR"
 
 echo "Running on branch $BRANCH"
 cd agent-operator-git-source
@@ -104,4 +106,4 @@ git config --global user.name "instanacd"
 git config --global user.email "instanacd@instana.com"
 git tag "${new_release}"
 echo "${new_release}" > ci/version
-echo "${new_release}" > ../version-output/version
+echo "${new_release}" > $VERSION_OUTPUT_DIR/version


### PR DESCRIPTION
## What

<!--
Please explain what you did. For small/trivial changes a single paragraph is probably sufficient.
For any larger changes this should include design choices.
-->

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
