### PR TITLE
[release-2.1] fix: install Go in operator-olm-github-release job

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -1123,6 +1123,8 @@ jobs:
                 fi
 
                 pushd agent-operator-git-source
+                source ./installGolang.sh amd64
+                export PATH=$PATH:/usr/local/go/bin
 
                 # Create a place to store our output for packaging up
                 mkdir -p target


### PR DESCRIPTION
## Why

The operator-olm-github-release job in the Concourse pipeline was failing with `go: command not found` error. This job runs `make bundle` which requires Go to be installed. Like the e2e tests, this job uses the e2e-test-base-image which intentionally does not include Go.

## What

Added Go installation in the operator-olm-github-release job before running make commands:
```bash
source ./installGolang.sh amd64
export PATH=$PATH:/usr/local/go/bin
```

This follows the same pattern as the e2e test fixes in PR #485.

## References

- No story/card - this is a CI pipeline fix
- Related e2e test fix: https://github.com/instana/instana-agent-operator/pull/485
- Related PR for main branch: https://github.com/instana/instana-agent-operator/pull/490

## Checklist

- [x] Backwards compatible? - Yes, this only affects CI pipeline execution
- [x] Release notes in public docs updated? - Not needed, internal CI fix only
- [x] unit/e2e test coverage added or updated? - Not applicable, this fixes the CI job execution itself