### PR TITLE
fix: improve cache configuration with label-based filtering

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|go.sum|flake.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-09T09:37:41Z",
+  "generated_at": "2026-06-01T14:44:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -87,16 +87,6 @@
         "verified_result": null
       }
     ],
-    "ci/fedramp-promotion-pipeline.yaml": [
-      {
-        "hashed_secret": "9af3842326eadff7d85a55edfec67f6d8a3a259f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 65,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "config/samples/instana_v1_instanaagent_multiple_backends_external_keyssecret.yaml": [
       {
         "hashed_secret": "90c179e25b3da65c5bea4a355a7b6e8a308c0f1d",
@@ -122,7 +112,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 175,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -152,7 +142,7 @@
         "hashed_secret": "c7c6508b19455e3e8040e60e9833fbede92e5d8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 552,
+        "line_number": 694,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -160,7 +150,7 @@
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 569,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -168,7 +158,7 @@
         "hashed_secret": "2d3e82be1e73866269ea97c6d02040fe73e7ab54",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 577,
+        "line_number": 746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -176,7 +166,7 @@
         "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 604,
+        "line_number": 773,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -184,7 +174,7 @@
         "hashed_secret": "4f151c44a6783667af6cedaa3d12560f8af2f38a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 791,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -192,7 +182,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1023,
+        "line_number": 1227,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -202,7 +192,7 @@
         "hashed_secret": "0178f29221fc921764a968c3ab620a3465db6529",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 136,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -212,7 +202,7 @@
         "hashed_secret": "6d2a23dc63cd9ca596ea4396e5b492310e87165e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 27,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -220,7 +210,7 @@
         "hashed_secret": "9fbd4024ebb2c7e2779a80aa127d560c62234e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 49,
+        "line_number": 50,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -228,7 +218,7 @@
         "hashed_secret": "62d6314bd936033553442d72fe8ce3b93ba8802d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -238,7 +228,7 @@
         "hashed_secret": "9fbd4024ebb2c7e2779a80aa127d560c62234e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -246,7 +236,7 @@
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -254,7 +244,7 @@
         "hashed_secret": "62d6314bd936033553442d72fe8ce3b93ba8802d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 51,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -265,6 +255,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "e2e/multi_namespace_test.go": [
+      {
+        "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 117,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -290,7 +290,7 @@
         "hashed_secret": "1e92d214c7b3714429986ccbb3829f0c0aef9823",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 850,
+        "line_number": 942,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -300,7 +300,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 237,
+        "line_number": 278,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -308,7 +308,7 @@
         "hashed_secret": "62d6314bd936033553442d72fe8ce3b93ba8802d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 239,
+        "line_number": 280,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -318,7 +318,7 @@
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 225,
+        "line_number": 226,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -326,7 +326,7 @@
         "hashed_secret": "62d6314bd936033553442d72fe8ce3b93ba8802d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 234,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -336,7 +336,7 @@
         "hashed_secret": "de11ae65b615005fc760f8ec4ed62bd0df1a851f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 44,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -344,7 +344,7 @@
         "hashed_secret": "9fbd4024ebb2c7e2779a80aa127d560c62234e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 64,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -728,7 +728,7 @@
         "hashed_secret": "7cc3f717407355351c9184d91e27109c3b79427d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 497,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -748,7 +748,7 @@
         "hashed_secret": "de11ae65b615005fc760f8ec4ed62bd0df1a851f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 399,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -794,7 +794,7 @@
         "hashed_secret": "de11ae65b615005fc760f8ec4ed62bd0df1a851f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 55,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -802,7 +802,7 @@
         "hashed_secret": "9fbd4024ebb2c7e2779a80aa127d560c62234e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 75,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -908,7 +908,7 @@
         "hashed_secret": "72dbb7a1a5fd02337cd8c96d9c29fbd3903b2568",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 62,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -916,7 +916,7 @@
         "hashed_secret": "2a2181890f272be78e265bfae30e021e0ac63556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 194,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -924,7 +924,7 @@
         "hashed_secret": "c046043e5646ac642511397212144e8936fcb97f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 271,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ci/sps-scripts/ephemeral-k8s-e2e.sh
+++ b/ci/sps-scripts/ephemeral-k8s-e2e.sh
@@ -99,7 +99,8 @@ gcloud compute instances create ${VM_NAME} \
   --labels="purpose=e2e-testing,creation-time=$(date +%s),max-lifetime=90m" \
   --metadata="startup-script=#!/bin/bash
     # Install k3s with tls-san to include the external IP in the certificate
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC=\"--disable=traefik --tls-san=\$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H 'Metadata-Flavor: Google')\" sh -
+    # Use --cluster-init to enable embedded ETCD instead of SQLite (required for ETCD scraping tests)
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC=\"--cluster-init --disable=traefik --tls-san=\$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H 'Metadata-Flavor: Google')\" sh -
   " \
   --tags=k3s-server
 

--- a/e2e/agent_id_persistence_test.go
+++ b/e2e/agent_id_persistence_test.go
@@ -23,6 +23,7 @@ import (
 // TestAgentIDPersistence verifies that the agent ID persists across pod restarts
 // when INSTANA_PERSIST_HOST_UNIQUE_ID is set and /var/lib is mounted
 func TestAgentIDPersistence(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCr()
 
 	agentIDPersistenceFeature := features.New("agent ID persistence across pod restarts").

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -45,6 +45,25 @@ import (
 
 // env.Funcs to be used in the test initialization
 
+// CollectOperatorLogsOnFailure collects operator logs when a test fails for easier debugging
+// This is a common utility function used across multiple e2e tests
+func CollectOperatorLogsOnFailure(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("==== Test failed, collecting operator logs ====")
+			p := utils.RunCommand(
+				"kubectl logs -n instana-agent deployment/instana-agent-controller-manager --tail=100",
+			)
+			if p.Err() != nil {
+				t.Logf("Could not collect operator logs: %v", p.Err())
+			} else {
+				t.Logf("Operator logs (last 100 lines):\n%s", p.Result())
+			}
+		}
+	})
+}
+
 // DeleteAgentNamespace ensures a proper cleanup of existing instana agent installations.
 // The namespace cannot be just deleted in all scenarios, as finalizers on the agent CR might block the namespace termination
 func EnsureAgentNamespaceDeletion() env.Func {
@@ -76,6 +95,11 @@ func EnsureAgentNamespaceDeletion() env.Func {
 		}
 
 		log.Info("Agent CR cleanup completed")
+
+		// Clean up ALL Agent CRs from ALL namespaces to prevent CRD deletion from getting stuck
+		// This is critical because CRDs cannot be deleted while CRs with finalizers exist
+		log.Info("Cleaning up all Agent CRs from all namespaces to prevent CRD deletion issues")
+		cleanupAllAgentCRs()
 
 		// full purge of resources if anything would be left in the cluster
 		p = utils.RunCommand(
@@ -202,6 +226,88 @@ func DeleteAgentCRIfPresent() env.Func {
 		log.Info("Agent CR is gone")
 		return ctx, nil
 	}
+}
+
+// cleanupAllAgentCRs removes all Agent CRs from all namespaces to prevent CRD deletion from getting stuck.
+// This is critical because CRDs cannot be deleted while CRs with finalizers exist in any namespace.
+func cleanupAllAgentCRs() {
+	log.Info("Searching for Agent CRs in all namespaces")
+
+	// Get all Agent CRs across all namespaces
+	p := utils.RunCommand(
+		"kubectl get agents.instana.io -A --no-headers -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name",
+	)
+	if p.Err() != nil {
+		log.Warningf("Could not list Agent CRs across namespaces: %v", p.Err())
+		return
+	}
+
+	output := strings.TrimSpace(p.Result())
+	if output == "" {
+		log.Info("No Agent CRs found in any namespace")
+		return
+	}
+
+	// Parse and delete each Agent CR
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		namespace := fields[0]
+		name := fields[1]
+
+		log.Infof("Found Agent CR %s/%s, removing finalizers and deleting", namespace, name)
+
+		// Remove finalizers first to allow deletion
+		patchCmd := fmt.Sprintf(
+			"kubectl patch agent %s -n %s -p '{\"metadata\":{\"finalizers\":[]}}' --type=merge 2>&1",
+			name,
+			namespace,
+		)
+		patchResult := utils.RunCommand(patchCmd)
+		if patchResult.Err() != nil {
+			// Check if error is because CRD doesn't exist (which is fine)
+			output := patchResult.Result()
+			if strings.Contains(output, "the server doesn't have a resource type") ||
+				strings.Contains(output, "no matches for kind") {
+				log.Infof("Agent CRD already deleted, skipping cleanup of %s/%s", namespace, name)
+				continue
+			}
+			log.Warningf(
+				"Could not remove finalizers from Agent CR %s/%s: %v - %s",
+				namespace,
+				name,
+				patchResult.Err(),
+				output,
+			)
+		}
+
+		// Delete the Agent CR (force delete if needed)
+		deleteCmd := fmt.Sprintf(
+			"kubectl delete agent %s -n %s --ignore-not-found --timeout=30s --force --grace-period=0 2>&1",
+			name,
+			namespace,
+		)
+		deleteResult := utils.RunCommand(deleteCmd)
+		if deleteResult.Err() != nil {
+			// Check if error is because CRD doesn't exist (which is fine)
+			output := deleteResult.Result()
+			if strings.Contains(output, "the server doesn't have a resource type") ||
+				strings.Contains(output, "no matches for kind") {
+				log.Infof("Agent CRD already deleted, CR %s/%s is gone", namespace, name)
+			} else {
+				log.Warningf("Could not delete Agent CR %s/%s: %v - %s", namespace, name, deleteResult.Err(), output)
+			}
+		} else {
+			log.Infof("Successfully deleted Agent CR %s/%s", namespace, name)
+		}
+	}
+
+	// Give Kubernetes a moment to process the deletions
+	time.Sleep(2 * time.Second)
+	log.Info("Completed cleanup of all Agent CRs")
 }
 
 func EnsureReusableEnvironment() env.Func {
@@ -541,6 +647,64 @@ func SetupOperatorDevBuild() e2etypes.StepFunc {
 				)
 			}
 			t.Log("Deployment submitted")
+
+			// Wait for CRD to be established after make install deploy
+			// This prevents "create not allowed while custom resource definition is terminating" errors
+			t.Log("Waiting for CRD to be established")
+			crdClient, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for CRD to exist and be established (not terminating)
+			err = wait.For(
+				func(ctx context.Context) (bool, error) {
+					crd := &unstructured.Unstructured{}
+					crd.SetGroupVersionKind(schema.GroupVersionKind{
+						Group:   "apiextensions.k8s.io",
+						Version: "v1",
+						Kind:    "CustomResourceDefinition",
+					})
+					err := crdClient.Resources().Get(ctx, "agents.instana.io", "", crd)
+					if err != nil {
+						return false, nil // CRD doesn't exist yet
+					}
+
+					// Check if CRD has deletionTimestamp (is terminating)
+					deletionTimestamp, found, err := unstructured.NestedString(
+						crd.Object,
+						"metadata",
+						"deletionTimestamp",
+					)
+					if err == nil && found && deletionTimestamp != "" {
+						t.Log("CRD is terminating, waiting for new CRD to be created")
+						return false, nil // CRD is being deleted, wait for new one
+					}
+
+					// Check if CRD is established
+					conditions, found, err := unstructured.NestedSlice(
+						crd.Object,
+						"status",
+						"conditions",
+					)
+					if err != nil || !found {
+						return false, nil
+					}
+					for _, c := range conditions {
+						condition := c.(map[string]interface{})
+						if condition["type"] == "Established" && condition["status"] == "True" {
+							return true, nil
+						}
+					}
+					return false, nil
+				},
+				wait.WithTimeout(time.Minute*3),
+				wait.WithInterval(time.Second*2),
+			)
+			if err != nil {
+				t.Fatalf("CRD did not become established: %v", err)
+			}
+			t.Log("CRD is established and ready")
 		} else {
 			t.Logf("Operator already running desired image %s, skipping redeploy", desiredImage)
 		}
@@ -739,7 +903,8 @@ func WaitForDeploymentToBecomeReady(name string) e2etypes.StepFunc {
 				}
 
 				for _, condition := range dep.Status.Conditions {
-					if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
+					if condition.Type == appsv1.DeploymentAvailable &&
+						condition.Status == corev1.ConditionTrue {
 						return true, nil
 					}
 				}

--- a/e2e/agentremote_install_test.go
+++ b/e2e/agentremote_install_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestInitialRemoteInstall(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCr(AgentRemoteCustomResourceName)
 	initialInstallFeature := features.New("initial install dev-operator-build").
 		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
@@ -47,6 +48,7 @@ func TestInitialRemoteInstall(t *testing.T) {
 	testEnv.Test(t, initialInstallFeature)
 }
 func TestUpdateRemoteInstall(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCr(AgentRemoteCustomResourceName)
 	// Cannot currently use as instana agent remote does not exist in latest version
 	// installLatestFeature := features.New("deploy latest released instana-agent-operator").

--- a/e2e/env_vars_test.go
+++ b/e2e/env_vars_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestEnvVarsWithKubernetesFormat(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Create a ConfigMap and Secret that will be referenced by environment variables
 	setupConfigMapAndSecret := func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		r, err := resources.New(cfg.Client().RESTConfig())

--- a/e2e/extra_volume_test.go
+++ b/e2e/extra_volume_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestExtraVolumeWithSecret(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	installCrWithExtraVolumeFeature := features.New("extra volume with secret").
 		Setup(SetupOperatorDevBuild()).
 		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).

--- a/e2e/install_test.go
+++ b/e2e/install_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestInitialInstall(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCr()
 	initialInstallFeature := features.New("initial install dev-operator-build").
 		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready

--- a/e2e/install_with_pdb_test.go
+++ b/e2e/install_with_pdb_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestInstallWithK8sensorPodDisruptionBudget(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCr()
 	enabled := true
 	agent.Spec.K8sSensor.PodDisruptionBudget.Enabled = &enabled

--- a/e2e/multi_backend_test.go
+++ b/e2e/multi_backend_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestMultiBackendSupportExternalSecret(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	installCrWithExternalSecretFeature := features.New("multiple backend support with external keyssecret and useSecretMounts: false").
 		Setup(SetupOperatorDevBuild()).
 		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
@@ -92,6 +93,7 @@ func TestMultiBackendSupportExternalSecret(t *testing.T) {
 }
 
 func TestMultiBackendSupportExternalSecretWithSecretMounts(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	installCrWithExternalSecretAndSecretMountsFeature := features.New(
 		"multiple backend support with external keyssecret and useSecretMounts: true",
 	).
@@ -178,6 +180,7 @@ func TestMultiBackendSupportExternalSecretWithSecretMounts(t *testing.T) {
 }
 
 func TestMultiBackendSupportInlineSecret(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	installCrWithInlineSecretFeature := features.New("multiple backend support with inlined keyssecret").
 		Setup(SetupOperatorDevBuild()).
 		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
@@ -227,6 +230,7 @@ func TestMultiBackendSupportInlineSecret(t *testing.T) {
 }
 
 func TestRemovalOfAdditionalBackend(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCr()
 
 	agent.Spec.Agent.AdditionalBackends = append(

--- a/e2e/multi_namespace_test.go
+++ b/e2e/multi_namespace_test.go
@@ -1,0 +1,614 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "github.com/instana/instana-agent-operator/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	// Test namespace for alternate CR deployment
+	AlternateAgentNamespace = "instana-agent-alternate"
+
+	// Label used by operator to identify managed resources
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	ManagedByValue = "instana-agent-operator"
+)
+
+// TestMultiNamespaceOperatorDeployment tests the core multi-namespace functionality:
+// Operator deployed in namespace A (instana-agent) can successfully manage an
+// InstanaAgent CR deployed in namespace B (instana-agent-alternate).
+func TestMultiNamespaceOperatorDeployment(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
+
+	// Create agent CR for alternate namespace
+	agent := NewAgentCr()
+	agent.Name = "instana-agent-alternate"
+	agent.Namespace = AlternateAgentNamespace
+
+	multiNamespaceFeature := features.New("operator manages CR in different namespace").
+		Setup(SetupOperatorDevBuild()). // Operator in instana-agent namespace
+		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		Setup(CreateNamespace(AlternateAgentNamespace)).
+		Setup(DeployAgentCrInNamespace(&agent, AlternateAgentNamespace)).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Wait for operator to reconcile the CR and create resources
+			t.Log("Waiting for operator to reconcile CR in alternate namespace")
+			time.Sleep(10 * time.Second)
+			return ctx
+		}).
+		Assess(
+			"verify agent resources created in alternate namespace",
+			VerifyAgentResourcesInNamespace(AlternateAgentNamespace),
+		).
+		Assess("verify resources have managed-by label", VerifyManagedByLabels(AlternateAgentNamespace)).
+		Assess("verify operator reconciles deleted resources", VerifyReconciliationAcrossNamespaces(AlternateAgentNamespace)).
+		Teardown(CleanupNamespace(AlternateAgentNamespace)).
+		Feature()
+
+	testEnv.Test(t, multiNamespaceFeature)
+}
+
+// TestCrossNamespaceKeysSecretAccess tests that the operator can access KeysSecret
+// in the agent's namespace (not the operator's namespace).
+// This verifies that Secrets are cached cluster-wide, allowing the operator
+// to manage agents in any namespace with their own KeysSecrets.
+func TestCrossNamespaceKeysSecretAccess(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
+
+	const agentNamespace = "instana-agent-keys-test"
+	const keysSecretName = "external-keys"
+
+	agent := NewAgentCr()
+	agent.Name = "instana-agent-keys"
+	agent.Namespace = agentNamespace
+	agent.Spec.Agent.KeysSecret = keysSecretName // pragma: allowlist secret
+
+	crossNamespaceKeysFeature := features.New("operator accesses KeysSecret in agent namespace").
+		Setup(SetupOperatorDevBuild()).
+		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		Setup(CreateNamespace(agentNamespace)).
+		Setup(CreateKeysSecretInNamespace(keysSecretName, agentNamespace)).
+		Setup(DeployAgentCrInNamespace(&agent, agentNamespace)).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Wait for operator to reconcile CR and create resources
+			t.Log("Waiting for operator to reconcile CR with external KeysSecret")
+			time.Sleep(10 * time.Second)
+			return ctx
+		}).
+		Assess(
+			"verify agent references keys secret in same namespace",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				r, err := resources.New(cfg.Client().RESTConfig())
+				if err != nil {
+					t.Fatal("Failed to initialize client:", err)
+				}
+
+				agentCR := &v1.InstanaAgent{}
+				if err := r.Get(ctx, agent.Name, agentNamespace, agentCR); err != nil {
+					t.Fatalf("Failed to get agent CR: %v", err)
+				}
+
+				if agentCR.Spec.Agent.KeysSecret != keysSecretName {
+					t.Fatalf(
+						"Agent CR does not reference correct KeysSecret. Expected: %s, Got: %s",
+						keysSecretName,
+						agentCR.Spec.Agent.KeysSecret,
+					)
+				}
+
+				// Verify the secret exists in the agent's namespace
+				secret := &corev1.Secret{}
+				if err := r.Get(ctx, keysSecretName, agentNamespace, secret); err != nil {
+					t.Fatalf("Failed to get KeysSecret in agent namespace: %v", err)
+				}
+
+				t.Logf(
+					"✓ Agent CR correctly references KeysSecret '%s' in namespace '%s'",
+					keysSecretName,
+					agentNamespace,
+				)
+				return ctx
+			}).
+		Assess("wait for k8sensor deployment", WaitForK8sensorDeploymentInNamespace(agentNamespace)).
+		Assess("wait for agent daemonset", WaitForAgentDaemonSetInNamespace(agentNamespace)).
+		Teardown(CleanupNamespace(agentNamespace)).
+		Feature()
+
+	testEnv.Test(t, crossNamespaceKeysFeature)
+}
+
+// Helper Functions
+
+// CreateNamespace creates a namespace for testing
+func CreateNamespace(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Creating namespace: %s", namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+
+		if err := r.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", namespace, err)
+		}
+
+		t.Logf("Namespace %s created successfully", namespace)
+		return ctx
+	}
+}
+
+// CleanupNamespace deletes a namespace after testing
+// It first deletes any InstanaAgent CRs in the namespace to avoid reconciliation
+// conflicts during namespace termination
+func CleanupNamespace(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Cleaning up namespace: %s", namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Logf("Failed to initialize client for cleanup: %v", err)
+			return ctx
+		}
+
+		// First, try to get and delete any InstanaAgent CR in this namespace
+		// This prevents the operator from trying to reconcile during namespace termination
+		agent := &v1.InstanaAgent{}
+		// Try common CR names based on namespace
+		possibleNames := []string{namespace, "instana-agent"}
+		for _, name := range possibleNames {
+			if err := r.Get(ctx, name, namespace, agent); err == nil {
+				t.Logf("Deleting Agent CR %s/%s before namespace cleanup", namespace, name)
+				if err := r.Delete(ctx, agent); err != nil && !apierrors.IsNotFound(err) {
+					t.Logf("Warning: Failed to delete Agent CR %s/%s: %v", namespace, name, err)
+				} else {
+					// Give the operator time to process the CR deletion
+					t.Logf("Waiting for operator to process CR deletion in namespace %s", namespace)
+					time.Sleep(5 * time.Second)
+					break
+				}
+			}
+		}
+
+		// Now delete the namespace
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+
+		if err := r.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Warning: Failed to delete namespace %s: %v", namespace, err)
+		} else {
+			t.Logf("Namespace %s deleted successfully", namespace)
+		}
+
+		return ctx
+	}
+}
+
+// DeployAgentCrInNamespace deploys an InstanaAgent CR in a specific namespace
+func DeployAgentCrInNamespace(agent *v1.InstanaAgent, namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Deploying InstanaAgent CR '%s' in namespace '%s'", agent.Name, namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		agent.Namespace = namespace
+		if err := r.Create(ctx, agent); err != nil {
+			t.Fatalf("Failed to create InstanaAgent CR in namespace %s: %v", namespace, err)
+		}
+
+		t.Logf(
+			"InstanaAgent CR '%s' deployed successfully in namespace '%s'",
+			agent.Name,
+			namespace,
+		)
+		return ctx
+	}
+}
+
+// CreateKeysSecretInNamespace creates a KeysSecret in a specific namespace
+func CreateKeysSecretInNamespace(secretName, namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Creating KeysSecret '%s' in namespace '%s'", secretName, namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		secret := &corev1.Secret{ // pragma: allowlist secret
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"key": []byte(InstanaTestCfg.InstanaBackend.AgentKey), // pragma: allowlist secret
+			},
+		}
+
+		if err := r.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create KeysSecret in namespace %s: %v", namespace, err)
+		}
+
+		t.Logf("KeysSecret '%s' created successfully in namespace '%s'", secretName, namespace)
+		return ctx
+	}
+}
+
+// WaitForK8sensorDeploymentInNamespace waits for the k8sensor deployment to become ready in a specific namespace
+// Uses label-based discovery to find the deployment dynamically
+func WaitForK8sensorDeploymentInNamespace(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Waiting for k8sensor deployment in namespace '%s' to become ready", namespace)
+
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		err = wait.For(
+			func(ctx context.Context) (bool, error) {
+				// Find k8sensor deployment by label
+				depList := &appsv1.DeploymentList{}
+				if err := r.WithNamespace(namespace).List(ctx, depList); err != nil {
+					return false, err
+				}
+
+				for i := range depList.Items {
+					dep := &depList.Items[i]
+					if dep.Labels[ManagedByLabel] == ManagedByValue {
+						// Check if deployment is ready
+						for _, cond := range dep.Status.Conditions {
+							if cond.Type == appsv1.DeploymentAvailable &&
+								cond.Status == corev1.ConditionTrue {
+								t.Logf(
+									"✓ K8sensor deployment '%s' is ready in namespace '%s'",
+									dep.Name,
+									namespace,
+								)
+								return true, nil
+							}
+						}
+						// Deployment found but not ready yet
+						return false, nil
+					}
+				}
+				// Deployment not found yet
+				return false, nil
+			},
+			wait.WithTimeout(time.Minute*5),
+			wait.WithInterval(time.Second*5),
+		)
+
+		if err != nil {
+			t.Fatalf(
+				"K8sensor deployment in namespace '%s' did not become ready: %v",
+				namespace,
+				err,
+			)
+		}
+
+		return ctx
+	}
+}
+
+// WaitForAgentDaemonSetInNamespace waits for the agent daemonset to become ready in a specific namespace
+// Uses label-based discovery to find the daemonset dynamically
+func WaitForAgentDaemonSetInNamespace(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Waiting for agent daemonset in namespace '%s' to become ready", namespace)
+
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		err = wait.For(
+			func(ctx context.Context) (bool, error) {
+				// Find agent daemonset by label
+				dsList := &appsv1.DaemonSetList{}
+				if err := r.WithNamespace(namespace).List(ctx, dsList); err != nil {
+					return false, err
+				}
+
+				for i := range dsList.Items {
+					ds := &dsList.Items[i]
+					if ds.Labels[ManagedByLabel] == ManagedByValue {
+						// Check if daemonset is ready
+						if ds.Status.NumberReady > 0 &&
+							ds.Status.NumberReady == ds.Status.DesiredNumberScheduled {
+							t.Logf(
+								"✓ Agent daemonset '%s' is ready in namespace '%s'",
+								ds.Name,
+								namespace,
+							)
+							return true, nil
+						}
+						// DaemonSet found but not ready yet
+						return false, nil
+					}
+				}
+				// DaemonSet not found yet
+				return false, nil
+			},
+			wait.WithTimeout(time.Minute*5),
+			wait.WithInterval(time.Second*5),
+		)
+
+		if err != nil {
+			t.Fatalf("Agent daemonset in namespace '%s' did not become ready: %v", namespace, err)
+		}
+
+		return ctx
+	}
+}
+
+// VerifyAgentResourcesInNamespace verifies that agent resources are created in the specified namespace
+func VerifyAgentResourcesInNamespace(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Verifying agent resources in namespace '%s'", namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		// Debug: List all DaemonSets in all namespaces to see where they are
+		allDsList := &appsv1.DaemonSetList{}
+		if err := r.List(ctx, allDsList); err == nil {
+			t.Logf("DEBUG: Found %d DaemonSets across all namespaces:", len(allDsList.Items))
+			for _, ds := range allDsList.Items {
+				t.Logf("  - %s/%s", ds.Namespace, ds.Name)
+			}
+		}
+
+		// Check for DaemonSet - operator names it after the CR name, not a fixed name
+		// List all DaemonSets in the namespace
+		client := cfg.Client()
+		dsList := &appsv1.DaemonSetList{}
+		if err := client.Resources(namespace).List(ctx, dsList); err != nil {
+			t.Fatalf("Failed to list DaemonSets in namespace %s: %v", namespace, err)
+		}
+
+		if len(dsList.Items) == 0 {
+			t.Fatalf("No DaemonSets found in namespace %s", namespace)
+		}
+
+		// Find the agent DaemonSet (should have the managed-by label)
+		var agentDS *appsv1.DaemonSet
+		for i := range dsList.Items {
+			if dsList.Items[i].Labels[ManagedByLabel] == ManagedByValue {
+				agentDS = &dsList.Items[i]
+				break
+			}
+		}
+
+		if agentDS == nil {
+			t.Fatalf(
+				"No agent DaemonSet with label %s=%s found in namespace %s",
+				ManagedByLabel,
+				ManagedByValue,
+				namespace,
+			)
+		}
+		t.Logf("✓ DaemonSet '%s' found in namespace '%s'", agentDS.Name, namespace)
+
+		// Check for Deployment - operator names it after the CR name with -k8sensor suffix
+		depList := &appsv1.DeploymentList{}
+		if err := client.Resources(namespace).List(ctx, depList); err != nil {
+			t.Fatalf("Failed to list Deployments in namespace %s: %v", namespace, err)
+		}
+
+		// Find the k8sensor deployment (should have the managed-by label)
+		var k8sensorDep *appsv1.Deployment
+		for i := range depList.Items {
+			if depList.Items[i].Labels[ManagedByLabel] == ManagedByValue {
+				k8sensorDep = &depList.Items[i]
+				break
+			}
+		}
+
+		if k8sensorDep == nil {
+			t.Fatalf(
+				"No k8sensor Deployment with label %s=%s found in namespace %s",
+				ManagedByLabel,
+				ManagedByValue,
+				namespace,
+			)
+		}
+		t.Logf("✓ Deployment '%s' found in namespace '%s'", k8sensorDep.Name, namespace)
+
+		// Check for ServiceAccount (find by label)
+		saList := &corev1.ServiceAccountList{}
+		if err := r.WithNamespace(namespace).List(ctx, saList); err != nil {
+			t.Fatalf("Failed to list ServiceAccounts in namespace %s: %v", namespace, err)
+		}
+
+		var agentSA *corev1.ServiceAccount
+		for i := range saList.Items {
+			if saList.Items[i].Labels[ManagedByLabel] == ManagedByValue {
+				agentSA = &saList.Items[i]
+				break
+			}
+		}
+
+		if agentSA == nil {
+			t.Fatalf(
+				"ServiceAccount with label %s=%s not found in namespace %s",
+				ManagedByLabel,
+				ManagedByValue,
+				namespace,
+			)
+		}
+		t.Logf("✓ ServiceAccount '%s' found in namespace '%s'", agentSA.Name, namespace)
+
+		t.Logf("All agent resources verified in namespace '%s'", namespace)
+		return ctx
+	}
+}
+
+// VerifyManagedByLabels verifies that all operator-created resources have the managed-by label.
+// This is critical for the label-based cache filtering to work correctly.
+func VerifyManagedByLabels(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Verifying managed-by labels in namespace '%s'", namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		// Check DaemonSet labels
+		ds := &appsv1.DaemonSet{}
+		if err := r.Get(ctx, AgentDaemonSetName, namespace, ds); err == nil {
+			if ds.Labels[ManagedByLabel] != ManagedByValue {
+				t.Errorf("DaemonSet missing or incorrect managed-by label. Expected: %s, Got: %s",
+					ManagedByValue, ds.Labels[ManagedByLabel])
+			} else {
+				t.Logf("✓ DaemonSet has correct managed-by label")
+			}
+		}
+
+		// Check Deployment labels
+		dep := &appsv1.Deployment{}
+		if err := r.Get(ctx, K8sensorDeploymentName, namespace, dep); err == nil {
+			if dep.Labels[ManagedByLabel] != ManagedByValue {
+				t.Errorf("Deployment missing or incorrect managed-by label. Expected: %s, Got: %s",
+					ManagedByValue, dep.Labels[ManagedByLabel])
+			} else {
+				t.Logf("✓ Deployment has correct managed-by label")
+			}
+		}
+
+		// Check ServiceAccount labels
+		sa := &corev1.ServiceAccount{}
+		if err := r.Get(ctx, "instana-agent", namespace, sa); err == nil {
+			if sa.Labels[ManagedByLabel] != ManagedByValue {
+				t.Errorf(
+					"ServiceAccount missing or incorrect managed-by label. Expected: %s, Got: %s",
+					ManagedByValue,
+					sa.Labels[ManagedByLabel],
+				)
+			} else {
+				t.Logf("✓ ServiceAccount has correct managed-by label")
+			}
+		}
+
+		// Check ClusterRole labels (cluster-scoped, but should still have label)
+		cr := &rbacv1.ClusterRole{}
+		clusterRoleName := fmt.Sprintf("instana-agent-clusterrole-%s", namespace)
+		if err := r.Get(ctx, clusterRoleName, "", cr); err == nil {
+			if cr.Labels[ManagedByLabel] != ManagedByValue {
+				t.Errorf("ClusterRole missing or incorrect managed-by label. Expected: %s, Got: %s",
+					ManagedByValue, cr.Labels[ManagedByLabel])
+			} else {
+				t.Logf("✓ ClusterRole has correct managed-by label")
+			}
+		}
+
+		t.Logf("Managed-by labels verified in namespace '%s'", namespace)
+		return ctx
+	}
+}
+
+// VerifyReconciliationAcrossNamespaces verifies that the operator can reconcile resources
+// in a namespace different from where the operator is deployed.
+// This tests that the label-based cache filtering allows cross-namespace reconciliation.
+func VerifyReconciliationAcrossNamespaces(namespace string) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Logf("Verifying cross-namespace reconciliation for namespace '%s'", namespace)
+		r, err := resources.New(cfg.Client().RESTConfig())
+		if err != nil {
+			t.Fatal("Failed to initialize client:", err)
+		}
+
+		// Find the DaemonSet by label (not by hardcoded name)
+		dsList := &appsv1.DaemonSetList{}
+		if err := r.WithNamespace(namespace).List(ctx, dsList); err != nil {
+			t.Fatalf("Failed to list DaemonSets: %v", err)
+		}
+
+		var ds *appsv1.DaemonSet
+		for i := range dsList.Items {
+			if dsList.Items[i].Labels[ManagedByLabel] == ManagedByValue {
+				ds = &dsList.Items[i]
+				break
+			}
+		}
+
+		if ds == nil {
+			t.Fatalf(
+				"DaemonSet with label %s=%s not found in namespace %s",
+				ManagedByLabel,
+				ManagedByValue,
+				namespace,
+			)
+		}
+
+		originalUID := ds.UID
+		originalName := ds.Name
+		t.Logf(
+			"Deleting DaemonSet '%s' (UID: %s) to trigger reconciliation",
+			originalName,
+			originalUID,
+		)
+
+		if err := r.Delete(ctx, ds); err != nil {
+			t.Fatalf("Failed to delete DaemonSet: %v", err)
+		}
+
+		// Wait for the DaemonSet to be recreated by the operator
+		t.Logf("Waiting for operator to recreate DaemonSet in namespace '%s'", namespace)
+		err = wait.For(
+			func(ctx context.Context) (bool, error) {
+				// List DaemonSets and find the one with managed-by label
+				newDsList := &appsv1.DaemonSetList{}
+				if err := r.WithNamespace(namespace).List(ctx, newDsList); err != nil {
+					return false, err
+				}
+
+				for i := range newDsList.Items {
+					if newDsList.Items[i].Labels[ManagedByLabel] == ManagedByValue {
+						// Verify it's a new resource (different UID)
+						return newDsList.Items[i].UID != originalUID, nil
+					}
+				}
+				return false, nil // DaemonSet not found yet
+			},
+			wait.WithTimeout(time.Minute*2),
+			wait.WithInterval(time.Second*5),
+		)
+
+		if err != nil {
+			t.Fatalf("Operator failed to reconcile DaemonSet in namespace %s: %v", namespace, err)
+		}
+
+		t.Logf("✓ Operator successfully reconciled resources across namespaces")
+		return ctx
+	}
+}
+
+// Made with Bob

