### PR TITLE
refactor(INSTA-76421): Lower complexity, early exit from iteration

### DIFF
--- a/controllers/etcd_discovery.go
+++ b/controllers/etcd_discovery.go
@@ -178,7 +178,6 @@ func (r *InstanaAgentReconciler) getServiceWithLabel(
 		Namespace: kubeSystemNamespace,
 		Name:      name,
 	}, service)
-
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -203,7 +202,6 @@ func (r *InstanaAgentReconciler) getServiceByName(
 		Namespace: kubeSystemNamespace,
 		Name:      name,
 	}, service)
-
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -219,25 +217,25 @@ func (r *InstanaAgentReconciler) findMetricsPortAndScheme(
 	service *corev1.Service,
 ) (*int32, string) {
 	for _, port := range service.Spec.Ports {
-		if port.Name == "metrics" {
-			// Use switch/case for scheme determination
-			scheme := "https" // Default to https for unknown ports
-			switch port.Port {
-			case constants.ETCDMetricsPortHTTPS:
-				scheme = "https"
-			case constants.ETCDMetricsPortHTTP:
-				scheme = "http"
-			}
-
-			// Check for scheme annotation override
-			if schemeOverride, ok := service.Annotations["instana.io/etcd-scheme"]; ok {
-				scheme = schemeOverride
-			}
-
-			return &port.Port, scheme
+		if port.Name != "metrics" {
+			continue
 		}
-	}
+		// Use switch/case for scheme determination
+		scheme := "https" // Default to https for unknown ports
+		switch port.Port {
+		case constants.ETCDMetricsPortHTTPS:
+			scheme = "https"
+		case constants.ETCDMetricsPortHTTP:
+			scheme = "http"
+		}
 
+		// Check for scheme annotation override
+		if schemeOverride, ok := service.Annotations["instana.io/etcd-scheme"]; ok {
+			scheme = schemeOverride
+		}
+
+		return &port.Port, scheme
+	}
 	return nil, ""
 }
 


### PR DESCRIPTION
## Why

Cyclomatic complexity and the number of nested scopes was unnecessarily high.

## What

Reduce nesting, exit early.

## References

<!-- Please include links to other artifacts related to this code change. -->

INSTA-76421

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
