### PR TITLE
fix: revert k8sensor security context tightening

### DIFF
--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -316,16 +316,6 @@ func (d *deploymentBuilder) build() *appsv1.Deployment {
 							Ports: []corev1.ContainerPort{
 								ports.InstanaAgentAPIPortConfig.AsContainerPort(),
 							},
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser:                pointer.To(int64(1000)),
-								RunAsGroup:               pointer.To(int64(1000)),
-								RunAsNonRoot:             pointer.To(true),
-								ReadOnlyRootFilesystem:   pointer.To(true),
-								AllowPrivilegeEscalation: pointer.To(false),
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{"all"},
-								},
-							},
 						},
 					},
 					// k8sensor is run as a "k8sensor" user (i.e: uid 1000), and thus reading the files from the secret volume


### PR DESCRIPTION
## Why
We need to revert k8sensor updated security context, so that we can test it properly

## What
Forward reverted the commit made for it. 

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