--- a/e2e/multizone_test.go
+++ b/e2e/multizone_test.go
@@ -373,6 +373,7 @@ func CleanupNodeLabels() features.Func {
 }
 
 func TestMultiZones(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	installWithMultiZones := features.New("multizone agent").
 		Setup(SetupOperatorDevBuild()).
 		Setup(WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).

--- a/e2e/namespace_configmap_test.go
+++ b/e2e/namespace_configmap_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestNamespaceLabelConfigmap(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCr()
 	installAndCheckNamespaceLabels := features.New("check namespace configmap in agent pods").
 		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready

--- a/e2e/opentelemetry_ports_test.go
+++ b/e2e/opentelemetry_ports_test.go
@@ -25,6 +25,7 @@ const (
 )
 
 func TestOpenTelemetryPorts(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Define the test feature
 	openTelemetryPortsFeature := features.New("opentelemetry ports configuration").
 		Setup(SetupOperatorDevBuild()).

--- a/e2e/secret_mounts_test.go
+++ b/e2e/secret_mounts_test.go
@@ -704,6 +704,7 @@ func WaitForPodsToBeRecreatedForComponent(component string) features.Func {
 
 // TestSecretMountsDefaultBehavior tests the default behavior with useSecretMounts: true
 func TestSecretMountsDefaultBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCrWithSecretMounts(true)
 
 	defaultBehaviorFeature := features.New("secret mounts default behavior (useSecretMounts: true)").
@@ -729,6 +730,7 @@ func TestSecretMountsDefaultBehavior(t *testing.T) {
 
 // TestSecretMountsLegacyBehavior tests the legacy behavior with useSecretMounts: false
 func TestSecretMountsLegacyBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCrWithSecretMounts(false)
 
 	legacyBehaviorFeature := features.New("secret mounts legacy behavior (useSecretMounts: false)").
@@ -745,6 +747,7 @@ func TestSecretMountsLegacyBehavior(t *testing.T) {
 
 // TestSecretMountsSwitchingModes tests switching between secret mounts modes
 func TestSecretMountsSwitchingModes(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCrWithSecretMounts(true)
 
 	switchingModesFeature := features.New("switching between secret mounts modes").
@@ -772,6 +775,7 @@ func TestSecretMountsSwitchingModes(t *testing.T) {
 
 // TestSecretMountsHttpsProxyFile tests the https-proxy-file functionality
 func TestSecretMountsHttpsProxyFile(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Create a modified agent with proxy settings and ensure the proxy host is set
 	agent := NewAgentCrWithSecretMountsAndProxy()
 
@@ -799,6 +803,7 @@ func TestSecretMountsHttpsProxyFile(t *testing.T) {
 
 // TestRemoteSecretMountsDefaultBehavior tests the default behavior with useSecretMounts: true for remote agent
 func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCrWithSecretMounts(true)
 
 	defaultBehaviorFeature := features.New("remote agent secret mounts default behavior (useSecretMounts: true)").
@@ -826,6 +831,7 @@ func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
 
 // TestRemoteSecretMountsLegacyBehavior tests the legacy behavior with useSecretMounts: false for remote agent
 func TestRemoteSecretMountsLegacyBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCrWithSecretMounts(false)
 
 	legacyBehaviorFeature := features.New("remote agent secret mounts legacy behavior (useSecretMounts: false)").
@@ -844,6 +850,7 @@ func TestRemoteSecretMountsLegacyBehavior(t *testing.T) {
 
 // TestRemoteSecretMountsSwitchingModes tests switching between secret mounts modes for remote agent
 func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCrWithSecretMounts(true)
 
 	switchingModesFeature := features.New("switching between remote agent secret mounts modes").
@@ -890,6 +897,7 @@ func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
 
 // TestRemoteSecretMountsHttpsProxyFile tests the https-proxy-file functionality for remote agent
 func TestRemoteSecretMountsHttpsProxyFile(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Create a modified agent with proxy settings and ensure the proxy host is set
 	agent := NewAgentRemoteCrWithSecretMountsAndProxy()
 

--- a/e2e/secure_etcd_scraping_test.go
+++ b/e2e/secure_etcd_scraping_test.go
@@ -21,10 +21,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/pkg/types"
@@ -75,6 +77,24 @@ func SetupETCDCASecret() types.StepFunc {
 			t.Fatal("Failed to create CA certificate Secret:", err) // pragma: allowlist secret
 		}
 		t.Log("CA certificate Secret created")
+
+		// Wait for secret to be fully available before proceeding
+		// This prevents race conditions where the operator reconciles before the secret exists
+		t.Log("Waiting for secret to be available")
+		secret := &corev1.Secret{}
+		err = wait.For(
+			func(ctx context.Context) (bool, error) {
+				err := r.Get(ctx, "etcd-ca-cert", cfg.Namespace(), secret)
+				return err == nil, nil
+			},
+			wait.WithTimeout(time.Second*30),
+			wait.WithInterval(time.Second*1),
+		)
+		if err != nil {
+			t.Fatal("Secret did not become available:", err)
+		}
+		t.Log("Secret is available")
+
 		CleanupSecretAfterTest(t, cfg.Namespace(), "etcd-ca-cert")
 
 		return ctx
@@ -142,6 +162,8 @@ func SetupInstanaAgentCR() types.StepFunc {
 }
 
 func TestSecureETCDScraping(t *testing.T) {
+	// Collect operator logs if test fails
+	CollectOperatorLogsOnFailure(t)
 
 	installCrWithSecureETCDFeature := features.New("secure ETCD scraping").
 		Setup(SetupOperatorDevBuild()).

--- a/e2e/selective_monitoring_test.go
+++ b/e2e/selective_monitoring_test.go
@@ -38,6 +38,7 @@ const (
 // It deploys the agent in opt-in mode and verifies that only JVMs in namespaces with the
 // instana-workload-monitoring=true label are monitored.
 func TestSelectiveMonitoring(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Create a new agent CR with selective monitoring enabled
 	agent := NewAgentCrWithSelectiveMonitoring()
 
@@ -253,6 +254,8 @@ func deployJavaDemoApp(
 }
 
 // VerifySelectiveMonitoring verifies that only the JVM in the opt-in namespace is monitored.
+// This implementation correlates PIDs with container IDs and mapping them
+// back to pods/namespaces using the Kubernetes API.
 func VerifySelectiveMonitoring() features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		t.Log("Verifying selective monitoring...")
@@ -270,11 +273,9 @@ func VerifySelectiveMonitoring() features.Func {
 			NamespaceOptIn,
 		}
 
-		// Find all demo app pods across all namespaces
-		t.Log("Finding all demo app pods...")
-		var demoAppPods []corev1.Pod
-		var demoAppNodes = make(map[string]bool)
-		var podsByNamespace = make(map[string][]corev1.Pod)
+		// Build a map of container ID to pod/namespace for quick lookup
+		t.Log("Building container ID to pod/namespace mapping...")
+		containerToPod := make(map[string]*podInfo)
 
 		for _, ns := range namespaces {
 			podList, err := clientSet.CoreV1().Pods(ns).List(
@@ -288,17 +289,25 @@ func VerifySelectiveMonitoring() features.Func {
 				continue
 			}
 
-			podsByNamespace[ns] = podList.Items
 			for _, pod := range podList.Items {
-				demoAppPods = append(demoAppPods, pod)
-				demoAppNodes[pod.Spec.NodeName] = true
-				t.Logf("Found demo app pod %s in namespace %s on node %s",
-					pod.Name, pod.Namespace, pod.Spec.NodeName)
+				for _, containerStatus := range pod.Status.ContainerStatuses {
+					// Extract container ID (format: containerd://abc123...)
+					containerID := extractContainerID(containerStatus.ContainerID)
+					if containerID != "" {
+						containerToPod[containerID] = &podInfo{
+							name:      pod.Name,
+							namespace: pod.Namespace,
+							nodeName:  pod.Spec.NodeName,
+						}
+						t.Logf("Mapped container ID %s to pod %s in namespace %s on node %s",
+							containerID, pod.Name, pod.Namespace, pod.Spec.NodeName)
+					}
+				}
 			}
 		}
 
-		if len(demoAppPods) == 0 {
-			t.Fatal("No demo app pods found in any namespace")
+		if len(containerToPod) == 0 {
+			t.Fatal("No demo app containers found in any namespace")
 		}
 
 		// Get all agent pods
@@ -312,25 +321,6 @@ func VerifySelectiveMonitoring() features.Func {
 		if len(agentPodList.Items) == 0 {
 			t.Fatal("No agent pods found")
 		}
-
-		// Find agent pods running on the same nodes as our demo apps
-		var relevantAgentPods []corev1.Pod
-		for _, agentPod := range agentPodList.Items {
-			if demoAppNodes[agentPod.Spec.NodeName] {
-				relevantAgentPods = append(relevantAgentPods, agentPod)
-				t.Logf("Found agent pod %s on node %s that has demo app pods",
-					agentPod.Name, agentPod.Spec.NodeName)
-			}
-		}
-
-		if len(relevantAgentPods) == 0 {
-			t.Fatal("No agent pods found on nodes where demo apps are running")
-		}
-
-		// Define regex patterns for finding PIDs and attachment logs
-		vmDiscoveryRegex := regexp.MustCompile(
-			`adding new VM with PID (\d+).*INSTANA_TEST_POD_NAME=([^,\s]+)`,
-		)
 
 		// Track attachment status for each namespace
 		attachmentStatus := map[string]bool{
@@ -353,8 +343,7 @@ func VerifySelectiveMonitoring() features.Func {
 
 		for time.Now().Before(deadline) {
 			// Check if we've already found attachments that shouldn't happen
-			if attachmentStatus[NamespaceNoLabel] ||
-				attachmentStatus[NamespaceOptOut] {
+			if attachmentStatus[NamespaceNoLabel] || attachmentStatus[NamespaceOptOut] {
 				t.Error("Found JVM attachment in namespace that should not be monitored")
 				break
 			}
@@ -365,9 +354,9 @@ func VerifySelectiveMonitoring() features.Func {
 				break
 			}
 
-			// Check logs from all relevant agent pods
-			for _, agentPod := range relevantAgentPods {
-				t.Logf("Checking logs from agent pod %s on worker node %s",
+			// Check logs from all agent pods
+			for _, agentPod := range agentPodList.Items {
+				t.Logf("Checking logs from agent pod %s on node %s",
 					agentPod.Name, agentPod.Spec.NodeName)
 
 				var buf bytes.Buffer
@@ -393,55 +382,11 @@ func VerifySelectiveMonitoring() features.Func {
 				// Store the logs for this agent pod
 				agentLogs[agentPod.Name] = logs
 
-				t.Logf("Agent logs retrieved from pod %s on worker node %s, checking for JVM attachment...",
-					agentPod.Name, agentPod.Spec.NodeName)
+				t.Logf("Agent logs retrieved from pod %s, analyzing for JVM attachments...",
+					agentPod.Name)
 
-				// For each namespace, check if its pods are being monitored
-				for ns, pods := range podsByNamespace {
-					for _, pod := range pods {
-						podName := pod.Name
-
-						// Look for VM discovery log entries for this pod
-						matches := vmDiscoveryRegex.FindAllStringSubmatch(logs, -1)
-						for _, match := range matches {
-							if len(match) >= 3 && strings.Contains(match[2], podName) {
-								// Found a VM discovery log for this pod
-								pid := match[1]
-								t.Logf("Found VM discovery for pod %s in namespace %s with PID %s",
-									podName, ns, pid)
-
-								// Check if there's an initial attach attempt
-								attachAttemptPattern := fmt.Sprintf(
-									"Performing initial attach to JVM with PID %s",
-									pid,
-								)
-								if strings.Contains(logs, attachAttemptPattern) {
-									t.Logf(
-										"Found attach attempt for pod %s (PID %s) in namespace %s",
-										podName,
-										pid,
-										ns,
-									)
-
-									// Check if the attachment was successful
-									attachSuccessPattern := fmt.Sprintf(
-										"Initial attach to JVM with PID %s successful",
-										pid,
-									)
-									if strings.Contains(logs, attachSuccessPattern) {
-										t.Logf(
-											"Found successful attachment for pod %s (PID %s) in namespace %s",
-											podName,
-											pid,
-											ns,
-										)
-										attachmentStatus[ns] = true
-									}
-								}
-							}
-						}
-					}
-				}
+				// Analyze logs using the new correlation approach
+				analyzeLogsForAttachments(t, logs, containerToPod, attachmentStatus)
 			}
 
 			// If we haven't found what we're looking for, wait before checking again
@@ -498,10 +443,91 @@ func VerifySelectiveMonitoring() features.Func {
 		// If we have failures, dump the agent logs for debugging
 		if hasFailures {
 			t.Log("Test failed - dumping agent logs for debugging purposes")
-			dumpAgentLogs(t, agentLogs, relevantAgentPods)
+			dumpAgentLogs(t, agentLogs, agentPodList.Items)
 		}
 
 		return ctx
+	}
+}
+
+// podInfo holds information about a pod for container-to-pod mapping
+type podInfo struct {
+	name      string
+	namespace string
+	nodeName  string
+}
+
+// extractContainerID extracts the actual container ID from the full container ID string
+// (e.g., "containerd://abc123..." -> "abc123...")
+func extractContainerID(fullContainerID string) string {
+	parts := strings.SplitN(fullContainerID, "://", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return fullContainerID
+}
+
+// analyzeLogsForAttachments analyzes agent logs to find JVM attachments and correlates them
+// with pods/namespaces using container ID mapping
+func analyzeLogsForAttachments(
+	t *testing.T,
+	logs string,
+	containerToPod map[string]*podInfo,
+	attachmentStatus map[string]bool,
+) {
+	// Regex patterns for extracting information from logs
+	// Pattern 1: VM discovery with PID and container ID
+	// Example: "adding new VM with PID 57368, ContainerizedVirtualMachineImpl
+	// [pid=57368...containerId=2e88aa9bd86c8fbb..."
+	vmDiscoveryRegex := regexp.MustCompile(
+		`adding new VM with PID (\d+).*containerId=([a-f0-9]+)`,
+	)
+
+	// Pattern 2: Successful JVM attachment
+	// Example: "Initial attach to JVM with PID 57368 successful"
+	attachSuccessRegex := regexp.MustCompile(
+		`Initial attach to JVM with PID (\d+) successful`,
+	)
+
+	// Build a map of PID to container ID from VM discovery logs
+	pidToContainerID := make(map[string]string)
+	vmMatches := vmDiscoveryRegex.FindAllStringSubmatch(logs, -1)
+	for _, match := range vmMatches {
+		if len(match) >= 3 {
+			pid := match[1]
+			containerID := match[2]
+			pidToContainerID[pid] = containerID
+			t.Logf("Found VM discovery: PID %s -> Container ID %s", pid, containerID)
+		}
+	}
+
+	// Find successful attachments and correlate with namespaces
+	attachMatches := attachSuccessRegex.FindAllStringSubmatch(logs, -1)
+	for _, match := range attachMatches {
+		if len(match) >= 2 {
+			pid := match[1]
+			t.Logf("Found successful JVM attachment for PID %s", pid)
+
+			// Look up the container ID for this PID
+			containerID, found := pidToContainerID[pid]
+			if !found {
+				t.Logf("Warning: Could not find container ID for PID %s", pid)
+				continue
+			}
+
+			// Look up the pod info for this container ID
+			podInfo, found := containerToPod[containerID]
+			if !found {
+				t.Logf("Warning: Could not find pod info for container ID %s", containerID)
+				continue
+			}
+
+			t.Logf("Successfully correlated PID %s -> Container %s -> Pod %s in namespace %s",
+				pid, containerID, podInfo.name, podInfo.namespace)
+
+			// Mark this namespace as having an attachment
+			attachmentStatus[podInfo.namespace] = true
+		}
 	}
 }
 

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	RequireFullResetBeforeTest(
 		t,
 		"TestUpdateInstallFromOldGenericResourceNames requires clean environment before installing legacy operator",

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
@@ -55,6 +57,57 @@ func init() {
 	utilruntime.Must(agentoperatorv1.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
+}
+
+// getCacheOptions returns the cache configuration for the operator
+// This configuration enables multi-namespace support while maintaining memory efficiency
+// through label-based filtering
+func getCacheOptions() (cache.Options, error) {
+	// Label selector for resources managed by this operator
+	managedByOperator, err := labels.Parse("app.kubernetes.io/managed-by=instana-agent-operator")
+	if err != nil {
+		return cache.Options{}, err
+	}
+
+	return cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			// InstanaAgent and InstanaAgentRemote CRs - watch all namespaces
+			&agentoperatorv1.InstanaAgent{}:       {},
+			&agentoperatorv1.InstanaAgentRemote{}: {},
+
+			// Namespace objects - watch all for label monitoring (instana-workload-monitoring)
+			&corev1.Namespace{}: {},
+
+			// Operator-managed resources - filter by label across all namespaces
+			&appsv1.DaemonSet{}: {
+				Label: managedByOperator,
+			},
+			&appsv1.Deployment{}: {
+				Label: managedByOperator,
+			},
+			&corev1.ServiceAccount{}: {
+				Label: managedByOperator,
+			},
+			&policyv1.PodDisruptionBudget{}: {
+				Label: managedByOperator,
+			},
+			&rbacv1.ClusterRole{}: {
+				Label: managedByOperator,
+			},
+			&rbacv1.ClusterRoleBinding{}: {
+				Label: managedByOperator,
+			},
+
+			// ConfigMaps and Secrets - watch all namespaces without label filter
+			// This allows access to user-provided KeysSecrets and ETCD resources
+			// in openshift-etcd and kube-system namespaces
+			&corev1.ConfigMap{}: {},
+			&corev1.Secret{}:    {},
+
+			// Services - watch all namespaces for ETCD service discovery
+			&corev1.Service{}: {},
+		},
+	}, nil
 }
 
 func main() {
@@ -101,18 +154,20 @@ func main() {
 		log.Info("Leader election namespace set from POD_NAMESPACE", "namespace", operatorNamespace)
 	}
 
-	// Configure cache to only watch resources in the operator's namespace
-	// This prevents caching ALL resources cluster-wide and reduces memory usage significantly
-	// ClusterRole and ClusterRoleBinding are cluster-scoped so they will still be cached cluster-wide
-	log.Info("Configuring cache to watch only operator namespace", "namespace", operatorNamespace)
+	// Configure cache to watch only resources managed by this operator using label selectors
+	// This reduces memory usage while allowing the operator to work across namespaces
+	// Resources created by the operator have label: app.kubernetes.io/managed-by=instana-agent-operator
+	log.Info("Configuring cache with label-based filtering for operator-managed resources")
+
+	cacheOpts, err := getCacheOptions()
+	if err != nil {
+		log.Error(err, "Failed to create cache options")
+		os.Exit(1)
+	}
 
 	mgr, err := ctrl.NewManager(
 		cfg, ctrl.Options{
-			Cache: cache.Options{
-				DefaultNamespaces: map[string]cache.Config{
-					operatorNamespace: {},
-				},
-			},
+			Cache: cacheOpts,
 			Metrics: metricsserver.Options{
 				BindAddress: metricsAddr,
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -21,34 +21,79 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	ctrl "sigs.k8s.io/controller-runtime"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentoperatorv1 "github.com/instana/instana-agent-operator/api/v1"
 )
 
-func TestManagerCacheConfiguration(t *testing.T) {
+func TestLabelBasedCacheConfiguration(t *testing.T) {
 	assertions := require.New(t)
 
-	operatorNamespace := "test-namespace"
-	assertions.NoError(os.Setenv("POD_NAMESPACE", operatorNamespace))
-	defer func() {
-		assertions.NoError(os.Unsetenv("POD_NAMESPACE"))
-	}()
+	// Get cache options using the shared function
+	cacheOpts, err := getCacheOptions()
+	assertions.NoError(err)
+	assertions.NotNil(cacheOpts.ByObject)
+	assertions.Len(cacheOpts.ByObject, 12, "Should have 12 resource types configured")
 
-	opts := ctrl.Options{
-		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				operatorNamespace: {},
-			},
-		},
-		Controller: config.Controller{
-			SkipNameValidation: func() *bool { b := true; return &b }(),
-		},
+	// Verify the cache configuration structure is correct
+	assertions.IsType(map[client.Object]cache.ByObject{}, cacheOpts.ByObject)
+}
+
+func TestOperatorManagedLabelSelector(t *testing.T) {
+	assertions := require.New(t)
+
+	// Test the label selector parsing
+	managedByOperator, err := labels.Parse("app.kubernetes.io/managed-by=instana-agent-operator")
+	assertions.NoError(err)
+	assertions.NotNil(managedByOperator)
+
+	// Test that the selector matches expected labels
+	testLabels := map[string]string{
+		"app.kubernetes.io/managed-by": "instana-agent-operator",
+		"app.kubernetes.io/name":       "instana-agent",
 	}
+	assertions.True(managedByOperator.Matches(labels.Set(testLabels)))
 
-	assertions.NotNil(opts.Cache.DefaultNamespaces)
-	assertions.Len(opts.Cache.DefaultNamespaces, 1)
-	assertions.Contains(opts.Cache.DefaultNamespaces, operatorNamespace)
+	// Test that the selector doesn't match non-operator resources
+	nonOperatorLabels := map[string]string{
+		"app": "some-other-app",
+	}
+	assertions.False(managedByOperator.Matches(labels.Set(nonOperatorLabels)))
+}
+
+func TestCacheConfigurationForMultiNamespaceSupport(t *testing.T) {
+	assertions := require.New(t)
+
+	// Get cache options using the shared function
+	cacheOpts, err := getCacheOptions()
+	assertions.NoError(err)
+	assertions.NotNil(cacheOpts.ByObject)
+
+	// Verify InstanaAgent CRs are cached without namespace restriction
+	agentConfig := cacheOpts.ByObject[&agentoperatorv1.InstanaAgent{}]
+	assertions.Nil(agentConfig.Label, "InstanaAgent CRs should be cached in all namespaces")
+
+	// Verify ConfigMaps are cached cluster-wide for ETCD discovery
+	configMapConfig := cacheOpts.ByObject[&corev1.ConfigMap{}]
+	assertions.Nil(
+		configMapConfig.Label,
+		"ConfigMaps should be cached cluster-wide for ETCD discovery",
+	)
+
+	// Verify Secrets are cached cluster-wide for ETCD and user secrets
+	secretConfig := cacheOpts.ByObject[&corev1.Secret{}]
+	assertions.Nil(secretConfig.Label, "Secrets should be cached cluster-wide")
+
+	// Verify Services are cached cluster-wide for ETCD discovery
+	serviceConfig := cacheOpts.ByObject[&corev1.Service{}]
+	assertions.Nil(
+		serviceConfig.Label,
+		"Services should be cached cluster-wide for ETCD discovery",
+	)
 }
 
 func TestOperatorNamespaceFromEnvironment(t *testing.T) {
@@ -100,19 +145,26 @@ func TestOperatorNamespaceFromEnvironment(t *testing.T) {
 func TestCacheOptionsStructure(t *testing.T) {
 	assertions := require.New(t)
 
-	operatorNamespace := "test-namespace"
+	managedByOperator, err := labels.Parse("app.kubernetes.io/managed-by=instana-agent-operator")
+	assertions.NoError(err)
+
+	// Store the key to verify map access
+	daemonSetKey := &appsv1.DaemonSet{}
 
 	cacheOpts := cache.Options{
-		DefaultNamespaces: map[string]cache.Config{
-			operatorNamespace: {},
+		ByObject: map[client.Object]cache.ByObject{
+			daemonSetKey: {Label: managedByOperator},
 		},
 	}
 
-	assertions.NotNil(cacheOpts.DefaultNamespaces)
-	assertions.IsType(map[string]cache.Config{}, cacheOpts.DefaultNamespaces)
+	assertions.NotNil(cacheOpts.ByObject)
+	assertions.IsType(map[client.Object]cache.ByObject{}, cacheOpts.ByObject)
+	assertions.Len(cacheOpts.ByObject, 1, "Should have one resource type configured")
 
-	_, exists := cacheOpts.DefaultNamespaces[operatorNamespace]
-	assertions.True(exists)
+	// Verify using the same key reference
+	daemonSetConfig := cacheOpts.ByObject[daemonSetKey]
+	assertions.NotNil(daemonSetConfig.Label, "DaemonSet should have label filter")
+	assertions.Equal(managedByOperator, daemonSetConfig.Label)
 }
 
 // Made with Bob


### PR DESCRIPTION
Follow-up to PR #503 memory optimization - restores multi-namespace support while maintaining memory efficiency benefits.

This fix replaces namespace-scoped cache with label-based filtering using ByObject configuration, enabling the operator to:

- Support InstanaAgent CRs in any namespace (not just operator namespace)
- Access ETCD resources in openshift-etcd and kube-system namespaces
- Query namespaces with instana-workload-monitoring label
- Access user-provided KeysSecrets in any namespace

Implementation:
- Applied label filter (app.kubernetes.io/managed-by=instana-agent-operator) to operator-managed resources (DaemonSet, Deployment, ServiceAccount, PodDisruptionBudget, ClusterRole, ClusterRoleBinding)
- Configured cluster-wide caching for specific resource types:
  * ConfigMaps: Required for OpenShift ETCD CA bundle (openshift-etcd/etcd-ca-bundle)
  * Secrets: Required for OpenShift ETCD client cert (openshift-etcd/etcd-client) and user-provided KeysSecrets (spec.agent.keysSecret) in any namespace
  * Services: Required for vanilla K8s ETCD discovery (kube-system/etcd)
- Enabled InstanaAgent/InstanaAgentRemote CRs to be watched in all namespaces
- Added comprehensive tests for label-based cache configuration

Benefits:
- Preserves memory optimization from PR #503
- Restores full multi-namespace functionality
- Maintains efficient resource filtering through labels
- Supports all operator use cases (ETCD monitoring, selective monitoring, etc.)

Related: #503

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-88238)
- [CSP](https://ibmsf.lightning.force.com/lightning/r/Case/500gJ00000BWwc2QAD/view)

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated? -- automation takes care of it
- [x] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
