### PR TITLE
[INSTA-86323] feat: add NODE_NAME environment variable to agent pods

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -52,6 +52,23 @@ spec:
               optional: true
 ```
 
+## Automatically Injected Environment Variables
+
+The operator automatically injects certain environment variables into agent pods using the Kubernetes Downward API:
+
+- **NODE_NAME**: Set to [`spec.nodeName`](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) - the name of the Kubernetes node where the pod is running. This is used by the agent to avoid DNS lookups for hostname resolution, improving startup performance and reducing CoreDNS load.
+
+Example of the automatically injected NODE_NAME:
+```yaml
+env:
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+```
+
+You can override this by explicitly setting NODE_NAME in your `agent.pod.env` configuration if needed.
+
 ## Supported ValueFrom Sources
 
 The enhanced method supports all standard Kubernetes environment variable sources:

--- a/e2e/agent_id_persistence_test.go
+++ b/e2e/agent_id_persistence_test.go
@@ -26,10 +26,8 @@ func TestAgentIDPersistence(t *testing.T) {
 	agent := NewAgentCr()
 
 	agentIDPersistenceFeature := features.New("agent ID persistence across pod restarts").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("wait for k8sensor deployment to become ready",
 			WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready",

--- a/e2e/agent_remote_test_api.go
+++ b/e2e/agent_remote_test_api.go
@@ -96,13 +96,6 @@ func WaitForAgentRemoteSuccessfulBackendConnection() e2etypes.StepFunc {
 			t.Fatal(err)
 		}
 		time.Sleep(20 * time.Second)
-		podList, err := clientSet.CoreV1().Pods(cfg.Namespace()).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=instana-agent-remote"})
-		if err != nil {
-			log.Fatal(err)
-		}
-		if len(podList.Items) == 0 {
-			log.Fatal("No pods found")
-		}
 
 		connectionSuccessful := false
 		var buf *bytes.Buffer
@@ -110,10 +103,31 @@ func WaitForAgentRemoteSuccessfulBackendConnection() e2etypes.StepFunc {
 			log.Info("Sleeping 20 seconds")
 			time.Sleep(20 * time.Second)
 			log.Info("Fetching logs")
-			logReq := clientSet.CoreV1().Pods(cfg.Namespace()).GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{})
+
+			// Re-fetch pod list to handle pod recreation during upgrades
+			podList, err := clientSet.CoreV1().
+				Pods(cfg.Namespace()).
+				List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=instana-agent-remote"})
+			if err != nil {
+				log.Infof("Could not list pods: %v, will retry", err)
+				continue
+			}
+			if len(podList.Items) == 0 {
+				log.Info("No pods found, will retry")
+				continue
+			}
+
+			logReq := clientSet.CoreV1().
+				Pods(cfg.Namespace()).
+				GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{})
 			podLogs, err := logReq.Stream(ctx)
 			if err != nil {
-				log.Fatal("Could not stream logs", err)
+				log.Infof(
+					"Could not stream logs from pod %s: %v, will retry",
+					podList.Items[0].Name,
+					err,
+				)
+				continue
 			}
 			defer podLogs.Close()
 
@@ -121,7 +135,12 @@ func WaitForAgentRemoteSuccessfulBackendConnection() e2etypes.StepFunc {
 			_, err = io.Copy(buf, podLogs)
 
 			if err != nil {
-				log.Fatal(err)
+				log.Infof(
+					"Error copying logs from pod %s: %v, will retry",
+					podList.Items[0].Name,
+					err,
+				)
+				continue
 			}
 			if strings.Contains(buf.String(), "Connected using HTTP/2 to") {
 				log.Info("Connection established correctly")
@@ -148,7 +167,13 @@ func EnsureAgentRemoteDeletion() env.Func {
 
 		p = utils.RunCommand("kubectl get agentremote remote-agent -o yaml -n instana-agent")
 		// redact agent key if present
-		log.Info("Current agent remote CR: ", p.Command(), p.ExitCode(), "\n", strings.ReplaceAll(p.Result(), InstanaTestCfg.InstanaBackend.AgentKey, "***"))
+		log.Info(
+			"Current agent remote CR: ",
+			p.Command(),
+			p.ExitCode(),
+			"\n",
+			strings.ReplaceAll(p.Result(), InstanaTestCfg.InstanaBackend.AgentKey, "***"),
+		)
 
 		// Cleanup a potentially existing Agent CR first
 		if _, err := DeleteAgentRemoteCRIfPresent()(ctx, cfg); err != nil {
@@ -159,7 +184,13 @@ func EnsureAgentRemoteDeletion() env.Func {
 
 		p = utils.RunCommand("kubectl delete crd/agentsremote.instana.io")
 		if p.Err() != nil {
-			log.Warningf("Could not remove some artifacts, ignoring as they might not be present %s - %s - %s - %d", p.Command(), p.Err(), p.Out(), p.ExitCode())
+			log.Warningf(
+				"Could not remove some artifacts, ignoring as they might not be present %s - %s - %s - %d",
+				p.Command(),
+				p.Err(),
+				p.Out(),
+				p.ExitCode(),
+			)
 		}
 
 		log.Info("==== Cleanup completed ====")
@@ -193,7 +224,11 @@ func AdjustOcpPermissionsIfNecessaryRemote() env.Func {
 
 		if isOpenShift {
 			command := "oc adm policy add-scc-to-user anyuid -z instana-agent-remote -n instana-agent"
-			log.Infof("OpenShift detected, adding instana-agent-remote service account to SecurityContextConstraints via api, command would be: %s\n", command)
+			log.Infof(
+				"OpenShift detected, adding instana-agent-remote service account to "+
+					"SecurityContextConstraints via api, command would be: %s\n",
+				command,
+			)
 
 			// Define the GVR for SecurityContextConstraints
 			sccGVR := schema.GroupVersionResource{
@@ -225,11 +260,18 @@ func AdjustOcpPermissionsIfNecessaryRemote() env.Func {
 			}
 
 			// Check if service account is already in the list
-			serviceAccountId := fmt.Sprintf("system:serviceaccount:%s:%s", InstanaNamespace, "instana-agent-remote")
+			serviceAccountId := fmt.Sprintf(
+				"system:serviceaccount:%s:%s",
+				InstanaNamespace,
+				"instana-agent-remote",
+			)
 			userFound := slices.Contains(users, serviceAccountId)
 
 			if userFound {
-				log.Infof("Security Context Constraint \"anyuid\" already lists service account user: %v\n", serviceAccountId)
+				log.Infof(
+					"Security Context Constraint \"anyuid\" already lists service account user: %v\n",
+					serviceAccountId,
+				)
 				return ctx, nil
 			}
 
@@ -243,7 +285,10 @@ func AdjustOcpPermissionsIfNecessaryRemote() env.Func {
 			_, err = dynamicClient.Resource(sccGVR).
 				Update(ctx, sccUnstructured, metav1.UpdateOptions{})
 			if err != nil {
-				return ctx, fmt.Errorf("could not update Security Context Constraints on OCP cluster: %v", err)
+				return ctx, fmt.Errorf(
+					"could not update Security Context Constraints on OCP cluster: %v",
+					err,
+				)
 			}
 
 			return ctx, nil
@@ -261,7 +306,10 @@ func DeleteAgentRemoteCRIfPresent() env.Func {
 		// Create a client to interact with the Kube API
 		r, err := resources.New(cfg.Client().RESTConfig())
 		if err != nil {
-			return ctx, fmt.Errorf("cleanup: Error initializing client to delete agent remote CR: %v", err)
+			return ctx, fmt.Errorf(
+				"cleanup: Error initializing client to delete agent remote CR: %v",
+				err,
+			)
 		}
 
 		// Assume an existing namespace at this point, check if an agent remote CR is present (requires to adjust schema of current client)
@@ -269,7 +317,10 @@ func DeleteAgentRemoteCRIfPresent() env.Func {
 		err = v1.AddToScheme(r.GetScheme())
 		if err != nil {
 			// If this fails, the cleanup will not work properly -> failing
-			return ctx, fmt.Errorf("cleanup: Error could not add agent remote types to current scheme: %v", err)
+			return ctx, fmt.Errorf(
+				"cleanup: Error could not add agent remote types to current scheme: %v",
+				err,
+			)
 		}
 
 		// If the agent remote cr is available, but the operator is already gone, the finalizer will never be removed

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -887,7 +887,12 @@ func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 				GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{})
 			podLogs, err := logReq.Stream(ctx)
 			if err != nil {
-				t.Fatal("Could not stream logs", err)
+				t.Logf(
+					"Could not stream logs from pod %s: %v, will retry",
+					podList.Items[0].Name,
+					err,
+				)
+				continue
 			}
 			defer podLogs.Close()
 
@@ -895,7 +900,8 @@ func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 			_, err = io.Copy(buf, podLogs)
 
 			if err != nil {
-				t.Fatal(err)
+				t.Logf("Error copying logs from pod %s: %v, will retry", podList.Items[0].Name, err)
+				continue
 			}
 			if strings.Contains(buf.String(), "Connected using HTTP/2 to") {
 				t.Log("Connection established correctly")

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -863,15 +863,6 @@ func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 			t.Fatal(err)
 		}
 		time.Sleep(20 * time.Second)
-		podList, err := clientSet.CoreV1().
-			Pods(cfg.Namespace()).
-			List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=instana-agent"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(podList.Items) == 0 {
-			t.Fatal("No pods found")
-		}
 
 		connectionSuccessful := false
 		var buf *bytes.Buffer
@@ -879,6 +870,18 @@ func WaitForAgentSuccessfulBackendConnection() e2etypes.StepFunc {
 			t.Log("Sleeping 20 seconds")
 			time.Sleep(20 * time.Second)
 			t.Log("Fetching logs")
+
+			// Re-fetch pod list to handle pod recreation during upgrades
+			podList, err := clientSet.CoreV1().
+				Pods(cfg.Namespace()).
+				List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=instana-agent"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(podList.Items) == 0 {
+				t.Fatal("No pods found")
+			}
+
 			logReq := clientSet.CoreV1().
 				Pods(cfg.Namespace()).
 				GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{})

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -548,6 +548,33 @@ func SetupOperatorDevBuild() e2etypes.StepFunc {
 		if err := ensureOperatorHasPullSecret(ctx, cfg); err != nil {
 			t.Fatalf("Failed to ensure operator pull secret: %v", err)
 		}
+
+		// Wait for operator deployment to be ready before proceeding
+		// This ensures the controller is fully started and watching for CRs
+		// Fixes race condition where CR is created before controller is ready
+		t.Log("Waiting for operator deployment to be ready")
+		client, err := cfg.NewClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		dep := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      InstanaOperatorDeploymentName,
+				Namespace: cfg.Namespace(),
+			},
+		}
+
+		// Wait for deployment to exist and be ready
+		err = wait.For(
+			conditions.New(client.Resources()).
+				DeploymentConditionMatch(&dep, appsv1.DeploymentAvailable, corev1.ConditionTrue),
+			wait.WithTimeout(time.Minute*2),
+		)
+		if err != nil {
+			t.Fatalf("Operator deployment did not become ready: %v", err)
+		}
+		t.Log("Operator deployment is ready")
+
 		return ctx
 	}
 }

--- a/e2e/agentremote_install_test.go
+++ b/e2e/agentremote_install_test.go
@@ -18,9 +18,8 @@ import (
 func TestInitialRemoteInstall(t *testing.T) {
 	agent := NewAgentRemoteCr(AgentRemoteCustomResourceName)
 	initialInstallFeature := features.New("initial install dev-operator-build").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("check for single instance of instana-agent-controller-manager", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			r, err := resources.New(cfg.Client().RESTConfig())
 			if err != nil {
@@ -69,9 +68,8 @@ func TestUpdateRemoteInstall(t *testing.T) {
 	// 	Feature()
 
 	updateInstallDevBuildFeature := features.New("install dev-operator-build").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("wait for instana remote agent deployment to become ready", WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName)).
 		Assess("check agent log for successful connection", WaitForAgentRemoteSuccessfulBackendConnection()).
 		Feature()

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -20,9 +20,8 @@ import (
 func TestInitialInstall(t *testing.T) {
 	agent := NewAgentCr()
 	initialInstallFeature := features.New("initial install dev-operator-build").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("check for single instance of instana-agent-controller-manager", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			r, err := resources.New(cfg.Client().RESTConfig())
 			if err != nil {
@@ -84,7 +83,7 @@ func TestUpdateInstall(t *testing.T) {
 
 	updateInstallDevBuildFeature := features.New("upgrade install from latest released to dev-operator-build").
 		Setup(SetupOperatorDevBuild()).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		// Now waits for operator to be ready
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).

--- a/e2e/install_with_pdb_test.go
+++ b/e2e/install_with_pdb_test.go
@@ -20,9 +20,8 @@ func TestInstallWithK8sensorPodDisruptionBudget(t *testing.T) {
 	enabled := true
 	agent.Spec.K8sSensor.PodDisruptionBudget.Enabled = &enabled
 	f := features.New("install dev-operator-build and enable k8sensor podDisruptionBudget").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("check if instana-agent-controller-manager was able to deploy a podDisruptionBudget for the k8sensor", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			r, err := resources.New(cfg.Client().RESTConfig())

--- a/e2e/multi_backend_test.go
+++ b/e2e/multi_backend_test.go
@@ -249,8 +249,8 @@ func TestRemovalOfAdditionalBackend(t *testing.T) {
 
 	installDevBuildWithTwoAdditionalBackendsFeature := features.New("install with 2 additional backends").
 		Setup(SetupOperatorDevBuild()).
+		// Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName+"-1")).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName+"-2")).

--- a/e2e/multi_backend_test.go
+++ b/e2e/multi_backend_test.go
@@ -162,6 +162,11 @@ func TestMultiBackendSupportExternalSecretWithSecretMounts(t *testing.T) {
 			fmt.Sprintf("%s-1", K8sensorDeploymentName)),
 		).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreated(),
+		).
 		Assess("validate instana-agent-config secret contains 2 backends", ValidateAgentMultiBackendConfiguration()).
 		Assess("validate secret files are mounted correctly", ValidateSecretFilesMounted()).
 		Assess("validate sensitive environment variables are not set", ValidateSensitiveEnvVarsNotSet()).

--- a/e2e/namespace_configmap_test.go
+++ b/e2e/namespace_configmap_test.go
@@ -25,9 +25,8 @@ import (
 func TestNamespaceLabelConfigmap(t *testing.T) {
 	agent := NewAgentCr()
 	installAndCheckNamespaceLabels := features.New("check namespace configmap in agent pods").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent pod for namespaces label file", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {

--- a/e2e/secret_mounts_test.go
+++ b/e2e/secret_mounts_test.go
@@ -797,6 +797,11 @@ func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
 		Assess("wait for remote agent deployment to become ready after second update",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).
+		// Add a delay to ensure pods are fully recreated with secret mounts
+		Assess(
+			"wait for pods to be recreated with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
+		).
 		Assess("validate secret files are mounted correctly in remote agent after switching back",
 			ValidateRemoteSecretFilesMounted(),
 		).
@@ -905,6 +910,9 @@ func ValidateRemoteSecretFilesMounted() features.Func {
 		}
 
 		secretSource := secretVolumeSourceFromPod(&pod)
+		if secretSource == nil {
+			t.Fatalf("instana-secrets volume not found in remote agent pod %s", pod.Name)
+		}
 		ensureSecretFilePresent(t, ctx, r, cfg.Namespace(), secretSource, constants.SecretFileAgentKey)
 
 		return ctx

--- a/e2e/secret_mounts_test.go
+++ b/e2e/secret_mounts_test.go
@@ -685,6 +685,11 @@ func TestSecretMountsDefaultBehavior(t *testing.T) {
 		Setup(DeployAgentCr(&agent)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreated(),
+		).
 		Assess("validate secret files are mounted correctly", ValidateSecretFilesMounted()).
 		Assess("validate sensitive environment variables are not set", ValidateSensitiveEnvVarsNotSet()).
 		Assess("validate k8sensor uses agent-key-file argument", ValidateK8sensorAgentKeyFileArg()).
@@ -751,6 +756,11 @@ func TestSecretMountsHttpsProxyFile(t *testing.T) {
 		Setup(DeployAgentCr(&agent)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreated(),
+		).
 		Assess("validate https-proxy-file argument is used", ValidateHttpsProxyFileArg()).
 		Assess("validate HTTPS_PROXY secret file is mounted", ValidateHttpsProxyFileMounted()).
 		Feature()
@@ -770,6 +780,11 @@ func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
 		Assess("wait for remote agent deployment to become ready", WaitForDeploymentToBecomeReady(
 			AgentRemoteDeploymentName+AgentRemoteCustomResourceName,
 		)).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
+		).
 		Assess("validate secret files are mounted correctly in remote agent", ValidateRemoteSecretFilesMounted()).
 		Assess("validate sensitive environment variables are not set in remote agent",
 			ValidateRemoteSensitiveEnvVarsNotSet(),
@@ -806,6 +821,11 @@ func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
 		Setup(DeployAgentRemoteCr(&agent)).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
+		).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
 		).
 		Assess("validate secret files are mounted correctly in remote agent", ValidateRemoteSecretFilesMounted()).
 		Setup(UpdateAgentRemoteWithSecretMounts(false)).
@@ -853,6 +873,11 @@ func TestRemoteSecretMountsHttpsProxyFile(t *testing.T) {
 		Setup(DeployAgentRemoteCr(&agent)).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
+		).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
 		).
 		Assess("validate secret files are mounted correctly in remote agent", ValidateRemoteSecretFilesMounted()).
 		Feature()

--- a/e2e/secret_mounts_test.go
+++ b/e2e/secret_mounts_test.go
@@ -189,36 +189,42 @@ func ValidateSecretFilesMounted() features.Func {
 
 		listOps := resources.WithLabelSelector("app.kubernetes.io/component=instana-agent")
 
-		waitErr := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
-			pods := &corev1.PodList{}
-			if err := r.List(ctx, pods, listOps); err != nil {
-				return false, err
-			}
-			if len(pods.Items) == 0 {
-				t.Log("Waiting for agent pods to be created before validating secret mounts")
-				return false, nil
-			}
-
-			for _, pod := range pods.Items {
-				if !hasDaemonSetOwner(&pod) {
-					continue
+		waitErr := wait.PollUntilContextTimeout(
+			ctx,
+			pollInterval,
+			pollTimeout,
+			true,
+			func(ctx context.Context) (bool, error) {
+				pods := &corev1.PodList{}
+				if err := r.List(ctx, pods, listOps); err != nil {
+					return false, err
 				}
-
-				container := firstContainerOrFail(t, &pod)
-				if !hasVolumeMountAt(container, constants.InstanaSecretsDirectory) {
-					t.Logf("Pod %s missing secrets volume mount; waiting", pod.Name)
+				if len(pods.Items) == 0 {
+					t.Log("Waiting for agent pods to be created before validating secret mounts")
 					return false, nil
 				}
 
-				secretSource := secretVolumeSourceFromPod(&pod)
-				if secretSource == nil {
-					t.Logf("Pod %s missing secrets volume source; waiting", pod.Name)
-					return false, nil
-				}
-			}
+				for _, pod := range pods.Items {
+					if !hasDaemonSetOwner(&pod) {
+						continue
+					}
 
-			return true, nil
-		})
+					container := firstContainerOrFail(t, &pod)
+					if !hasVolumeMountAt(container, constants.InstanaSecretsDirectory) {
+						t.Logf("Pod %s missing secrets volume mount; waiting", pod.Name)
+						return false, nil
+					}
+
+					secretSource := secretVolumeSourceFromPod(&pod)
+					if secretSource == nil {
+						t.Logf("Pod %s missing secrets volume source; waiting", pod.Name)
+						return false, nil
+					}
+				}
+
+				return true, nil
+			},
+		)
 		if waitErr != nil {
 			t.Fatalf("instana agent pods did not mount secrets volume in time: %v", waitErr)
 		}
@@ -243,7 +249,14 @@ func ValidateSecretFilesMounted() features.Func {
 				t.Fatalf("pod %s missing secrets volume source after wait", pod.Name)
 			}
 
-			ensureSecretFilePresent(t, ctx, r, cfg.Namespace(), secretSource, constants.SecretFileAgentKey)
+			ensureSecretFilePresent(
+				t,
+				ctx,
+				r,
+				cfg.Namespace(),
+				secretSource,
+				constants.SecretFileAgentKey,
+			)
 			t.Logf("Pod %s mounts instana secrets volume", pod.Name)
 		}
 
@@ -316,35 +329,50 @@ func ValidateSensitiveEnvVarsSet() features.Func {
 			pollTimeout  = 2 * time.Minute
 		)
 
-		waitErr := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
-			pods := &corev1.PodList{}
-			if err := r.List(ctx, pods, listOps); err != nil {
-				return false, err
-			}
-			if len(pods.Items) == 0 {
-				t.Log("Waiting for agent pods to be created before checking environment variables")
-				return false, nil
-			}
-
-			for _, pod := range pods.Items {
-				if len(pod.Spec.Containers) == 0 {
-					t.Logf("Pod %s has no containers yet; waiting", pod.Name)
+		waitErr := wait.PollUntilContextTimeout(
+			ctx,
+			pollInterval,
+			pollTimeout,
+			true,
+			func(ctx context.Context) (bool, error) {
+				pods := &corev1.PodList{}
+				if err := r.List(ctx, pods, listOps); err != nil {
+					return false, err
+				}
+				if len(pods.Items) == 0 {
+					t.Log(
+						"Waiting for agent pods to be created before checking environment variables",
+					)
 					return false, nil
 				}
 
-				container := &pod.Spec.Containers[0]
-				for _, envName := range sensitiveEnvVars {
-					if env := findEnvVar(container, envName); env == nil {
-						t.Logf("Pod %s missing environment variable %s; waiting", pod.Name, envName)
+				for _, pod := range pods.Items {
+					if len(pod.Spec.Containers) == 0 {
+						t.Logf("Pod %s has no containers yet; waiting", pod.Name)
 						return false, nil
 					}
-				}
-			}
 
-			return true, nil
-		})
+					container := &pod.Spec.Containers[0]
+					for _, envName := range sensitiveEnvVars {
+						if env := findEnvVar(container, envName); env == nil {
+							t.Logf(
+								"Pod %s missing environment variable %s; waiting",
+								pod.Name,
+								envName,
+							)
+							return false, nil
+						}
+					}
+				}
+
+				return true, nil
+			},
+		)
 		if waitErr != nil {
-			t.Fatalf("Sensitive environment variables were not set after switching legacy mode: %v", waitErr)
+			t.Fatalf(
+				"Sensitive environment variables were not set after switching legacy mode: %v",
+				waitErr,
+			)
 		}
 
 		pods := &corev1.PodList{}
@@ -359,7 +387,12 @@ func ValidateSensitiveEnvVarsSet() features.Func {
 			container := firstContainerOrFail(t, &pod)
 			for _, envVar := range sensitiveEnvVars {
 				if env := findEnvVar(container, envVar); env != nil {
-					t.Logf("Sensitive environment variable %s is set in pod %s (%s)", envVar, pod.Name, describeEnvVar(env))
+					t.Logf(
+						"Sensitive environment variable %s is set in pod %s (%s)",
+						envVar,
+						pod.Name,
+						describeEnvVar(env),
+					)
 				}
 			}
 		}
@@ -580,7 +613,10 @@ func WaitForPodsToBeRecreated() features.Func {
 // WaitForPodsToBeRecreatedForComponent waits for pods matching the provided component label to be recreated after a configuration change.
 func WaitForPodsToBeRecreatedForComponent(component string) features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		t.Logf("Waiting for pods with component %q to be recreated with new configuration", component)
+		t.Logf(
+			"Waiting for pods with component %q to be recreated with new configuration",
+			component,
+		)
 
 		r, err := resources.New(cfg.Client().RESTConfig())
 		if err != nil {
@@ -592,34 +628,48 @@ func WaitForPodsToBeRecreatedForComponent(component string) features.Func {
 		const pollInterval = 2 * time.Second
 		const pollTimeout = 2 * time.Minute
 
-		waitErr := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
-			pods := &corev1.PodList{}
-			if err := r.List(ctx, pods, listOps); err != nil {
-				return false, err
-			}
-			if len(pods.Items) == 0 {
-				t.Logf("Waiting for pods with component %q to be recreated...", component)
-				return false, nil
-			}
-			allRunning := true
-			for _, pod := range pods.Items {
-				if pod.Status.Phase != corev1.PodRunning {
-					allRunning = false
-					t.Logf("Pod %s is in phase %s; waiting...", pod.Name, pod.Status.Phase)
-					break
+		waitErr := wait.PollUntilContextTimeout(
+			ctx,
+			pollInterval,
+			pollTimeout,
+			true,
+			func(ctx context.Context) (bool, error) {
+				pods := &corev1.PodList{}
+				if err := r.List(ctx, pods, listOps); err != nil {
+					return false, err
 				}
-			}
-			return allRunning, nil
-		})
+				if len(pods.Items) == 0 {
+					t.Logf("Waiting for pods with component %q to be recreated...", component)
+					return false, nil
+				}
+				allRunning := true
+				for _, pod := range pods.Items {
+					if pod.Status.Phase != corev1.PodRunning {
+						allRunning = false
+						t.Logf("Pod %s is in phase %s; waiting...", pod.Name, pod.Status.Phase)
+						break
+					}
+				}
+				return allRunning, nil
+			},
+		)
 		if waitErr != nil {
-			t.Fatalf("pods with component %q were not ready after configuration change: %v", component, waitErr)
+			t.Fatalf(
+				"pods with component %q were not ready after configuration change: %v",
+				component,
+				waitErr,
+			)
 		}
 
 		pods := &corev1.PodList{}
 		if err := r.List(ctx, pods, listOps); err != nil {
 			t.Fatal("failed to list pods after wait:", err)
 		}
-		t.Logf("Found %d pods with component %q after configuration change", len(pods.Items), component)
+		t.Logf(
+			"Found %d pods with component %q after configuration change",
+			len(pods.Items),
+			component,
+		)
 		return ctx
 	}
 }
@@ -630,11 +680,9 @@ func TestSecretMountsDefaultBehavior(t *testing.T) {
 
 	defaultBehaviorFeature := features.New("secret mounts default behavior (useSecretMounts: true)").
 		Setup(SetupOperatorDevBuild()).
+
+		// Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("validate secret files are mounted correctly", ValidateSecretFilesMounted()).
@@ -650,12 +698,8 @@ func TestSecretMountsLegacyBehavior(t *testing.T) {
 	agent := NewAgentCrWithSecretMounts(false)
 
 	legacyBehaviorFeature := features.New("secret mounts legacy behavior (useSecretMounts: false)").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("validate sensitive environment variables are set", ValidateSensitiveEnvVarsSet()).
@@ -670,12 +714,8 @@ func TestSecretMountsSwitchingModes(t *testing.T) {
 	agent := NewAgentCrWithSecretMounts(true)
 
 	switchingModesFeature := features.New("switching between secret mounts modes").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("validate secret files are mounted correctly", ValidateSecretFilesMounted()).
@@ -707,12 +747,8 @@ func TestSecretMountsHttpsProxyFile(t *testing.T) {
 	}
 
 	httpsProxyFeature := features.New("https-proxy-file functionality").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("validate https-proxy-file argument is used", ValidateHttpsProxyFileArg()).
@@ -728,11 +764,9 @@ func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
 
 	defaultBehaviorFeature := features.New("remote agent secret mounts default behavior (useSecretMounts: true)").
 		Setup(SetupOperatorDevBuild()).
+
+		// Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready", WaitForDeploymentToBecomeReady(
 			AgentRemoteDeploymentName+AgentRemoteCustomResourceName,
 		)).
@@ -751,11 +785,9 @@ func TestRemoteSecretMountsLegacyBehavior(t *testing.T) {
 
 	legacyBehaviorFeature := features.New("remote agent secret mounts legacy behavior (useSecretMounts: false)").
 		Setup(SetupOperatorDevBuild()).
+
+		// Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).
@@ -770,12 +802,8 @@ func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
 	agent := NewAgentRemoteCrWithSecretMounts(true)
 
 	switchingModesFeature := features.New("switching between remote agent secret mounts modes").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).
@@ -821,12 +849,8 @@ func TestRemoteSecretMountsHttpsProxyFile(t *testing.T) {
 	}
 
 	httpsProxyFeature := features.New("remote agent https-proxy-file functionality").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).
@@ -906,14 +930,24 @@ func ValidateRemoteSecretFilesMounted() features.Func {
 		pod := pods.Items[0]
 		container := firstContainerOrFail(t, &pod)
 		if !hasVolumeMountAt(container, constants.InstanaSecretsDirectory) {
-			t.Errorf("remote agent container does not mount secrets directory at %s", constants.InstanaSecretsDirectory)
+			t.Errorf(
+				"remote agent container does not mount secrets directory at %s",
+				constants.InstanaSecretsDirectory,
+			)
 		}
 
 		secretSource := secretVolumeSourceFromPod(&pod)
 		if secretSource == nil {
 			t.Fatalf("instana-secrets volume not found in remote agent pod %s", pod.Name)
 		}
-		ensureSecretFilePresent(t, ctx, r, cfg.Namespace(), secretSource, constants.SecretFileAgentKey)
+		ensureSecretFilePresent(
+			t,
+			ctx,
+			r,
+			cfg.Namespace(),
+			secretSource,
+			constants.SecretFileAgentKey,
+		)
 
 		return ctx
 	}

--- a/e2e/secret_mounts_test.go
+++ b/e2e/secret_mounts_test.go
@@ -642,15 +642,43 @@ func WaitForPodsToBeRecreatedForComponent(component string) features.Func {
 					t.Logf("Waiting for pods with component %q to be recreated...", component)
 					return false, nil
 				}
-				allRunning := true
+
+				// Check if all pods are from the same replica set and all are running
+				replicaSets := make(map[string]int)
+				runningCount := 0
 				for _, pod := range pods.Items {
-					if pod.Status.Phase != corev1.PodRunning {
-						allRunning = false
+					// Extract replica set name from pod name (format: deployment-replicaset-pod)
+					// e.g., "instana-agent-r-remote-agent-85959668c5-mjjbq" -> "85959668c5"
+					parts := strings.Split(pod.Name, "-")
+					if len(parts) >= 2 {
+						rsHash := parts[len(parts)-2]
+						replicaSets[rsHash]++
+					}
+
+					if pod.DeletionTimestamp != nil {
+						t.Logf("Pod %s is terminating; waiting for cleanup...", pod.Name)
+						return false, nil
+					}
+
+					if pod.Status.Phase == corev1.PodRunning {
+						runningCount++
+					} else {
 						t.Logf("Pod %s is in phase %s; waiting...", pod.Name, pod.Status.Phase)
-						break
+						return false, nil
 					}
 				}
-				return allRunning, nil
+
+				// Ensure all pods are from the same replica set (no old pods lingering)
+				if len(replicaSets) > 1 {
+					t.Logf(
+						"Multiple replica sets detected (%d), waiting for old pods to terminate...",
+						len(replicaSets),
+					)
+					return false, nil
+				}
+
+				// All pods must be running
+				return runningCount == len(pods.Items), nil
 			},
 		)
 		if waitErr != nil {
@@ -685,6 +713,7 @@ func TestSecretMountsDefaultBehavior(t *testing.T) {
 		Setup(DeployAgentCr(&agent)).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
+
 		// Add a delay to ensure pods are fully created with secret mounts
 		Assess(
 			"wait for pods to be created with secret mounts",
@@ -780,6 +809,7 @@ func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
 		Assess("wait for remote agent deployment to become ready", WaitForDeploymentToBecomeReady(
 			AgentRemoteDeploymentName+AgentRemoteCustomResourceName,
 		)).
+
 		// Add a delay to ensure pods are fully created with secret mounts
 		Assess(
 			"wait for pods to be created with secret mounts",

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -56,7 +56,7 @@ func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
 
 	updateInstallDevBuildFeature := features.New("upgrade install from latest released to dev-operator-build").
 		Setup(SetupOperatorDevBuild()).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		// Now waits for operator to be ready
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset.go
@@ -135,6 +135,7 @@ func (d *daemonSetBuilder) getEnvVars() []corev1.EnvVar {
 		env.DownloadKeyEnv,
 		env.InstanaAgentPodNameEnv,
 		env.PodIPEnv,
+		env.NodeNameEnv,
 		env.K8sServiceDomainEnv,
 		env.EnableAgentSocketEnv,
 		env.NamespacesDetailsPathEnv,

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset_env_test.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset_env_test.go
@@ -113,8 +113,16 @@ func TestDaemonSetBuilder_PodEnvVars(t *testing.T) {
 	}
 
 	assert.True(t, foundTestEnvVar, "TEST_ENV_VAR not found in container environment variables")
-	assert.True(t, foundTestEnvVarFromField, "TEST_ENV_VAR_FROM_FIELD not found in container environment variables")
-	assert.True(t, foundTestEnvVarFromSecret, "TEST_ENV_VAR_FROM_SECRET not found in container environment variables")
+	assert.True(
+		t,
+		foundTestEnvVarFromField,
+		"TEST_ENV_VAR_FROM_FIELD not found in container environment variables",
+	)
+	assert.True(
+		t,
+		foundTestEnvVarFromSecret,
+		"TEST_ENV_VAR_FROM_SECRET not found in container environment variables",
+	)
 }
 
 func TestDaemonSetBuilder_EnvVarPrecedence(t *testing.T) {
@@ -184,7 +192,14 @@ func TestDaemonSetBuilder_EnvVarPrecedence(t *testing.T) {
 
 	// Check that there are no duplicates
 	for name, count := range envVarCounts {
-		assert.Equal(t, 1, count, "Environment variable %s appears %d times, expected once", name, count)
+		assert.Equal(
+			t,
+			1,
+			count,
+			"Environment variable %s appears %d times, expected once",
+			name,
+			count,
+		)
 	}
 
 	// Check that pod.env values take precedence over agent.env values
@@ -192,6 +207,193 @@ func TestDaemonSetBuilder_EnvVarPrecedence(t *testing.T) {
 		"pod.env value for INSTANA_AGENT_TAGS should take precedence")
 	assert.Equal(t, "pod-value", envVarValues["DUPLICATE_ENV_VAR"],
 		"pod.env value for DUPLICATE_ENV_VAR should take precedence")
+}
+
+func TestDaemonSetBuilder_NodeNameEnvVar(t *testing.T) {
+	// Given
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key:          "test-key",
+				EndpointHost: "test-host",
+				EndpointPort: "test-port",
+			},
+			Cluster: instanav1.Name{
+				Name: "test-cluster",
+			},
+		},
+	}
+
+	statusManager := status.NewAgentStatusManager(nil, nil)
+	dsBuilder := NewDaemonSetBuilder(agent, false, statusManager, false)
+
+	// When
+	obj := dsBuilder.Build()
+	if !obj.IsPresent() {
+		t.Fatal("Expected DaemonSet to be built")
+	}
+
+	// Then
+	ds, ok := obj.Get().(*appsv1.DaemonSet)
+	if !ok {
+		t.Fatal("Expected DaemonSet object")
+	}
+
+	envVars := ds.Spec.Template.Spec.Containers[0].Env
+
+	// Check if NODE_NAME environment variable is present
+	foundNodeName := false
+	for _, env := range envVars {
+		if env.Name == "NODE_NAME" {
+			foundNodeName = true
+			// Verify it uses fieldRef to get spec.nodeName
+			assert.NotNil(t, env.ValueFrom, "NODE_NAME should use ValueFrom")
+			assert.NotNil(t, env.ValueFrom.FieldRef, "NODE_NAME should use FieldRef")
+			assert.Equal(t, "spec.nodeName", env.ValueFrom.FieldRef.FieldPath,
+				"NODE_NAME should reference spec.nodeName")
+			break
+		}
+	}
+
+	assert.True(t, foundNodeName, "NODE_NAME environment variable should be present")
+}
+
+func TestDaemonSetBuilder_NodeNameEnvVarWithPersistence(t *testing.T) {
+	// Given
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key:          "test-key",
+				EndpointHost: "test-host",
+				EndpointPort: "test-port",
+			},
+			Cluster: instanav1.Name{
+				Name: "test-cluster",
+			},
+		},
+	}
+
+	statusManager := status.NewAgentStatusManager(nil, nil)
+	// Enable persistence flag
+	dsBuilder := NewDaemonSetBuilder(agent, false, statusManager, true)
+
+	// When
+	obj := dsBuilder.Build()
+	if !obj.IsPresent() {
+		t.Fatal("Expected DaemonSet to be built")
+	}
+
+	// Then
+	ds, ok := obj.Get().(*appsv1.DaemonSet)
+	if !ok {
+		t.Fatal("Expected DaemonSet object")
+	}
+
+	envVars := ds.Spec.Template.Spec.Containers[0].Env
+
+	// Check if NODE_NAME is present alongside persistence env vars
+	foundNodeName := false
+	foundPersistHostUniqueID := false
+	foundAgentIDFilePath := false
+
+	for _, env := range envVars {
+		switch env.Name {
+		case "NODE_NAME":
+			foundNodeName = true
+			assert.NotNil(t, env.ValueFrom, "NODE_NAME should use ValueFrom")
+			assert.NotNil(t, env.ValueFrom.FieldRef, "NODE_NAME should use FieldRef")
+			assert.Equal(t, "spec.nodeName", env.ValueFrom.FieldRef.FieldPath)
+		case "INSTANA_PERSIST_HOST_UNIQUE_ID":
+			foundPersistHostUniqueID = true
+			assert.Equal(t, "true", env.Value)
+		case "INSTANA_AGENT_ID_FILE_PATH":
+			foundAgentIDFilePath = true
+			assert.Equal(t, "/var/lib/instana/instana-agent-id", env.Value)
+		}
+	}
+
+	assert.True(t, foundNodeName, "NODE_NAME should be present")
+	assert.True(
+		t,
+		foundPersistHostUniqueID,
+		"INSTANA_PERSIST_HOST_UNIQUE_ID should be present when persistence is enabled",
+	)
+	assert.True(
+		t,
+		foundAgentIDFilePath,
+		"INSTANA_AGENT_ID_FILE_PATH should be present when persistence is enabled",
+	)
+}
+
+func TestDaemonSetBuilder_NodeNameCanBeOverridden(t *testing.T) {
+	// Given - user provides custom NODE_NAME via pod.env
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key:          "test-key",
+				EndpointHost: "test-host",
+				EndpointPort: "test-port",
+				Pod: instanav1.AgentPodSpec{
+					Env: []corev1.EnvVar{
+						{
+							Name:  "NODE_NAME",
+							Value: "custom-node-name",
+						},
+					},
+				},
+			},
+			Cluster: instanav1.Name{
+				Name: "test-cluster",
+			},
+		},
+	}
+
+	statusManager := status.NewAgentStatusManager(nil, nil)
+	dsBuilder := NewDaemonSetBuilder(agent, false, statusManager, false)
+
+	// When
+	obj := dsBuilder.Build()
+	if !obj.IsPresent() {
+		t.Fatal("Expected DaemonSet to be built")
+	}
+
+	// Then
+	ds, ok := obj.Get().(*appsv1.DaemonSet)
+	if !ok {
+		t.Fatal("Expected DaemonSet object")
+	}
+
+	envVars := ds.Spec.Template.Spec.Containers[0].Env
+
+	// Count NODE_NAME occurrences
+	nodeNameCount := 0
+	var nodeNameValue string
+	var nodeNameValueFrom *corev1.EnvVarSource
+
+	for _, env := range envVars {
+		if env.Name == "NODE_NAME" {
+			nodeNameCount++
+			nodeNameValue = env.Value
+			nodeNameValueFrom = env.ValueFrom
+		}
+	}
+
+	// Verify user's custom value takes precedence
+	assert.Equal(t, 1, nodeNameCount, "NODE_NAME should appear exactly once")
+	assert.Equal(t, "custom-node-name", nodeNameValue, "Custom NODE_NAME value should be used")
+	assert.Nil(t, nodeNameValueFrom, "Custom NODE_NAME should use direct value, not ValueFrom")
 }
 
 // Made with Bob

--- a/pkg/k8s/object/builders/agent/daemonset/daemonset_test.go
+++ b/pkg/k8s/object/builders/agent/daemonset/daemonset_test.go
@@ -164,6 +164,7 @@ func TestDaemonSetBuilder_getEnvVars(t *testing.T) {
 		env.DownloadKeyEnv,
 		env.InstanaAgentPodNameEnv,
 		env.PodIPEnv,
+		env.NodeNameEnv,
 		env.K8sServiceDomainEnv,
 		env.EnableAgentSocketEnv,
 		env.NamespacesDetailsPathEnv,
@@ -224,6 +225,7 @@ func TestDaemonSetBuilder_getEnvVarsWithPodEnv(t *testing.T) {
 	envBuilder := &mocks.MockEnvBuilder{}
 	defer envBuilder.AssertExpectations(t)
 	envBuilder.On("Build",
+		mock.Anything,
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,

--- a/pkg/k8s/object/builders/common/env/env_builder.go
+++ b/pkg/k8s/object/builders/common/env/env_builder.go
@@ -63,6 +63,7 @@ const (
 	K8sServiceDomainEnv
 	EnableAgentSocketEnv
 	NamespacesDetailsPathEnv
+	NodeNameEnv
 	InstanaOpenTelemetryGRPCEnabled
 	InstanaOpenTelemetryGRPCPort
 	InstanaOpenTelemetryHTTPEnabled
@@ -125,7 +126,7 @@ func (e *envBuilder) isSecret(envVar EnvVar) bool {
 		ListenAddressEnv, RedactK8sSecretsEnv, AgentZoneEnv, BackendURLEnv,
 		NoProxyEnv, ConfigPathEnv, EntrypointSkipBackendTemplateGeneration, BackendEnv,
 		InstanaAgentPodNameEnv, PodNameEnv, PodIPEnv, PodUIDEnv, PodNamespaceEnv,
-		K8sServiceDomainEnv, EnableAgentSocketEnv, NamespacesDetailsPathEnv,
+		K8sServiceDomainEnv, EnableAgentSocketEnv, NamespacesDetailsPathEnv, NodeNameEnv,
 		InstanaOpenTelemetryGRPCEnabled, InstanaOpenTelemetryGRPCPort,
 		InstanaOpenTelemetryHTTPEnabled, InstanaOpenTelemetryHTTPPort, CrdMonitoring:
 		return false
@@ -258,6 +259,8 @@ func (e *envBuilder) build(envVar EnvVar) *corev1.EnvVar {
 		return e.envWithObjectFieldSelector("POD_UID", "metadata.uid")
 	case PodNamespaceEnv:
 		return e.envWithObjectFieldSelector("POD_NAMESPACE", "metadata.namespace")
+	case NodeNameEnv:
+		return e.envWithObjectFieldSelector("NODE_NAME", "spec.nodeName")
 	case K8sServiceDomainEnv:
 		return &corev1.EnvVar{
 			Name:  "K8S_SERVICE_DOMAIN",


### PR DESCRIPTION
## Why

Automatically inject NODE_NAME environment variable using Kubernetes Downward API (spec.nodeName) to eliminate DNS lookups for hostname resolution. This improves agent startup performance and reduces CoreDNS load.
-->

## What

Changes:
- Add NodeNameEnv constant to env_builder.go
- Implement NODE_NAME field reference in env builder
- Include NODE_NAME in DaemonSet environment variables
- Add comprehensive unit tests for NODE_NAME functionality
- Update environment-variables.md documentation
## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-86323)
- [CSP](https://ibmsf.lightning.force.com/lightning/r/Case/500gJ00000BAy4bQAD/view)
- [Documentation PR](https://github.ibm.com/instana/docs/pull/19609)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [x] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated? - https://github.ibm.com/instana/docs/pull/19609
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
