### PR TITLE
ci: enable automatic release notes generation

### DIFF
--- a/ci/scripts/create-github-release.sh
+++ b/ci/scripts/create-github-release.sh
@@ -49,8 +49,8 @@ GITHUB_RELEASE_ID=$(echo "${GITHUB_RELEASE_RESPONSE}" | jq .id)
 if [[ -z "${GITHUB_RELEASE_ID}" ]] || [[ ${GITHUB_RELEASE_ID} == "null" ]]; then
   printf "\n%s\n" "Creating GitHub Release..."
   
-  # Construct the JSON payload
-  RELEASE_JSON="{ \"tag_name\": \"v${VERSION}\", \"target_commitish\": \"${BRANCH}\", \"name\": \"v${VERSION}\", \"make_latest\": \"${MAKE_LATEST}\" }"
+  # Construct the JSON payload with generate_release_notes enabled
+  RELEASE_JSON="{ \"tag_name\": \"v${VERSION}\", \"target_commitish\": \"${BRANCH}\", \"name\": \"v${VERSION}\", \"make_latest\": \"${MAKE_LATEST}\", \"generate_release_notes\": true }"
   echo "Release JSON payload: ${RELEASE_JSON}"
   
   GITHUB_RELEASE_RESPONSE=$(curl -X POST \


### PR DESCRIPTION
## Why

Currently, GitHub releases are created without any release notes, making it difficult for users to understand what changed between versions. We can manually click "Generate Release Notes" on the release page, but we don't want to have manual steps here if not required.

GitHub provides an automatic release notes generation feature that creates comprehensive release notes from merged PRs and commits, including contributors and categorization.

## What

Updated the GitHub Release Creation Script, when a new release is created, GitHub will now automatically generate release notes that include:
- Pull requests merged since the last release
- Commit messages
- Contributors
- Automatic categorization (features, bug fixes, etc.)

## References

- [GitHub API Documentation - Generate Release Notes](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)

## Checklist

- [x] Backwards compatible? Yes - only adds content to releases, doesn't change behavior
- [ ] Release notes in public docs updated? N/A - this is an internal CI/CD improvement
- [ ] unit/e2e test coverage added or updated? N/A - script change, tested via CI pipeline