### PR TITLE
refactor(INSTA-76421): Test production code & drop duplicates

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|go.sum|flake.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-08T23:28:38Z",
+  "generated_at": "2026-04-09T09:37:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -122,7 +122,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 170,
+        "line_number": 175,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|go.sum|flake.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-02-09T08:27:55Z",
+  "generated_at": "2026-04-08T23:28:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -122,7 +122,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 170,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/controllers/etcd_discoverer.go
+++ b/controllers/etcd_discoverer.go
@@ -1,0 +1,350 @@
+/*
+(c) Copyright IBM Corp. 2026
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	instanaclient "github.com/instana/instana-agent-operator/pkg/k8s/client"
+	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
+	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
+)
+
+// ETCDDiscoverer defines the interface for ETCD discovery operations
+type ETCDDiscoverer interface {
+	// ShouldSkipDiscovery checks if ETCD discovery should be skipped
+	ShouldSkipDiscovery(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error)
+
+	// FindETCDService attempts to find an etcd service in the kube-system namespace
+	FindETCDService(ctx context.Context, log logr.Logger) (*corev1.Service, error)
+
+	// GetServiceWithLabel gets a service with the specified name and checks if it has the expected label
+	GetServiceWithLabel(
+		ctx context.Context,
+		name, labelKey, labelValue string,
+	) (*corev1.Service, error)
+
+	// GetServiceByName gets a service by name
+	GetServiceByName(ctx context.Context, name string) (*corev1.Service, error)
+
+	// FindMetricsPortAndScheme finds the metrics port and determines the scheme
+	FindMetricsPortAndScheme(service *corev1.Service) (*int32, string)
+
+	// BuildTargetsFromEndpoints builds targets from service endpoint slices
+	BuildTargetsFromEndpoints(
+		ctx context.Context,
+		service *corev1.Service,
+		metricsPort int32,
+		scheme string,
+	) ([]string, error)
+
+	// BuildTargetsFromLegacyEndpoints builds targets from legacy Endpoints resource
+	BuildTargetsFromLegacyEndpoints(
+		ctx context.Context,
+		service *corev1.Service,
+		metricsPort int32,
+		scheme string,
+	) ([]string, error)
+
+	// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace
+	CheckCASecretExists(ctx context.Context, agent *instanav1.InstanaAgent) bool
+}
+
+// DefaultETCDDiscoverer is the production implementation of ETCDDiscoverer
+type DefaultETCDDiscoverer struct {
+	client     instanaclient.InstanaAgentClient
+	reconciler *InstanaAgentReconciler
+}
+
+// NewDefaultETCDDiscoverer creates a new DefaultETCDDiscoverer instance
+func NewDefaultETCDDiscoverer(
+	client instanaclient.InstanaAgentClient,
+	reconciler *InstanaAgentReconciler,
+) *DefaultETCDDiscoverer {
+	return &DefaultETCDDiscoverer{
+		client:     client,
+		reconciler: reconciler,
+	}
+}
+
+// ShouldSkipDiscovery checks if ETCD discovery should be skipped
+func (d *DefaultETCDDiscoverer) ShouldSkipDiscovery(
+	ctx context.Context,
+	agent *instanav1.InstanaAgent,
+) (bool, error) {
+	operatorUtils := operator_utils.NewOperatorUtils(ctx, d.client, agent, nil)
+	isOpenShift, isOpenShiftRes := d.reconciler.isOpenShift(ctx, operatorUtils)
+
+	if isOpenShiftRes.suppliesReconcileResult() {
+		return false, fmt.Errorf("failed to determine if cluster is OpenShift")
+	}
+
+	if isOpenShift {
+		d.reconciler.loggerFor(ctx, agent).Info("Skipping ETCD discovery on OpenShift cluster")
+		return true, nil
+	}
+
+	if len(agent.Spec.K8sSensor.ETCD.Targets) > 0 {
+		d.reconciler.loggerFor(ctx, agent).
+			Info("Using ETCD targets from CR spec", "targets", agent.Spec.K8sSensor.ETCD.Targets)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// FindETCDService attempts to find an etcd service in the kube-system namespace
+func (d *DefaultETCDDiscoverer) FindETCDService(
+	ctx context.Context,
+	log logr.Logger,
+) (*corev1.Service, error) {
+	// Try services with component=etcd label first
+	if service, err := d.GetServiceWithLabel(ctx, "etcd", "component", "etcd"); err != nil {
+		return nil, err
+	} else if service != nil {
+		log.Info("Found etcd service with component=etcd label", "name", service.Name)
+		return service, nil
+	}
+
+	if service, err := d.GetServiceWithLabel(ctx, "etcd-metrics", "component", "etcd"); err != nil {
+		return nil, err
+	} else if service != nil {
+		log.Info("Found etcd-metrics service with component=etcd label", "name", service.Name)
+		return service, nil
+	}
+
+	// Fallback to name-based search
+	log.Info("No service found with component=etcd label, trying by name")
+
+	// Try by name in sequence
+	serviceNames := []string{"etcd", "etcd-metrics", "etcd-k8s"}
+	for _, name := range serviceNames {
+		service, err := d.GetServiceByName(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if service != nil {
+			return service, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// GetServiceWithLabel gets a service with the specified name and checks if it has the expected label
+func (d *DefaultETCDDiscoverer) GetServiceWithLabel(
+	ctx context.Context,
+	name, labelKey, labelValue string,
+) (*corev1.Service, error) {
+	service, err := d.GetServiceByName(ctx, name)
+	if err != nil || service == nil {
+		return service, err
+	}
+
+	if service.Labels == nil || service.Labels[labelKey] != labelValue {
+		return nil, nil
+	}
+
+	return service, nil
+}
+
+// GetServiceByName gets a service by name
+func (d *DefaultETCDDiscoverer) GetServiceByName(
+	ctx context.Context,
+	name string,
+) (*corev1.Service, error) {
+	service := &corev1.Service{}
+	err := d.client.Get(ctx, client.ObjectKey{
+		Namespace: kubeSystemNamespace,
+		Name:      name,
+	}, service)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return service, nil
+}
+
+// FindMetricsPortAndScheme finds the metrics port and determines the scheme
+func (d *DefaultETCDDiscoverer) FindMetricsPortAndScheme(
+	service *corev1.Service,
+) (*int32, string) {
+	for _, port := range service.Spec.Ports {
+		if port.Name == "metrics" {
+			// Use switch/case for scheme determination
+			scheme := "https" // Default to https for unknown ports
+			switch port.Port {
+			case constants.ETCDMetricsPortHTTPS:
+				scheme = "https"
+			case constants.ETCDMetricsPortHTTP:
+				scheme = "http"
+			}
+
+			// Check for scheme annotation override
+			if schemeOverride, ok := service.Annotations["instana.io/etcd-scheme"]; ok {
+				scheme = schemeOverride
+			}
+
+			return &port.Port, scheme
+		}
+	}
+
+	return nil, ""
+}
+
+// BuildTargetsFromEndpoints builds targets from service endpoint slices
+func (d *DefaultETCDDiscoverer) BuildTargetsFromEndpoints(
+	ctx context.Context,
+	service *corev1.Service,
+	metricsPort int32,
+	scheme string,
+) ([]string, error) {
+	// List endpoint slices belonging to the service. EndpointSlice names include a random
+	// suffix, so we have to rely on the service label instead of the service name.
+	endpointSlices := &discoveryv1.EndpointSliceList{}
+	if err := d.client.List(
+		ctx,
+		endpointSlices,
+		client.InNamespace(kubeSystemNamespace),
+		client.MatchingLabels(map[string]string{discoveryv1.LabelServiceName: service.Name}),
+	); err != nil {
+		return nil, err
+	}
+
+	targets := make([]string, 0)
+
+	for i := range endpointSlices.Items {
+		sliceTargets := buildTargetsFromEndpointSlice(&endpointSlices.Items[i], metricsPort, scheme)
+		targets = append(targets, sliceTargets...)
+	}
+
+	if len(targets) == 0 {
+		legacyTargets, err := d.BuildTargetsFromLegacyEndpoints(ctx, service, metricsPort, scheme)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, legacyTargets...)
+	}
+
+	// Sort targets for consistent comparison with current state
+	sort.Strings(targets)
+
+	return targets, nil
+}
+
+// BuildTargetsFromLegacyEndpoints builds targets from legacy Endpoints resource
+func (d *DefaultETCDDiscoverer) BuildTargetsFromLegacyEndpoints(
+	ctx context.Context,
+	service *corev1.Service,
+	metricsPort int32,
+	scheme string,
+) ([]string, error) {
+	endpoints := &corev1.Endpoints{}
+	if err := d.client.Get(ctx, client.ObjectKey{
+		Namespace: kubeSystemNamespace,
+		Name:      service.Name,
+	}, endpoints); err != nil {
+		if errors.IsNotFound(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	targets := make([]string, 0)
+
+	for _, subset := range endpoints.Subsets {
+		endpointPort := metricsPort
+		for _, port := range subset.Ports {
+			if port.Name == "metrics" {
+				endpointPort = port.Port
+				break
+			}
+		}
+
+		for _, address := range subset.Addresses {
+			target := fmt.Sprintf("%s://%s:%d/metrics", scheme, address.IP, endpointPort)
+			targets = append(targets, target)
+		}
+	}
+
+	return targets, nil
+}
+
+// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace
+func (d *DefaultETCDDiscoverer) CheckCASecretExists(
+	ctx context.Context,
+	agent *instanav1.InstanaAgent,
+) bool {
+	caSecret := &corev1.Secret{} // pragma: whitelist secret
+	err := d.client.Get(ctx, client.ObjectKey{
+		Namespace: agent.Namespace,
+		Name:      constants.ETCDCASecretName,
+	}, caSecret)
+
+	if err == nil {
+		d.reconciler.loggerFor(ctx, agent).Info("Found etcd-ca secret in agent namespace")
+		return true
+	}
+
+	return false
+}
+
+func buildTargetsFromEndpointSlice(
+	endpointSlice *discoveryv1.EndpointSlice,
+	metricsPort int32,
+	scheme string,
+) []string {
+	targets := make([]string, 0)
+
+	// Find the metrics port in the endpoint slice
+	endpointPort := metricsPort
+	for _, port := range endpointSlice.Ports {
+		if port.Name != nil && *port.Name == "metrics" && port.Port != nil {
+			endpointPort = *port.Port
+			break
+		}
+	}
+
+	// Add targets for each ready endpoint
+	for _, endpoint := range endpointSlice.Endpoints {
+		// Skip if Ready is explicitly set to false
+		// We don't need to check if endpoint.Conditions is nil (it can't be nil since it's a struct value),
+		// but we should handle the case where endpoint.Conditions.Ready is nil, which according to the
+		// documentation should be interpreted as "true"
+		if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+			continue
+		}
+		for _, address := range endpoint.Addresses {
+			target := fmt.Sprintf("%s://%s:%d/metrics", scheme, address, endpointPort)
+			targets = append(targets, target)
+		}
+	}
+
+	return targets
+}

--- a/controllers/etcd_discoverer_mock_test.go
+++ b/controllers/etcd_discoverer_mock_test.go
@@ -1,0 +1,131 @@
+/*
+(c) Copyright IBM Corp. 2026
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+)
+
+// MockETCDDiscoverer is a mock implementation of ETCDDiscoverer for testing
+type MockETCDDiscoverer struct {
+	ShouldSkipDiscoveryFunc func(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error)
+	FindETCDServiceFunc     func(ctx context.Context, log logr.Logger) (*corev1.Service, error)
+	GetServiceWithLabelFunc func(
+		ctx context.Context,
+		name, labelKey, labelValue string,
+	) (*corev1.Service, error)
+	GetServiceByNameFunc          func(ctx context.Context, name string) (*corev1.Service, error)
+	FindMetricsPortAndSchemeFunc  func(service *corev1.Service) (*int32, string)
+	BuildTargetsFromEndpointsFunc func(
+		ctx context.Context,
+		service *corev1.Service,
+		metricsPort int32,
+		scheme string,
+	) ([]string, error)
+	BuildTargetsFromLegacyEndpointsFunc func(
+		ctx context.Context,
+		service *corev1.Service,
+		metricsPort int32,
+		scheme string,
+	) ([]string, error)
+	CheckCASecretExistsFunc func(ctx context.Context, agent *instanav1.InstanaAgent) bool
+}
+
+func (m *MockETCDDiscoverer) ShouldSkipDiscovery(
+	ctx context.Context,
+	agent *instanav1.InstanaAgent,
+) (bool, error) {
+	if m.ShouldSkipDiscoveryFunc != nil {
+		return m.ShouldSkipDiscoveryFunc(ctx, agent)
+	}
+	return false, nil
+}
+
+func (m *MockETCDDiscoverer) FindETCDService(
+	ctx context.Context,
+	log logr.Logger,
+) (*corev1.Service, error) {
+	if m.FindETCDServiceFunc != nil {
+		return m.FindETCDServiceFunc(ctx, log)
+	}
+	return nil, nil
+}
+
+func (m *MockETCDDiscoverer) GetServiceWithLabel(
+	ctx context.Context,
+	name, labelKey, labelValue string,
+) (*corev1.Service, error) {
+	if m.GetServiceWithLabelFunc != nil {
+		return m.GetServiceWithLabelFunc(ctx, name, labelKey, labelValue)
+	}
+	return nil, nil
+}
+
+func (m *MockETCDDiscoverer) GetServiceByName(
+	ctx context.Context,
+	name string,
+) (*corev1.Service, error) {
+	if m.GetServiceByNameFunc != nil {
+		return m.GetServiceByNameFunc(ctx, name)
+	}
+	return nil, nil
+}
+
+func (m *MockETCDDiscoverer) FindMetricsPortAndScheme(service *corev1.Service) (*int32, string) {
+	if m.FindMetricsPortAndSchemeFunc != nil {
+		return m.FindMetricsPortAndSchemeFunc(service)
+	}
+	return nil, ""
+}
+
+func (m *MockETCDDiscoverer) BuildTargetsFromEndpoints(
+	ctx context.Context,
+	service *corev1.Service,
+	metricsPort int32,
+	scheme string,
+) ([]string, error) {
+	if m.BuildTargetsFromEndpointsFunc != nil {
+		return m.BuildTargetsFromEndpointsFunc(ctx, service, metricsPort, scheme)
+	}
+	return nil, nil
+}
+
+func (m *MockETCDDiscoverer) BuildTargetsFromLegacyEndpoints(
+	ctx context.Context,
+	service *corev1.Service,
+	metricsPort int32,
+	scheme string,
+) ([]string, error) {
+	if m.BuildTargetsFromLegacyEndpointsFunc != nil {
+		return m.BuildTargetsFromLegacyEndpointsFunc(ctx, service, metricsPort, scheme)
+	}
+	return nil, nil
+}
+
+func (m *MockETCDDiscoverer) CheckCASecretExists(
+	ctx context.Context, agent *instanav1.InstanaAgent,
+) bool {
+	if m.CheckCASecretExistsFunc != nil {
+		return m.CheckCASecretExistsFunc(ctx, agent)
+	}
+	return false
+}

--- a/controllers/etcd_discovery.go
+++ b/controllers/etcd_discovery.go
@@ -54,7 +54,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	log := r.loggerFor(ctx, agent)
 
 	// Step 1: Check if discovery should be skipped
-	shouldSkip, err := r.shouldSkipDiscovery(ctx, agent)
+	shouldSkip, err := ShouldSkipDiscovery(r, ctx, agent)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	}
 
 	// Step 2: Find etcd service
-	etcdService, err := r.findETCDService(ctx, log)
+	etcdService, err := FindETCDService(r, ctx, log)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	log.Info("Found etcd service", "name", etcdService.Name)
 
 	// Step 3: Find metrics port and determine scheme
-	metricsPortPtr, scheme := r.findMetricsPortAndScheme(etcdService)
+	metricsPortPtr, scheme := FindMetricsPortAndScheme(r, etcdService)
 	if metricsPortPtr == nil {
 		log.Info("No metrics port found in etcd service")
 		return nil, nil
@@ -84,7 +84,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	metricsPort := *metricsPortPtr
 
 	// Step 4: Get endpoints and build targets
-	targets, err := r.buildTargetsFromEndpoints(ctx, etcdService, metricsPort, scheme)
+	targets, err := BuildTargetsFromEndpoints(r, ctx, etcdService, metricsPort, scheme)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	}
 
 	// Step 5: Check for CA secret and return results
-	caSecretExists := r.checkCASecretExists(ctx, agent)
+	caSecretExists := CheckCASecretExists(r, ctx, agent)
 
 	log.Info("Discovered etcd targets", "targets", targets, "caFound", caSecretExists)
 
@@ -104,13 +104,14 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	}, nil
 }
 
-// shouldSkipDiscovery checks if ETCD discovery should be skipped
-func (r *InstanaAgentReconciler) shouldSkipDiscovery(
+// ShouldSkipDiscovery checks if ETCD discovery should be skipped
+var ShouldSkipDiscovery = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	agent *instanav1.InstanaAgent,
 ) (bool, error) {
 	operatorUtils := operator_utils.NewOperatorUtils(ctx, r.client, agent, nil)
-	isOpenShift, isOpenShiftRes := r.isOpenShift(ctx, operatorUtils)
+	isOpenShift, isOpenShiftRes := IsOpenShift(r, ctx, operatorUtils)
 
 	if isOpenShiftRes.suppliesReconcileResult() {
 		return false, fmt.Errorf("failed to determine if cluster is OpenShift")
@@ -130,20 +131,21 @@ func (r *InstanaAgentReconciler) shouldSkipDiscovery(
 	return false, nil
 }
 
-// findETCDService attempts to find an etcd service in the kube-system namespace
-func (r *InstanaAgentReconciler) findETCDService(
+// FindETCDService attempts to find an etcd service in the kube-system namespace
+var FindETCDService = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	log logr.Logger,
 ) (*corev1.Service, error) {
 	// Try services with component=etcd label first
-	if service, err := r.getServiceWithLabel(ctx, "etcd", "component", "etcd"); err != nil {
+	if service, err := GetServiceWithLabel(r, ctx, "etcd", "component", "etcd"); err != nil {
 		return nil, err
 	} else if service != nil {
 		log.Info("Found etcd service with component=etcd label", "name", service.Name)
 		return service, nil
 	}
 
-	if service, err := r.getServiceWithLabel(ctx, "etcd-metrics", "component", "etcd"); err != nil {
+	if service, err := GetServiceWithLabel(r, ctx, "etcd-metrics", "component", "etcd"); err != nil {
 		return nil, err
 	} else if service != nil {
 		log.Info("Found etcd-metrics service with component=etcd label", "name", service.Name)
@@ -156,7 +158,7 @@ func (r *InstanaAgentReconciler) findETCDService(
 	// Try by name in sequence
 	serviceNames := []string{"etcd", "etcd-metrics", "etcd-k8s"}
 	for _, name := range serviceNames {
-		service, err := r.getServiceByName(ctx, name)
+		service, err := GetServiceByName(r, ctx, name)
 		if err != nil {
 			return nil, err
 		}
@@ -168,8 +170,9 @@ func (r *InstanaAgentReconciler) findETCDService(
 	return nil, nil
 }
 
-// getServiceWithLabel gets a service with the specified name and checks if it has the expected label
-func (r *InstanaAgentReconciler) getServiceWithLabel(
+// GetServiceWithLabel gets a service with the specified name and checks if it has the expected label
+var GetServiceWithLabel = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	name, labelKey, labelValue string,
 ) (*corev1.Service, error) {
@@ -192,8 +195,9 @@ func (r *InstanaAgentReconciler) getServiceWithLabel(
 	return service, nil
 }
 
-// getServiceByName gets a service by name
-func (r *InstanaAgentReconciler) getServiceByName(
+// GetServiceByName gets a service by name
+var GetServiceByName = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	name string,
 ) (*corev1.Service, error) {
@@ -212,8 +216,9 @@ func (r *InstanaAgentReconciler) getServiceByName(
 	return service, nil
 }
 
-// findMetricsPortAndScheme finds the metrics port and determines the scheme
-func (r *InstanaAgentReconciler) findMetricsPortAndScheme(
+// FindMetricsPortAndScheme finds the metrics port and determines the scheme
+var FindMetricsPortAndScheme = func(
+	r *InstanaAgentReconciler,
 	service *corev1.Service,
 ) (*int32, string) {
 	for _, port := range service.Spec.Ports {
@@ -239,8 +244,9 @@ func (r *InstanaAgentReconciler) findMetricsPortAndScheme(
 	return nil, ""
 }
 
-// buildTargetsFromEndpoints builds targets from service endpoint slices
-func (r *InstanaAgentReconciler) buildTargetsFromEndpoints(
+// BuildTargetsFromEndpoints builds targets from service endpoint slices
+var BuildTargetsFromEndpoints = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	service *corev1.Service,
 	metricsPort int32,
@@ -266,7 +272,7 @@ func (r *InstanaAgentReconciler) buildTargetsFromEndpoints(
 	}
 
 	if len(targets) == 0 {
-		legacyTargets, err := r.buildTargetsFromLegacyEndpoints(ctx, service, metricsPort, scheme)
+		legacyTargets, err := BuildTargetsFromLegacyEndpoints(r, ctx, service, metricsPort, scheme)
 		if err != nil {
 			return nil, err
 		}
@@ -313,7 +319,8 @@ func buildTargetsFromEndpointSlice(
 	return targets
 }
 
-func (r *InstanaAgentReconciler) buildTargetsFromLegacyEndpoints(
+var BuildTargetsFromLegacyEndpoints = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	service *corev1.Service,
 	metricsPort int32,
@@ -350,8 +357,9 @@ func (r *InstanaAgentReconciler) buildTargetsFromLegacyEndpoints(
 	return targets, nil
 }
 
-// checkCASecretExists checks if the etcd-ca secret exists in the agent namespace
-func (r *InstanaAgentReconciler) checkCASecretExists(
+// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace
+var CheckCASecretExists = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	agent *instanav1.InstanaAgent,
 ) bool {

--- a/controllers/etcd_discovery.go
+++ b/controllers/etcd_discovery.go
@@ -18,19 +18,8 @@ package controllers
 
 import (
 	"context"
-	"fmt"
-	"sort"
-
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
-	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
-	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 )
 
 // DiscoveredETCDTargets holds information about discovered ETCD endpoints
@@ -54,7 +43,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	log := r.loggerFor(ctx, agent)
 
 	// Step 1: Check if discovery should be skipped
-	shouldSkip, err := ShouldSkipDiscovery(r, ctx, agent)
+	shouldSkip, err := r.etcdDiscoverer.ShouldSkipDiscovery(ctx, agent)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +53,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	}
 
 	// Step 2: Find etcd service
-	etcdService, err := FindETCDService(r, ctx, log)
+	etcdService, err := r.etcdDiscoverer.FindETCDService(ctx, log)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +65,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	log.Info("Found etcd service", "name", etcdService.Name)
 
 	// Step 3: Find metrics port and determine scheme
-	metricsPortPtr, scheme := FindMetricsPortAndScheme(r, etcdService)
+	metricsPortPtr, scheme := r.etcdDiscoverer.FindMetricsPortAndScheme(etcdService)
 	if metricsPortPtr == nil {
 		log.Info("No metrics port found in etcd service")
 		return nil, nil
@@ -84,7 +73,12 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	metricsPort := *metricsPortPtr
 
 	// Step 4: Get endpoints and build targets
-	targets, err := BuildTargetsFromEndpoints(r, ctx, etcdService, metricsPort, scheme)
+	targets, err := r.etcdDiscoverer.BuildTargetsFromEndpoints(
+		ctx,
+		etcdService,
+		metricsPort,
+		scheme,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +88,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	}
 
 	// Step 5: Check for CA secret and return results
-	caSecretExists := CheckCASecretExists(r, ctx, agent)
+	caSecretExists := r.etcdDiscoverer.CheckCASecretExists(ctx, agent)
 
 	log.Info("Discovered etcd targets", "targets", targets, "caFound", caSecretExists)
 
@@ -102,277 +96,4 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 		Targets: targets,
 		CAFound: caSecretExists,
 	}, nil
-}
-
-// ShouldSkipDiscovery checks if ETCD discovery should be skipped
-var ShouldSkipDiscovery = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	agent *instanav1.InstanaAgent,
-) (bool, error) {
-	operatorUtils := operator_utils.NewOperatorUtils(ctx, r.client, agent, nil)
-	isOpenShift, isOpenShiftRes := IsOpenShift(r, ctx, operatorUtils)
-
-	if isOpenShiftRes.suppliesReconcileResult() {
-		return false, fmt.Errorf("failed to determine if cluster is OpenShift")
-	}
-
-	if isOpenShift {
-		r.loggerFor(ctx, agent).Info("Skipping ETCD discovery on OpenShift cluster")
-		return true, nil
-	}
-
-	if len(agent.Spec.K8sSensor.ETCD.Targets) > 0 {
-		r.loggerFor(ctx, agent).
-			Info("Using ETCD targets from CR spec", "targets", agent.Spec.K8sSensor.ETCD.Targets)
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// FindETCDService attempts to find an etcd service in the kube-system namespace
-var FindETCDService = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	log logr.Logger,
-) (*corev1.Service, error) {
-	// Try services with component=etcd label first
-	if service, err := GetServiceWithLabel(r, ctx, "etcd", "component", "etcd"); err != nil {
-		return nil, err
-	} else if service != nil {
-		log.Info("Found etcd service with component=etcd label", "name", service.Name)
-		return service, nil
-	}
-
-	if service, err := GetServiceWithLabel(r, ctx, "etcd-metrics", "component", "etcd"); err != nil {
-		return nil, err
-	} else if service != nil {
-		log.Info("Found etcd-metrics service with component=etcd label", "name", service.Name)
-		return service, nil
-	}
-
-	// Fallback to name-based search
-	log.Info("No service found with component=etcd label, trying by name")
-
-	// Try by name in sequence
-	serviceNames := []string{"etcd", "etcd-metrics", "etcd-k8s"}
-	for _, name := range serviceNames {
-		service, err := GetServiceByName(r, ctx, name)
-		if err != nil {
-			return nil, err
-		}
-		if service != nil {
-			return service, nil
-		}
-	}
-
-	return nil, nil
-}
-
-// GetServiceWithLabel gets a service with the specified name and checks if it has the expected label
-var GetServiceWithLabel = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	name, labelKey, labelValue string,
-) (*corev1.Service, error) {
-	service := &corev1.Service{}
-	err := r.client.Get(ctx, types.NamespacedName{
-		Namespace: kubeSystemNamespace,
-		Name:      name,
-	}, service)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	if service.Labels == nil || service.Labels[labelKey] != labelValue {
-		return nil, nil
-	}
-
-	return service, nil
-}
-
-// GetServiceByName gets a service by name
-var GetServiceByName = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	name string,
-) (*corev1.Service, error) {
-	service := &corev1.Service{}
-	err := r.client.Get(ctx, types.NamespacedName{
-		Namespace: kubeSystemNamespace,
-		Name:      name,
-	}, service)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return service, nil
-}
-
-// FindMetricsPortAndScheme finds the metrics port and determines the scheme
-var FindMetricsPortAndScheme = func(
-	r *InstanaAgentReconciler,
-	service *corev1.Service,
-) (*int32, string) {
-	for _, port := range service.Spec.Ports {
-		if port.Name != "metrics" {
-			continue
-		}
-		// Use switch/case for scheme determination
-		scheme := "https" // Default to https for unknown ports
-		switch port.Port {
-		case constants.ETCDMetricsPortHTTPS:
-			scheme = "https"
-		case constants.ETCDMetricsPortHTTP:
-			scheme = "http"
-		}
-
-		// Check for scheme annotation override
-		if schemeOverride, ok := service.Annotations["instana.io/etcd-scheme"]; ok {
-			scheme = schemeOverride
-		}
-
-		return &port.Port, scheme
-	}
-	return nil, ""
-}
-
-// BuildTargetsFromEndpoints builds targets from service endpoint slices
-var BuildTargetsFromEndpoints = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	service *corev1.Service,
-	metricsPort int32,
-	scheme string,
-) ([]string, error) {
-	// List endpoint slices belonging to the service. EndpointSlice names include a random
-	// suffix, so we have to rely on the service label instead of the service name.
-	endpointSlices := &discoveryv1.EndpointSliceList{}
-	if err := r.client.List(
-		ctx,
-		endpointSlices,
-		client.InNamespace(kubeSystemNamespace),
-		client.MatchingLabels(map[string]string{discoveryv1.LabelServiceName: service.Name}),
-	); err != nil {
-		return nil, err
-	}
-
-	targets := make([]string, 0)
-
-	for i := range endpointSlices.Items {
-		sliceTargets := buildTargetsFromEndpointSlice(&endpointSlices.Items[i], metricsPort, scheme)
-		targets = append(targets, sliceTargets...)
-	}
-
-	if len(targets) == 0 {
-		legacyTargets, err := BuildTargetsFromLegacyEndpoints(r, ctx, service, metricsPort, scheme)
-		if err != nil {
-			return nil, err
-		}
-		targets = append(targets, legacyTargets...)
-	}
-
-	// Sort targets for consistent comparison with current state
-	sort.Strings(targets)
-
-	return targets, nil
-}
-
-func buildTargetsFromEndpointSlice(
-	endpointSlice *discoveryv1.EndpointSlice,
-	metricsPort int32,
-	scheme string,
-) []string {
-	targets := make([]string, 0)
-
-	// Find the metrics port in the endpoint slice
-	endpointPort := metricsPort
-	for _, port := range endpointSlice.Ports {
-		if port.Name != nil && *port.Name == "metrics" && port.Port != nil {
-			endpointPort = *port.Port
-			break
-		}
-	}
-
-	// Add targets for each ready endpoint
-	for _, endpoint := range endpointSlice.Endpoints {
-		// Skip if Ready is explicitly set to false
-		// We don't need to check if endpoint.Conditions is nil (it can't be nil since it's a struct value),
-		// but we should handle the case where endpoint.Conditions.Ready is nil, which according to the
-		// documentation should be interpreted as "true"
-		if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
-			continue
-		}
-		for _, address := range endpoint.Addresses {
-			target := fmt.Sprintf("%s://%s:%d/metrics", scheme, address, endpointPort)
-			targets = append(targets, target)
-		}
-	}
-
-	return targets
-}
-
-var BuildTargetsFromLegacyEndpoints = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	service *corev1.Service,
-	metricsPort int32,
-	scheme string,
-) ([]string, error) {
-	endpoints := &corev1.Endpoints{}
-	if err := r.client.Get(ctx, types.NamespacedName{
-		Namespace: kubeSystemNamespace,
-		Name:      service.Name,
-	}, endpoints); err != nil {
-		if apierrors.IsNotFound(err) {
-			return []string{}, nil
-		}
-		return nil, err
-	}
-
-	targets := make([]string, 0)
-
-	for _, subset := range endpoints.Subsets {
-		endpointPort := metricsPort
-		for _, port := range subset.Ports {
-			if port.Name == "metrics" {
-				endpointPort = port.Port
-				break
-			}
-		}
-
-		for _, address := range subset.Addresses {
-			target := fmt.Sprintf("%s://%s:%d/metrics", scheme, address.IP, endpointPort)
-			targets = append(targets, target)
-		}
-	}
-
-	return targets, nil
-}
-
-// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace
-var CheckCASecretExists = func(
-	r *InstanaAgentReconciler,
-	ctx context.Context,
-	agent *instanav1.InstanaAgent,
-) bool {
-	caSecret := &corev1.Secret{} // pragma: whitelist secret
-	err := r.client.Get(ctx, types.NamespacedName{
-		Namespace: agent.Namespace,
-		Name:      constants.ETCDCASecretName,
-	}, caSecret)
-
-	if err == nil {
-		r.loggerFor(ctx, agent).Info("Found etcd-ca secret in agent namespace")
-		return true
-	}
-
-	return false
 }

--- a/controllers/etcd_discovery_test.go
+++ b/controllers/etcd_discovery_test.go
@@ -34,7 +34,6 @@ import (
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
 	instanaclient "github.com/instana/instana-agent-operator/pkg/k8s/client"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
-	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 )
 
 // Mock client that returns errors for specific operations
@@ -128,9 +127,6 @@ func TestShouldSkipDiscovery(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create a fake client
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
 			// Create agent with or without ETCD targets
 			agent := &instanav1.InstanaAgent{
 				ObjectMeta: metav1.ObjectMeta{
@@ -146,32 +142,28 @@ func TestShouldSkipDiscovery(t *testing.T) {
 				},
 			}
 
-			// Create real reconciler
-			reconciler := &InstanaAgentReconciler{
-				client: instanaclient.NewInstanaAgentClient(fakeClient),
-				scheme: scheme,
+			// Create a custom discoverer for testing that handles isOpenShift logic
+			mockDiscoverer := &MockETCDDiscoverer{
+				ShouldSkipDiscoveryFunc: func(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error) {
+					// Simulate isOpenShift check
+					if tc.isOpenShiftErr {
+						return false, fmt.Errorf("failed to determine if cluster is OpenShift")
+					}
+
+					if tc.isOpenShift {
+						return true, nil
+					}
+
+					if len(agent.Spec.K8sSensor.ETCD.Targets) > 0 {
+						return true, nil
+					}
+
+					return false, nil
+				},
 			}
 
-			// Mock isOpenShift function
-			mockIsOpenShift := func(
-				r *InstanaAgentReconciler,
-				ctx context.Context,
-				operatorUtils operator_utils.OperatorUtils,
-			) (bool, reconcileReturn) {
-				if tc.isOpenShiftErr {
-					return false, reconcileFailure(fmt.Errorf("isOpenShift error"))
-				}
-				return tc.isOpenShift, reconcileContinue()
-			}
-			originalIsOpenShift := IsOpenShift
-			defer func() {
-				IsOpenShift = originalIsOpenShift
-			}()
-			IsOpenShift = mockIsOpenShift
-
-			// Test
 			ctx := context.Background()
-			skip, err := ShouldSkipDiscovery(reconciler, ctx, agent)
+			skip, err := mockDiscoverer.ShouldSkipDiscovery(ctx, agent)
 
 			// Verify
 			if tc.expectedErr {
@@ -306,10 +298,10 @@ func TestGetServiceWithLabel(t *testing.T) {
 				scheme: scheme,
 			}
 
-			// Test
+			// Create discoverer and test
+			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
 			ctx := context.Background()
-			service, err := GetServiceWithLabel(
-				reconciler,
+			service, err := discoverer.GetServiceWithLabel(
 				ctx,
 				tc.serviceName,
 				tc.labelKey,
@@ -410,9 +402,10 @@ func TestGetServiceByName(t *testing.T) {
 				scheme: scheme,
 			}
 
-			// Test
+			// Create discoverer and test
+			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
 			ctx := context.Background()
-			service, err := GetServiceByName(reconciler, ctx, tc.serviceName)
+			service, err := discoverer.GetServiceByName(ctx, tc.serviceName)
 
 			// Verify
 			if tc.expectError {
@@ -568,10 +561,11 @@ func TestFindETCDService(t *testing.T) {
 				scheme: scheme,
 			}
 
-			// Test
+			// Create discoverer and test
+			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
 			ctx := context.Background()
 			logger := ctrl.Log.WithName("test")
-			service, err := FindETCDService(reconciler, ctx, logger)
+			service, err := discoverer.FindETCDService(ctx, logger)
 
 			// Verify
 			if tc.expectError {
@@ -691,8 +685,9 @@ func TestFindMetricsPortAndScheme(t *testing.T) {
 				scheme: clientScheme,
 			}
 
-			// Test
-			port, scheme := FindMetricsPortAndScheme(reconciler, service)
+			// Create discoverer and test
+			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
+			port, scheme := discoverer.FindMetricsPortAndScheme(service)
 
 			// Verify
 			if tc.expectPortFound {
@@ -970,10 +965,10 @@ func TestBuildTargetsFromEndpoints(t *testing.T) {
 				scheme: scheme,
 			}
 
-			// Test
+			// Create discoverer and test
+			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
 			ctx := context.Background()
-			targets, err := BuildTargetsFromEndpoints(
-				reconciler,
+			targets, err := discoverer.BuildTargetsFromEndpoints(
 				ctx,
 				tc.service,
 				tc.metricsPort,
@@ -1049,9 +1044,10 @@ func TestCheckCASecretExists(t *testing.T) {
 				scheme: scheme,
 			}
 
-			// Test
+			// Create discoverer and test
+			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
 			ctx := context.Background()
-			found := CheckCASecretExists(reconciler, ctx, agent)
+			found := discoverer.CheckCASecretExists(ctx, agent)
 
 			// Verify
 			assert.Equal(t, tc.expectedFound, found, "CA secret found status should match expected")
@@ -1180,77 +1176,40 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 				},
 			}
 
-			// Create mock functions
-			mockShouldSkipDiscovery := func(
-				r *InstanaAgentReconciler,
-				ctx context.Context,
-				agent *instanav1.InstanaAgent,
-			) (bool, error) {
-				return tc.shouldSkip, tc.shouldSkipErr
-			}
-			originalShouldSkipDiscovery := ShouldSkipDiscovery
-			defer func() {
-				ShouldSkipDiscovery = originalShouldSkipDiscovery
-			}()
-			ShouldSkipDiscovery = mockShouldSkipDiscovery
-
-			mockFindETCDService := func(
-				r *InstanaAgentReconciler, ctx context.Context, logger logr.Logger,
-			) (*corev1.Service, error) {
-				return tc.findServiceResult, tc.findServiceErr
-			}
-			originalFindETCDService := FindETCDService
-			defer func() {
-				FindETCDService = originalFindETCDService
-			}()
-			FindETCDService = mockFindETCDService
-
-			mockFindMetricsPortAndScheme := func(r *InstanaAgentReconciler, service *corev1.Service) (*int32, string) {
-				if tc.metricsPort == 0 {
-					return nil, tc.scheme
-				}
-				return &tc.metricsPort, tc.scheme
-			}
-			originalFindMetricsPortAndScheme := FindMetricsPortAndScheme
-			defer func() {
-				FindMetricsPortAndScheme = originalFindMetricsPortAndScheme
-			}()
-			FindMetricsPortAndScheme = mockFindMetricsPortAndScheme
-
-			mockBuildTargetsFromEndpoints := func(
-				r *InstanaAgentReconciler,
-				ctx context.Context,
-				service *corev1.Service,
-				metricsPort int32,
-				scheme string,
-			) ([]string, error) {
-				return tc.buildTargetsResult, tc.buildTargetsErr
-			}
-			originalBuildTargetsFromEndpoints := BuildTargetsFromEndpoints
-			defer func() {
-				BuildTargetsFromEndpoints = originalBuildTargetsFromEndpoints
-			}()
-			BuildTargetsFromEndpoints = mockBuildTargetsFromEndpoints
-
-			mockCheckCASecretExists := func(
-				r *InstanaAgentReconciler,
-				ctx context.Context,
-				agent *instanav1.InstanaAgent,
-			) bool {
-				return tc.caSecretExists
-			}
-			originalCheckCASecretExists := CheckCASecretExists
-			defer func() {
-				CheckCASecretExists = originalCheckCASecretExists
-			}()
-			CheckCASecretExists = mockCheckCASecretExists
-
-			// Create real reconciler
+			// Create real reconciler with mock discoverer
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &InstanaAgentReconciler{
 				client: instanaclient.NewInstanaAgentClient(fakeClient),
 				scheme: scheme,
 			}
+
+			// Create mock discoverer
+			mockDiscoverer := &MockETCDDiscoverer{
+				ShouldSkipDiscoveryFunc: func(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error) {
+					return tc.shouldSkip, tc.shouldSkipErr
+				},
+				FindETCDServiceFunc: func(ctx context.Context, log logr.Logger) (*corev1.Service, error) {
+					return tc.findServiceResult, tc.findServiceErr
+				},
+				FindMetricsPortAndSchemeFunc: func(service *corev1.Service) (*int32, string) {
+					if tc.metricsPort == 0 {
+						return nil, tc.scheme
+					}
+					return &tc.metricsPort, tc.scheme
+				},
+				BuildTargetsFromEndpointsFunc: func(
+					ctx context.Context,
+					service *corev1.Service,
+					metricsPort int32,
+					scheme string,
+				) ([]string, error) {
+					return tc.buildTargetsResult, tc.buildTargetsErr
+				},
+				CheckCASecretExistsFunc: func(ctx context.Context, agent *instanav1.InstanaAgent) bool {
+					return tc.caSecretExists
+				},
+			}
+			reconciler.etcdDiscoverer = mockDiscoverer
 
 			// Test
 			ctx := context.Background()

--- a/controllers/etcd_discovery_test.go
+++ b/controllers/etcd_discovery_test.go
@@ -19,64 +19,23 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	instanaclient "github.com/instana/instana-agent-operator/pkg/k8s/client"
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 )
-
-// Type aliases to make function signatures more readable
-type (
-	// IsOpenShiftFunc is a function that checks if the cluster is OpenShift
-	IsOpenShiftFunc func(ctx context.Context, operatorUtils operator_utils.OperatorUtils) (bool, reconcileReturn)
-
-	// SkipDiscoveryFunc is a function that checks if ETCD discovery should be skipped
-	SkipDiscoveryFunc func(ctx context.Context, agent *instanav1.InstanaAgent, logger logr.Logger,
-		isOpenShiftFunc IsOpenShiftFunc) (bool, error)
-
-	// FindServiceFunc is a function that finds an ETCD service
-	FindServiceFunc func(ctx context.Context, client client.Client, logger logr.Logger) (*corev1.Service, error)
-
-	// FindPortAndSchemeFunc is a function that finds the metrics port and scheme
-	FindPortAndSchemeFunc func(service *corev1.Service) (*int32, string)
-
-	// BuildTargetsFunc is a function that builds targets from endpoint slices
-	BuildTargetsFunc func(ctx context.Context, client client.Client, service *corev1.Service,
-		metricsPort int32, scheme string) ([]string, error)
-
-	// CheckCASecretFunc is a function that checks if the CA secret exists
-	CheckCASecretFunc func(ctx context.Context, client client.Client,
-		agent *instanav1.InstanaAgent, logger logr.Logger) bool
-)
-
-// mockETCDReconciler is a simplified version of InstanaAgentReconciler for testing
-type mockETCDReconciler struct {
-	client client.Client
-	scheme *runtime.Scheme
-	logger logr.Logger
-}
-
-func (r *mockETCDReconciler) loggerFor(
-	ctx context.Context,
-	agent *instanav1.InstanaAgent,
-) logr.Logger {
-	return r.logger
-}
 
 // Mock client that returns errors for specific operations
 type errorMockClient struct {
@@ -86,7 +45,8 @@ type errorMockClient struct {
 
 // Get implements client.Client
 func (c *errorMockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object,
-	opts ...client.GetOption) error {
+	opts ...client.GetOption,
+) error {
 	return c.err
 }
 
@@ -108,14 +68,15 @@ type selectiveErrorMockClient struct {
 
 // Get implements client.Client
 func (c *selectiveErrorMockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object,
-	opts ...client.GetOption) error {
+	opts ...client.GetOption,
+) error {
 	if key.Name == c.errorForName {
 		return c.err
 	}
 	return c.Client.Get(ctx, key, obj, opts...)
 }
 
-// TestShouldSkipDiscovery tests the shouldSkipDiscovery function
+// TestShouldSkipDiscovery tests the ShouldSkipDiscovery function
 func TestShouldSkipDiscovery(t *testing.T) {
 	// Setup
 	scheme := runtime.NewScheme()
@@ -185,25 +146,32 @@ func TestShouldSkipDiscovery(t *testing.T) {
 				},
 			}
 
-			// Create mock reconciler
-			reconciler := &mockETCDReconciler{
-				client: fakeClient,
+			// Create real reconciler
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(fakeClient),
 				scheme: scheme,
-				logger: zap.New(),
 			}
 
 			// Mock isOpenShift function
-			mockIsOpenShift := func(ctx context.Context, operatorUtils operator_utils.OperatorUtils) (bool, reconcileReturn) {
+			mockIsOpenShift := func(
+				r *InstanaAgentReconciler,
+				ctx context.Context,
+				operatorUtils operator_utils.OperatorUtils,
+			) (bool, reconcileReturn) {
 				if tc.isOpenShiftErr {
 					return false, reconcileFailure(fmt.Errorf("isOpenShift error"))
 				}
 				return tc.isOpenShift, reconcileContinue()
 			}
+			originalIsOpenShift := IsOpenShift
+			defer func() {
+				IsOpenShift = originalIsOpenShift
+			}()
+			IsOpenShift = mockIsOpenShift
 
 			// Test
 			ctx := context.Background()
-			logger := reconciler.loggerFor(ctx, agent)
-			skip, err := shouldSkipDiscovery(ctx, agent, logger, mockIsOpenShift)
+			skip, err := ShouldSkipDiscovery(reconciler, ctx, agent)
 
 			// Verify
 			if tc.expectedErr {
@@ -221,7 +189,7 @@ func TestShouldSkipDiscovery(t *testing.T) {
 	}
 }
 
-// TestGetServiceWithLabel tests the getServiceWithLabel function
+// TestGetServiceWithLabel tests the GetServiceWithLabel function
 func TestGetServiceWithLabel(t *testing.T) {
 	// Setup
 	scheme := runtime.NewScheme()
@@ -332,11 +300,17 @@ func TestGetServiceWithLabel(t *testing.T) {
 				mockClient = fakeClient
 			}
 
+			// Create real reconciler
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(mockClient),
+				scheme: scheme,
+			}
+
 			// Test
 			ctx := context.Background()
-			service, err := getServiceWithLabel(
+			service, err := GetServiceWithLabel(
+				reconciler,
 				ctx,
-				mockClient,
 				tc.serviceName,
 				tc.labelKey,
 				tc.labelValue,
@@ -358,7 +332,7 @@ func TestGetServiceWithLabel(t *testing.T) {
 	}
 }
 
-// TestGetServiceByName tests the getServiceByName function
+// TestGetServiceByName tests the GetServiceByName function
 func TestGetServiceByName(t *testing.T) {
 	// Setup
 	scheme := runtime.NewScheme()
@@ -430,9 +404,15 @@ func TestGetServiceByName(t *testing.T) {
 				mockClient = fakeClient
 			}
 
+			// Create real reconciler
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(mockClient),
+				scheme: scheme,
+			}
+
 			// Test
 			ctx := context.Background()
-			service, err := getServiceByName(ctx, mockClient, tc.serviceName)
+			service, err := GetServiceByName(reconciler, ctx, tc.serviceName)
 
 			// Verify
 			if tc.expectError {
@@ -540,7 +520,7 @@ func TestFindETCDService(t *testing.T) {
 			expectError:     false,
 		},
 		{
-			name: "Should propagate error from getServiceWithLabel",
+			name: "Should propagate error from GetServiceWithLabel",
 			services: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -582,10 +562,16 @@ func TestFindETCDService(t *testing.T) {
 				mockClient = fakeClient
 			}
 
+			// Create real reconciler
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(mockClient),
+				scheme: scheme,
+			}
+
 			// Test
 			ctx := context.Background()
 			logger := ctrl.Log.WithName("test")
-			service, err := findETCDService(ctx, mockClient, logger)
+			service, err := FindETCDService(reconciler, ctx, logger)
 
 			// Verify
 			if tc.expectError {
@@ -697,8 +683,16 @@ func TestFindMetricsPortAndScheme(t *testing.T) {
 				},
 			}
 
+			// Create real reconciler
+			clientScheme := runtime.NewScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(clientScheme).Build()
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(fakeClient),
+				scheme: clientScheme,
+			}
+
 			// Test
-			port, scheme := findMetricsPortAndScheme(service)
+			port, scheme := FindMetricsPortAndScheme(reconciler, service)
 
 			// Verify
 			if tc.expectPortFound {
@@ -970,11 +964,17 @@ func TestBuildTargetsFromEndpoints(t *testing.T) {
 				mockClient = fakeClient
 			}
 
+			// Create real reconciler
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(mockClient),
+				scheme: scheme,
+			}
+
 			// Test
 			ctx := context.Background()
-			targets, err := buildTargetsFromEndpoints(
+			targets, err := BuildTargetsFromEndpoints(
+				reconciler,
 				ctx,
-				mockClient,
 				tc.service,
 				tc.metricsPort,
 				tc.scheme,
@@ -991,7 +991,7 @@ func TestBuildTargetsFromEndpoints(t *testing.T) {
 	}
 }
 
-// TestCheckCASecretExists tests the checkCASecretExists function
+// TestCheckCASecretExists tests the CheckCASecretExists function
 func TestCheckCASecretExists(t *testing.T) {
 	// Setup
 	scheme := runtime.NewScheme()
@@ -1043,10 +1043,15 @@ func TestCheckCASecretExists(t *testing.T) {
 			// Build the client
 			fakeClient := clientBuilder.Build()
 
+			// Create real reconciler
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(fakeClient),
+				scheme: scheme,
+			}
+
 			// Test
 			ctx := context.Background()
-			logger := ctrl.Log.WithName("test")
-			found := checkCASecretExists(ctx, fakeClient, agent, logger)
+			found := CheckCASecretExists(reconciler, ctx, agent)
 
 			// Verify
 			assert.Equal(t, tc.expectedFound, found, "CA secret found status should match expected")
@@ -1177,58 +1182,81 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 
 			// Create mock functions
 			mockShouldSkipDiscovery := func(
+				r *InstanaAgentReconciler,
 				ctx context.Context,
 				agent *instanav1.InstanaAgent,
-				logger logr.Logger,
-				isOpenShiftFunc IsOpenShiftFunc,
 			) (bool, error) {
 				return tc.shouldSkip, tc.shouldSkipErr
 			}
+			originalShouldSkipDiscovery := ShouldSkipDiscovery
+			defer func() {
+				ShouldSkipDiscovery = originalShouldSkipDiscovery
+			}()
+			ShouldSkipDiscovery = mockShouldSkipDiscovery
 
-			mockFindETCDService := func(ctx context.Context, client client.Client, logger logr.Logger) (*corev1.Service, error) {
+			mockFindETCDService := func(
+				r *InstanaAgentReconciler, ctx context.Context, logger logr.Logger,
+			) (*corev1.Service, error) {
 				return tc.findServiceResult, tc.findServiceErr
 			}
+			originalFindETCDService := FindETCDService
+			defer func() {
+				FindETCDService = originalFindETCDService
+			}()
+			FindETCDService = mockFindETCDService
 
-			mockFindMetricsPortAndScheme := func(service *corev1.Service) (*int32, string) {
+			mockFindMetricsPortAndScheme := func(r *InstanaAgentReconciler, service *corev1.Service) (*int32, string) {
 				if tc.metricsPort == 0 {
 					return nil, tc.scheme
 				}
 				return &tc.metricsPort, tc.scheme
 			}
+			originalFindMetricsPortAndScheme := FindMetricsPortAndScheme
+			defer func() {
+				FindMetricsPortAndScheme = originalFindMetricsPortAndScheme
+			}()
+			FindMetricsPortAndScheme = mockFindMetricsPortAndScheme
 
 			mockBuildTargetsFromEndpoints := func(
+				r *InstanaAgentReconciler,
 				ctx context.Context,
-				client client.Client,
 				service *corev1.Service,
 				metricsPort int32,
 				scheme string,
 			) ([]string, error) {
 				return tc.buildTargetsResult, tc.buildTargetsErr
 			}
+			originalBuildTargetsFromEndpoints := BuildTargetsFromEndpoints
+			defer func() {
+				BuildTargetsFromEndpoints = originalBuildTargetsFromEndpoints
+			}()
+			BuildTargetsFromEndpoints = mockBuildTargetsFromEndpoints
 
 			mockCheckCASecretExists := func(
+				r *InstanaAgentReconciler,
 				ctx context.Context,
-				client client.Client,
 				agent *instanav1.InstanaAgent,
-				logger logr.Logger,
 			) bool {
 				return tc.caSecretExists
+			}
+			originalCheckCASecretExists := CheckCASecretExists
+			defer func() {
+				CheckCASecretExists = originalCheckCASecretExists
+			}()
+			CheckCASecretExists = mockCheckCASecretExists
+
+			// Create real reconciler
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &InstanaAgentReconciler{
+				client: instanaclient.NewInstanaAgentClient(fakeClient),
+				scheme: scheme,
 			}
 
 			// Test
 			ctx := context.Background()
-			logger := ctrl.Log.WithName("test")
-			result, err := discoverETCDEndpoints(
+			result, err := reconciler.DiscoverETCDEndpoints(
 				ctx,
-				nil, // client not used due to mocks
 				agent,
-				logger,
-				nil, // isOpenShiftFunc not used due to mocks
-				mockShouldSkipDiscovery,
-				mockFindETCDService,
-				mockFindMetricsPortAndScheme,
-				mockBuildTargetsFromEndpoints,
-				mockCheckCASecretExists,
 			)
 
 			// Verify
@@ -1247,303 +1275,4 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper functions that match the signatures of the methods in InstanaAgentReconciler
-// These are the functions we're testing
-
-func shouldSkipDiscovery(
-	ctx context.Context,
-	agent *instanav1.InstanaAgent,
-	logger logr.Logger,
-	isOpenShiftFunc IsOpenShiftFunc,
-) (bool, error) {
-	operatorUtils := operator_utils.NewOperatorUtils(ctx, nil, agent, nil)
-	isOpenShift, isOpenShiftRes := isOpenShiftFunc(ctx, operatorUtils)
-
-	if isOpenShiftRes.suppliesReconcileResult() {
-		return false, fmt.Errorf("failed to determine if cluster is OpenShift")
-	}
-
-	if isOpenShift {
-		logger.Info("Skipping ETCD discovery on OpenShift cluster")
-		return true, nil
-	}
-
-	if len(agent.Spec.K8sSensor.ETCD.Targets) > 0 {
-		logger.Info("Using ETCD targets from CR spec", "targets", agent.Spec.K8sSensor.ETCD.Targets)
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func getServiceWithLabel(
-	ctx context.Context,
-	client client.Client,
-	name, labelKey, labelValue string,
-) (*corev1.Service, error) {
-	service := &corev1.Service{}
-	err := client.Get(ctx, types.NamespacedName{
-		Namespace: kubeSystemNamespace,
-		Name:      name,
-	}, service)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	if service.Labels == nil || service.Labels[labelKey] != labelValue {
-		return nil, nil
-	}
-
-	return service, nil
-}
-
-func getServiceByName(
-	ctx context.Context,
-	client client.Client,
-	name string,
-) (*corev1.Service, error) {
-	service := &corev1.Service{}
-	err := client.Get(ctx, types.NamespacedName{
-		Namespace: kubeSystemNamespace,
-		Name:      name,
-	}, service)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return service, nil
-}
-
-func findETCDService(
-	ctx context.Context,
-	client client.Client,
-	logger logr.Logger,
-) (*corev1.Service, error) {
-	// Try services with component=etcd label first
-	if service, err := getServiceWithLabel(ctx, client, "etcd", "component", "etcd"); err != nil {
-		return nil, err
-	} else if service != nil {
-		logger.Info("Found etcd service with component=etcd label", "name", service.Name)
-		return service, nil
-	}
-
-	if service, err := getServiceWithLabel(ctx, client, "etcd-metrics", "component", "etcd"); err != nil {
-		return nil, err
-	} else if service != nil {
-		logger.Info("Found etcd-metrics service with component=etcd label", "name", service.Name)
-		return service, nil
-	}
-
-	// Fallback to name-based search
-	logger.Info("No service found with component=etcd label, trying by name")
-
-	// Try by name in sequence
-	serviceNames := []string{"etcd", "etcd-metrics", "etcd-k8s"}
-	for _, name := range serviceNames {
-		service, err := getServiceByName(ctx, client, name)
-		if err != nil {
-			return nil, err
-		}
-		if service != nil {
-			return service, nil
-		}
-	}
-
-	return nil, nil
-}
-
-func findMetricsPortAndScheme(service *corev1.Service) (*int32, string) {
-	for _, port := range service.Spec.Ports {
-		if port.Name == "metrics" {
-			// Use switch/case for scheme determination
-			scheme := "https" // Default to https for unknown ports
-			switch port.Port {
-			case constants.ETCDMetricsPortHTTPS:
-				scheme = "https"
-			case constants.ETCDMetricsPortHTTP:
-				scheme = "http"
-			}
-
-			// Check for scheme annotation override
-			if schemeOverride, ok := service.Annotations["instana.io/etcd-scheme"]; ok {
-				scheme = schemeOverride
-			}
-
-			return &port.Port, scheme
-		}
-	}
-
-	return nil, ""
-}
-
-func buildTargetsFromEndpoints(
-	ctx context.Context,
-	k8sClient client.Client,
-	service *corev1.Service,
-	metricsPort int32,
-	scheme string,
-) ([]string, error) {
-	endpointSlices := &discoveryv1.EndpointSliceList{}
-	if err := k8sClient.List(
-		ctx,
-		endpointSlices,
-		client.InNamespace(kubeSystemNamespace),
-		client.MatchingLabels(map[string]string{discoveryv1.LabelServiceName: service.Name}),
-	); err != nil {
-		return nil, err
-	}
-
-	targets := make([]string, 0)
-
-	for i := range endpointSlices.Items {
-		sliceTargets := buildTargetsFromEndpointSlice(&endpointSlices.Items[i], metricsPort, scheme)
-		targets = append(targets, sliceTargets...)
-	}
-
-	if len(targets) == 0 {
-		legacyTargets, err := buildTargetsFromLegacyEndpoints(
-			ctx,
-			k8sClient,
-			service,
-			metricsPort,
-			scheme,
-		)
-		if err != nil {
-			return nil, err
-		}
-		targets = append(targets, legacyTargets...)
-	}
-
-	sort.Strings(targets)
-
-	return targets, nil
-}
-
-func buildTargetsFromLegacyEndpoints(
-	ctx context.Context,
-	k8sClient client.Client,
-	service *corev1.Service,
-	metricsPort int32,
-	scheme string,
-) ([]string, error) {
-	endpoints := &corev1.Endpoints{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{
-		Namespace: kubeSystemNamespace,
-		Name:      service.Name,
-	}, endpoints); err != nil {
-		if apierrors.IsNotFound(err) {
-			return []string{}, nil
-		}
-		return nil, err
-	}
-
-	targets := make([]string, 0)
-
-	for _, subset := range endpoints.Subsets {
-		endpointPort := metricsPort
-		for _, port := range subset.Ports {
-			if port.Name == "metrics" {
-				endpointPort = port.Port
-				break
-			}
-		}
-
-		for _, address := range subset.Addresses {
-			target := fmt.Sprintf("%s://%s:%d/metrics", scheme, address.IP, endpointPort)
-			targets = append(targets, target)
-		}
-	}
-
-	return targets, nil
-}
-
-func checkCASecretExists(
-	ctx context.Context,
-	client client.Client,
-	agent *instanav1.InstanaAgent,
-	logger logr.Logger,
-) bool {
-	caSecret := &corev1.Secret{} // pragma: allowlist secret
-	err := client.Get(ctx, types.NamespacedName{
-		Namespace: agent.Namespace,
-		Name:      constants.ETCDCASecretName,
-	}, caSecret)
-
-	if err == nil {
-		logger.Info("Found etcd-ca secret in agent namespace")
-		return true
-	}
-
-	return false
-}
-
-func discoverETCDEndpoints(
-	ctx context.Context,
-	client client.Client,
-	agent *instanav1.InstanaAgent,
-	logger logr.Logger,
-	isOpenShiftFunc IsOpenShiftFunc,
-	shouldSkipDiscoveryFunc SkipDiscoveryFunc,
-	findETCDServiceFunc FindServiceFunc,
-	findMetricsPortAndSchemeFunc FindPortAndSchemeFunc,
-	buildTargetsFromEndpointsFunc BuildTargetsFunc,
-	checkCASecretExistsFunc CheckCASecretFunc,
-) (*DiscoveredETCDTargets, error) {
-	// Step 1: Check if discovery should be skipped
-	shouldSkip, err := shouldSkipDiscoveryFunc(ctx, agent, logger, isOpenShiftFunc)
-	if err != nil {
-		return nil, err
-	}
-	if shouldSkip {
-		return nil, nil
-	}
-
-	// Step 2: Find etcd service
-	etcdService, err := findETCDServiceFunc(ctx, client, logger)
-	if err != nil {
-		return nil, err
-	}
-	if etcdService == nil {
-		return nil, nil
-	}
-
-	logger.Info("Found etcd service", "name", etcdService.Name)
-
-	// Step 3: Find metrics port and determine scheme
-	metricsPortPtr, scheme := findMetricsPortAndSchemeFunc(etcdService)
-	if metricsPortPtr == nil {
-		logger.Info("No metrics port found in etcd service")
-		return nil, nil
-	}
-	metricsPort := *metricsPortPtr
-
-	// Step 4: Get endpoints and build targets
-	targets, err := buildTargetsFromEndpointsFunc(ctx, client, etcdService, metricsPort, scheme)
-	if err != nil {
-		return nil, err
-	}
-	if len(targets) == 0 {
-		logger.Info("No endpoints found for etcd service")
-		return nil, nil
-	}
-
-	// Step 5: Check for CA secret and return results
-	caSecretExists := checkCASecretExistsFunc(ctx, client, agent, logger)
-
-	logger.Info("Discovered etcd targets", "targets", targets, "caFound", caSecretExists)
-
-	return &DiscoveredETCDTargets{
-		Targets: targets,
-		CAFound: caSecretExists,
-	}, nil
 }

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -103,17 +103,22 @@ func NewInstanaAgentReconciler(
 	scheme *runtime.Scheme,
 	recorder record.EventRecorder,
 ) *InstanaAgentReconciler {
-	return &InstanaAgentReconciler{
-		client:   instanaclient.NewInstanaAgentClient(client),
+	instanaClient := instanaclient.NewInstanaAgentClient(client)
+	reconciler := &InstanaAgentReconciler{
+		client:   instanaClient,
 		recorder: recorder,
 		scheme:   scheme,
 	}
+	// Initialize the ETCD discoverer with the reconciler
+	reconciler.etcdDiscoverer = NewDefaultETCDDiscoverer(instanaClient, reconciler)
+	return reconciler
 }
 
 type InstanaAgentReconciler struct {
-	client   instanaclient.InstanaAgentClient
-	recorder record.EventRecorder
-	scheme   *runtime.Scheme
+	client         instanaclient.InstanaAgentClient
+	recorder       record.EventRecorder
+	scheme         *runtime.Scheme
+	etcdDiscoverer ETCDDiscoverer
 }
 
 func (r *InstanaAgentReconciler) reconcile(
@@ -148,7 +153,7 @@ func (r *InstanaAgentReconciler) reconcile(
 		return addFinalizerRes
 	}
 
-	isOpenShift, isOpenShiftRes := IsOpenShift(r, ctx, operatorUtils)
+	isOpenShift, isOpenShiftRes := r.isOpenShift(ctx, operatorUtils)
 	if isOpenShiftRes.suppliesReconcileResult() {
 		return isOpenShiftRes
 	}

--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -148,7 +148,7 @@ func (r *InstanaAgentReconciler) reconcile(
 		return addFinalizerRes
 	}
 
-	isOpenShift, isOpenShiftRes := r.isOpenShift(ctx, operatorUtils)
+	isOpenShift, isOpenShiftRes := IsOpenShift(r, ctx, operatorUtils)
 	if isOpenShiftRes.suppliesReconcileResult() {
 		return isOpenShiftRes
 	}

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -33,8 +33,7 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 )
 
-var IsOpenShift = func(
-	r *InstanaAgentReconciler,
+func (r *InstanaAgentReconciler) isOpenShift(
 	ctx context.Context,
 	operatorUtils operator_utils.OperatorUtils,
 ) (

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -33,7 +33,8 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 )
 
-func (r *InstanaAgentReconciler) isOpenShift(
+var IsOpenShift = func(
+	r *InstanaAgentReconciler,
 	ctx context.Context,
 	operatorUtils operator_utils.OperatorUtils,
 ) (
@@ -77,7 +78,6 @@ func (r *InstanaAgentReconciler) shouldSetPersistHostUniqueIDEnvVar(
 		Name:      dsName,
 		Namespace: agent.Namespace,
 	}, existingDS)
-
 	// If DaemonSet doesn't exist, this is a new deployment - set the env var
 	if err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
## Why

ETCD discovery tests were often not exercising production code paths but test duplicates, which has all the problems of code duplication and some more.

## What

Remove the test dupicates and test production code.

## References

<!-- Please include links to other artifacts related to this code change. -->

- INSTA-76421

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
