### PR TITLE
fix: optimize controller memory consumption with namespace-scoped cache

### DIFF
--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -29,11 +29,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	instanav1 "github.com/instana/instana-agent-operator/api/v1"
 	instanaclient "github.com/instana/instana-agent-operator/pkg/k8s/client"
@@ -77,6 +79,9 @@ func Add(mgr manager.Manager) error {
 
 				return requests
 			}),
+			// Only trigger reconciliation when namespace labels change
+			// This prevents unnecessary reconciliations on namespace status updates
+			builder.WithPredicates(predicate.LabelChangedPredicate{}),
 		).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&appsv1.Deployment{}).

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -100,8 +101,18 @@ func main() {
 		log.Info("Leader election namespace set from POD_NAMESPACE", "namespace", operatorNamespace)
 	}
 
+	// Configure cache to only watch resources in the operator's namespace
+	// This prevents caching ALL resources cluster-wide and reduces memory usage significantly
+	// ClusterRole and ClusterRoleBinding are cluster-scoped so they will still be cached cluster-wide
+	log.Info("Configuring cache to watch only operator namespace", "namespace", operatorNamespace)
+
 	mgr, err := ctrl.NewManager(
 		cfg, ctrl.Options{
+			Cache: cache.Options{
+				DefaultNamespaces: map[string]cache.Config{
+					operatorNamespace: {},
+				},
+			},
 			Metrics: metricsserver.Options{
 				BindAddress: metricsAddr,
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,118 @@
+/*
+(c) Copyright IBM Corp. 2024, 2025
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+)
+
+func TestManagerCacheConfiguration(t *testing.T) {
+	assertions := require.New(t)
+
+	operatorNamespace := "test-namespace"
+	assertions.NoError(os.Setenv("POD_NAMESPACE", operatorNamespace))
+	defer func() {
+		assertions.NoError(os.Unsetenv("POD_NAMESPACE"))
+	}()
+
+	opts := ctrl.Options{
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				operatorNamespace: {},
+			},
+		},
+		Controller: config.Controller{
+			SkipNameValidation: func() *bool { b := true; return &b }(),
+		},
+	}
+
+	assertions.NotNil(opts.Cache.DefaultNamespaces)
+	assertions.Len(opts.Cache.DefaultNamespaces, 1)
+	assertions.Contains(opts.Cache.DefaultNamespaces, operatorNamespace)
+}
+
+func TestOperatorNamespaceFromEnvironment(t *testing.T) {
+	const defaultNamespace = "instana-agent"
+
+	for _, tt := range []struct {
+		name              string
+		envValue          string
+		expectedNamespace string
+	}{
+		{
+			name:              "custom namespace from environment",
+			envValue:          "custom-monitoring",
+			expectedNamespace: "custom-monitoring",
+		},
+		{
+			name:              "default namespace when env not set",
+			envValue:          "",
+			expectedNamespace: defaultNamespace,
+		},
+		{
+			name:              "instana-agent namespace",
+			envValue:          "instana-agent",
+			expectedNamespace: "instana-agent",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := require.New(t)
+
+			if tt.envValue != "" {
+				assertions.NoError(os.Setenv("POD_NAMESPACE", tt.envValue))
+				defer func() {
+					assertions.NoError(os.Unsetenv("POD_NAMESPACE"))
+				}()
+			} else {
+				assertions.NoError(os.Unsetenv("POD_NAMESPACE"))
+			}
+
+			operatorNamespace := os.Getenv("POD_NAMESPACE")
+			if operatorNamespace == "" {
+				operatorNamespace = defaultNamespace
+			}
+
+			assertions.Equal(tt.expectedNamespace, operatorNamespace)
+		})
+	}
+}
+
+func TestCacheOptionsStructure(t *testing.T) {
+	assertions := require.New(t)
+
+	operatorNamespace := "test-namespace"
+
+	cacheOpts := cache.Options{
+		DefaultNamespaces: map[string]cache.Config{
+			operatorNamespace: {},
+		},
+	}
+
+	assertions.NotNil(cacheOpts.DefaultNamespaces)
+	assertions.IsType(map[string]cache.Config{}, cacheOpts.DefaultNamespaces)
+
+	_, exists := cacheOpts.DefaultNamespaces[operatorNamespace]
+	assertions.True(exists)
+}
+
+// Made with Bob


### PR DESCRIPTION

## Why

The watch was memory exhaustive in clusters with many resources.

## What

Configure the controller-runtime cache to only watch resources in the operator's namespace, significantly reducing memory footprint on clusters with many resources.

The cache now only stores resources from the operator's namespace (determined by POD_NAMESPACE environment variable) instead of caching all cluster-wide resources. ClusterRole and ClusterRoleBinding remain cached cluster-wide as they are cluster-scoped resources.

Additionally, added LabelChangedPredicate to the namespace watch to only trigger reconciliation when namespace labels change, preventing unnecessary reconciliations on namespace status updates.


## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX) -- todo
- [CSP](https://ibmsf.lightning.force.com/lightning/r/Case/500gJ00000AhaQkQAJ/view)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
