### PR TITLE
fix(INSTA-75604): Namespace scoped cache for discovery from `kube-system`

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,15 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func getCacheOptions(operatorNamespace string) cache.Options {
+	return cache.Options{
+		DefaultNamespaces: map[string]cache.Config{
+			operatorNamespace: {},
+			"kube-system":     {},
+		},
+	}
+}
+
 func main() {
 	var metricsAddr string
 	var probeAddr string
@@ -101,18 +110,18 @@ func main() {
 		log.Info("Leader election namespace set from POD_NAMESPACE", "namespace", operatorNamespace)
 	}
 
-	// Configure cache to only watch resources in the operator's namespace
+	// Configure cache to only watch resources in the operator's namespace and in kube-system
 	// This prevents caching ALL resources cluster-wide and reduces memory usage significantly
 	// ClusterRole and ClusterRoleBinding are cluster-scoped so they will still be cached cluster-wide
-	log.Info("Configuring cache to watch only operator namespace", "namespace", operatorNamespace)
+	log.Info(
+		"Configuring cache to watch operator namespace and kube-system",
+		"namespace",
+		operatorNamespace,
+	)
 
 	mgr, err := ctrl.NewManager(
 		cfg, ctrl.Options{
-			Cache: cache.Options{
-				DefaultNamespaces: map[string]cache.Config{
-					operatorNamespace: {},
-				},
-			},
+			Cache: getCacheOptions(operatorNamespace),
 			Metrics: metricsserver.Options{
 				BindAddress: metricsAddr,
 			},
@@ -186,7 +195,14 @@ func cleanupOldOperator(k8sClient k8sClient.Client) {
 	}
 
 	if err := k8sClient.List(context.Background(), deploymentsList, deploymentOptions); err != nil {
-		log.Info(fmt.Sprintf("Failed to get list the deployment with the label %s:%s and name %s", labelKey, instanaclient.FieldOwnerName, InstanaOperatorOldDeploymentName))
+		log.Info(
+			fmt.Sprintf(
+				"Failed to get list the deployment with the label %s:%s and name %s",
+				labelKey,
+				instanaclient.FieldOwnerName,
+				InstanaOperatorOldDeploymentName,
+			),
+		)
 	} else {
 		// there should be only one deployment but we iterate just in case
 		log.Info(fmt.Sprintf("Found %v deployments that match the criteria", len(deploymentsList.Items)))

--- a/main_test.go
+++ b/main_test.go
@@ -36,19 +36,24 @@ func TestManagerCacheConfiguration(t *testing.T) {
 	}()
 
 	opts := ctrl.Options{
-		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				operatorNamespace: {},
-			},
-		},
+		Cache: getCacheOptions(operatorNamespace),
 		Controller: config.Controller{
 			SkipNameValidation: func() *bool { b := true; return &b }(),
 		},
 	}
 
 	assertions.NotNil(opts.Cache.DefaultNamespaces)
-	assertions.Len(opts.Cache.DefaultNamespaces, 1)
+	assertions.Len(
+		opts.Cache.DefaultNamespaces,
+		2,
+		"Cache should watch both operator namespace and kube-system",
+	)
 	assertions.Contains(opts.Cache.DefaultNamespaces, operatorNamespace)
+	assertions.Contains(
+		opts.Cache.DefaultNamespaces,
+		"kube-system",
+		"Cache should include kube-system namespace",
+	)
 }
 
 func TestOperatorNamespaceFromEnvironment(t *testing.T) {
@@ -91,8 +96,14 @@ func TestOperatorNamespaceFromEnvironment(t *testing.T) {
 			if operatorNamespace == "" {
 				operatorNamespace = defaultNamespace
 			}
-
-			assertions.Equal(tt.expectedNamespace, operatorNamespace)
+			cacheOpts := getCacheOptions(operatorNamespace)
+			assertions.NotNil(cacheOpts.DefaultNamespaces)
+			assertions.Contains(
+				cacheOpts.DefaultNamespaces,
+				tt.expectedNamespace,
+				"%s namespace should be in cache configuration",
+				tt.expectedNamespace,
+			)
 		})
 	}
 }
@@ -102,17 +113,21 @@ func TestCacheOptionsStructure(t *testing.T) {
 
 	operatorNamespace := "test-namespace"
 
-	cacheOpts := cache.Options{
-		DefaultNamespaces: map[string]cache.Config{
-			operatorNamespace: {},
-		},
-	}
-
+	cacheOpts := getCacheOptions(operatorNamespace)
 	assertions.NotNil(cacheOpts.DefaultNamespaces)
 	assertions.IsType(map[string]cache.Config{}, cacheOpts.DefaultNamespaces)
 
-	_, exists := cacheOpts.DefaultNamespaces[operatorNamespace]
-	assertions.True(exists)
+	assertions.Contains(
+		cacheOpts.DefaultNamespaces,
+		operatorNamespace,
+		"%s namespace should be in cache configuration",
+		operatorNamespace,
+	)
+	assertions.Contains(
+		cacheOpts.DefaultNamespaces,
+		"kube-system",
+		"kube-system namespace should be in cache configuration",
+	)
 }
 
 // Made with Bob


### PR DESCRIPTION
## Why
Commit `e67b6e1ead9a344bb20410a9ff0762560005aba4` broke the 
[ETCD metrics service discovery](
https://github.com/instana/instana-agent-operator/blob/f98eb36d80104507cabb267c32372e286c6e3559/docs/etcd-metrics.md#vanilla-kubernetes-clusters)
from the `kube-system` namespace, that which now fails with:

```
E0513 11:32:53.971614   30591 apply.go:487] "Failed to discover ETCD endpoints" err="unable to get: kube-system/etcd because of unknown namespace for the cache" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-a
gent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="d6d5871a-0e00-4e8f-82b6-d1a7970e737e" Generation=1 UID="360cd932-2b98-44b0-8be2-7cf55f2d5702"
````

Futhermore the added UT TCs, were completely futile, as they were not covering any production code.

## What

* This PR fixes the above broken functionality.
* This PR adds coverage to actual production code
* Fixes obvious assertion misues
* Ensures with assertions that the `kube-system` is also in the cache.

## References


- [Story / Card](https://jsw.ibm.com/browse/INSTA-75604)
- [Documentation](http://example.com)
- [CSP](http://example.com)
- [Documentation PR](http://example.com)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
