### PR TITLE
[INSTA-89100] fix: skip k8sensor status condition when explicitly disabled

### DIFF
--- a/controllers/instanaagent_controller.go
+++ b/controllers/instanaagent_controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/operator_utils"
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
 	"github.com/instana/instana-agent-operator/pkg/multierror"
+	"github.com/instana/instana-agent-operator/pkg/pointer"
 	"github.com/instana/instana-agent-operator/pkg/recovery"
 )
 
@@ -143,6 +144,14 @@ func (r *InstanaAgentReconciler) reconcile(
 	log.Info("reconciling Agent CR")
 
 	agent.Default()
+
+	// Log if k8sensor is disabled
+	if !pointer.DerefOrDefault(agent.Spec.K8sSensor.DeploymentSpec.Enabled.Enabled, true) {
+		log.Info(
+			"k8sensor deployment is disabled - Kubernetes cluster monitoring will not be available",
+		)
+	}
+
 	operatorUtils := operator_utils.NewOperatorUtils(
 		ctx,
 		r.client,

--- a/pkg/k8s/operator/status/agent_status_manager.go
+++ b/pkg/k8s/operator/status/agent_status_manager.go
@@ -239,10 +239,17 @@ func (a *agentStatusManager) getAllK8sSensorsAvailableCondition(ctx context.Cont
 		Message:            "",
 	}
 
+	// Check if k8sensor is explicitly disabled
+	if !pointer.DerefOrDefault(a.agentOld.Spec.K8sSensor.DeploymentSpec.Enabled.Enabled, true) {
+		// k8sensor is disabled, skip this condition entirely by returning a failure result
+		// We use a sentinel error to indicate this is intentionally skipped, not an actual error
+		return result.OfFailure[metav1.Condition](fmt.Errorf("k8sensor is disabled"))
+	}
+
 	if objectKeyHasNoName(a.k8sSensorDeployment) {
 		condition.Status = metav1.ConditionUnknown
-		condition.Reason = "K8sSensorDeploymentNotConfigured"
-		condition.Message = "K8sSensor deployment has not been configured for this agent"
+		condition.Reason = "K8sensorDeploymentNotConfigured"
+		condition.Message = "k8sensor deployment has not been configured for this agent"
 		return result.OfSuccess(condition)
 	}
 
@@ -252,9 +259,9 @@ func (a *agentStatusManager) getAllK8sSensorsAvailableCondition(ctx context.Cont
 		_, err := res.Get()
 
 		condition.Status = metav1.ConditionUnknown
-		condition.Reason = "K8sSensorDeploymentInfoUnavailable"
+		condition.Reason = "K8sensorDeploymentInfoUnavailable"
 		msg := fmt.Sprintf(
-			"failed to retrieve status of K8sSensor Deployment: %s due to error: %s",
+			"failed to retrieve status of k8sensor deployment: %s due to error: %s",
 			a.k8sSensorDeployment.Name,
 			err.Error(),
 		)
@@ -267,12 +274,12 @@ func (a *agentStatusManager) getAllK8sSensorsAvailableCondition(ctx context.Cont
 	switch deploymentIsAvailableAndComplete(deployment) {
 	case true:
 		condition.Status = metav1.ConditionTrue
-		condition.Reason = "AllDesiredK8sSensorsAvailable"
-		condition.Message = "All desired K8sSensors are available and using up-to-date configuration"
+		condition.Reason = "AllDesiredK8sensorsAvailable"
+		condition.Message = "All desired k8sensors are available and using up-to-date configuration"
 	default:
 		condition.Status = metav1.ConditionFalse
-		condition.Reason = "NotAllDesiredK8sSensorsAvailable"
-		condition.Message = "Not all desired K8sSensors are available or some K8sSensors are not using up-to-date configuration"
+		condition.Reason = "NotAllDesiredK8sensorsAvailable"
+		condition.Message = "Not all desired k8sensors are available or some k8sensors are not using up-to-date configuration"
 	}
 
 	return result.OfSuccess(condition)
@@ -334,11 +341,14 @@ func (a *agentStatusManager) agentWithUpdatedStatus(
 			Get()
 	a.setConditionAndFireEvent(agentNew, allAgentsAvailableCondition)
 
-	allK8sSensorsAvailableCondition, _ :=
-		a.getAllK8sSensorsAvailableCondition(ctx).
-			OnFailure(errBuilder.AddSingle).
-			Get()
-	a.setConditionAndFireEvent(agentNew, allK8sSensorsAvailableCondition)
+	allK8sSensorsAvailableConditionResult := a.getAllK8sSensorsAvailableCondition(ctx).
+		OnFailure(errBuilder.AddSingle)
+
+	// Only set the condition if k8sensor is enabled (result is successful)
+	if allK8sSensorsAvailableConditionResult.IsSuccess() {
+		allK8sSensorsAvailableCondition, _ := allK8sSensorsAvailableConditionResult.Get()
+		a.setConditionAndFireEvent(agentNew, allK8sSensorsAvailableCondition)
+	}
 
 	return result.Of(agentNew, errBuilder.Build())
 }

--- a/pkg/k8s/operator/status/agent_status_manager_test.go
+++ b/pkg/k8s/operator/status/agent_status_manager_test.go
@@ -67,8 +67,14 @@ func TestUpdateAgentStatus(t *testing.T) {
 		Name:      "AddAgentDaemonsetName",
 		Namespace: "AddAgentDaemonsetNamespace",
 	}}
-	k8sSensorDeployment := &types.NamespacedName{Name: "test_name_deployment", Namespace: "test_namespace_deployment"}
-	namespacesConfigmap := &types.NamespacedName{Name: "test_name_namespaces_configmap", Namespace: "test_name_namespaces_configmap"}
+	k8sSensorDeployment := &types.NamespacedName{
+		Name:      "test_name_deployment",
+		Namespace: "test_namespace_deployment",
+	}
+	namespacesConfigmap := &types.NamespacedName{
+		Name:      "test_name_namespaces_configmap",
+		Namespace: "test_name_namespaces_configmap",
+	}
 
 	num := int64(1)
 	semVer := instanav1.SemanticVersion{}
@@ -304,7 +310,10 @@ func TestUpdateAgentStatus(t *testing.T) {
 						Return(writer)
 				}
 
-				agentStatusManager := NewAgentStatusManager(instanaAgentClient, record.NewFakeRecorder(10))
+				agentStatusManager := NewAgentStatusManager(
+					instanaAgentClient,
+					record.NewFakeRecorder(10),
+				)
 
 				if test.agent != nil {
 					agentStatusManager.SetAgentOld(test.agent)
@@ -335,4 +344,120 @@ func TestUpdateAgentStatus(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestGetAllK8sSensorsAvailableCondition_WhenDisabled(t *testing.T) {
+	assertions := require.New(t)
+	ctx := t.Context()
+
+	// Create an agent with k8sensor explicitly disabled
+	agent := &instanav1.InstanaAgent{
+		Spec: instanav1.InstanaAgentSpec{
+			K8sSensor: instanav1.K8sSpec{
+				DeploymentSpec: instanav1.KubernetesDeploymentSpec{
+					Enabled: instanav1.Enabled{
+						Enabled: func() *bool { b := false; return &b }(),
+					},
+				},
+			},
+		},
+	}
+
+	instanaAgentClient := &mocks.MockInstanaAgentClient{}
+	defer instanaAgentClient.AssertExpectations(t)
+
+	agentStatusManager := NewAgentStatusManager(instanaAgentClient, record.NewFakeRecorder(10)).(*agentStatusManager)
+	agentStatusManager.SetAgentOld(agent)
+
+	// Call the method
+	result := agentStatusManager.getAllK8sSensorsAvailableCondition(ctx)
+
+	// When k8sensor is disabled, the function should return a failure result (empty condition)
+	assertions.True(result.IsFailure(), "Expected failure result when k8sensor is disabled")
+
+	// Verify no client calls were made since we skip the condition entirely
+	instanaAgentClient.AssertNotCalled(t, "GetAsResult")
+}
+
+func TestGetAllK8sSensorsAvailableCondition_WhenEnabled(t *testing.T) {
+	assertions := require.New(t)
+	ctx := t.Context()
+
+	// Create an agent with k8sensor enabled (default)
+	agent := &instanav1.InstanaAgent{
+		Spec: instanav1.InstanaAgentSpec{
+			K8sSensor: instanav1.K8sSpec{
+				DeploymentSpec: instanav1.KubernetesDeploymentSpec{
+					Enabled: instanav1.Enabled{
+						Enabled: func() *bool { b := true; return &b }(),
+					},
+				},
+			},
+		},
+	}
+
+	instanaAgentClient := &mocks.MockInstanaAgentClient{}
+	defer instanaAgentClient.AssertExpectations(t)
+
+	agentStatusManager := NewAgentStatusManager(instanaAgentClient, record.NewFakeRecorder(10)).(*agentStatusManager)
+	agentStatusManager.SetAgentOld(agent)
+	// Don't set k8sSensorDeployment to simulate "not configured" scenario
+
+	// Call the method
+	result := agentStatusManager.getAllK8sSensorsAvailableCondition(ctx)
+
+	// When k8sensor is enabled but not configured, should return success with "not configured" condition
+	assertions.True(result.IsSuccess(), "Expected success result when k8sensor is enabled")
+
+	condition, err := result.Get()
+	assertions.Nil(err)
+	assertions.Equal(metav1.ConditionUnknown, condition.Status)
+	assertions.Equal("K8sensorDeploymentNotConfigured", condition.Reason)
+	assertions.Equal(
+		"k8sensor deployment has not been configured for this agent",
+		condition.Message,
+	)
+}
+
+func TestGetAllK8sSensorsAvailableCondition_WhenEnabledNil(t *testing.T) {
+	assertions := require.New(t)
+	ctx := t.Context()
+
+	// Create an agent with k8sensor enabled field as nil (defaults to true)
+	agent := &instanav1.InstanaAgent{
+		Spec: instanav1.InstanaAgentSpec{
+			K8sSensor: instanav1.K8sSpec{
+				DeploymentSpec: instanav1.KubernetesDeploymentSpec{
+					Enabled: instanav1.Enabled{
+						Enabled: nil, // nil defaults to true
+					},
+				},
+			},
+		},
+	}
+
+	instanaAgentClient := &mocks.MockInstanaAgentClient{}
+	defer instanaAgentClient.AssertExpectations(t)
+
+	agentStatusManager := NewAgentStatusManager(instanaAgentClient, record.NewFakeRecorder(10)).(*agentStatusManager)
+	agentStatusManager.SetAgentOld(agent)
+	// Don't set k8sSensorDeployment to simulate "not configured" scenario
+
+	// Call the method
+	result := agentStatusManager.getAllK8sSensorsAvailableCondition(ctx)
+
+	// When k8sensor enabled is nil (defaults to true) but not configured, should return "not configured" condition
+	assertions.True(
+		result.IsSuccess(),
+		"Expected success result when k8sensor enabled is nil (defaults to true)",
+	)
+
+	condition, err := result.Get()
+	assertions.Nil(err)
+	assertions.Equal(metav1.ConditionUnknown, condition.Status)
+	assertions.Equal("K8sensorDeploymentNotConfigured", condition.Reason)
+	assertions.Equal(
+		"k8sensor deployment has not been configured for this agent",
+		condition.Message,
+	)
 }


### PR DESCRIPTION
## Why

Customer disabled the k8sensor on purpose and OCP console flooded with `"K8sSensor deployment has not been configured"` 

## What

Fixes issue where "K8sSensor deployment has not been configured" error
was logged even when k8sensor was disabled via enabled: false.

Changes:
- Skip k8sensor condition check when disabled in status manager
- Add informative log when k8sensor is disabled during reconciliation
- Update all k8sensor messages to use consistent naming (k8sensor/K8sensor) as it's used in public docs
- Add comprehensive test coverage for disabled/enabled/nil scenarios

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-89100)
- [CSP](https://ibmsf.lightning.force.com/lightning/r/case/500gJ00000BkByD/view)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [x] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
