### PR TITLE
fix: install Go in Concourse e2e tests

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -560,6 +560,8 @@ jobs:
                   - -ceu
                   - |
                     cd agent-operator-git-source
+                    source ./installGolang.sh amd64
+                    export PATH=$PATH:/usr/local/go/bin
                     bash ./ci/scripts/cluster-authentication.sh
                     make pre-pull-images generate e2e
             on_success:
@@ -667,6 +669,8 @@ jobs:
                   - -ceu
                   - |
                     cd agent-operator-git-source
+                    source ./installGolang.sh amd64
+                    export PATH=$PATH:/usr/local/go/bin
                     bash ./ci/scripts/cluster-authentication.sh
                     make pre-pull-images generate e2e
             on_success:


### PR DESCRIPTION
## Why

The Concourse pipeline e2e tests were failing with `go: command not found` error. This happened because Go was intentionally removed from the e2e base image to avoid frequent rebuilds when Go versions change. However, the Concourse pipeline was not installing Go before running tests, unlike other CI scripts (SPS).

## What

Added Go installation step in both Concourse e2e test tasks before running tests:
- `run-e2e-test-gke-operator-lowest`
- `run-e2e-test-gke-operator-latest`

The fix uses the existing `installGolang.sh` script to dynamically install Go at runtime, matching the approach already used in:
- `ci/sps-scripts/setup.sh`
- `ci/sps-scripts/unit-test.sh`
- `ci/sps-scripts/olm-build.sh`

Modified `ci/pipeline.yaml` to add these lines before running e2e tests:
```bash
source ./installGolang.sh amd64
export PATH=$PATH:/usr/local/go/bin
```

## References

- No story/card - this is a CI pipeline fix
- Related PR for release-2.1: https://github.com/instana/instana-agent-operator/pull/485

## Checklist

- [x] Backwards compatible? - Yes, this only affects CI pipeline execution
- [x] Release notes in public docs updated? - Not needed, internal CI fix only
- [x] unit/e2e test coverage added or updated? - Not applicable, this fixes the e2e test execution itself