### PR TITLE
e2e: add cleanup helpers for secrets and configmaps

### DIFF
--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -941,3 +941,36 @@ func CleanupConfigMapAfterTest(t *testing.T, namespace, name string) {
 		}
 	})
 }
+
+// CollectOperatorLogsOnFailure collects operator logs when a test fails for easier debugging
+func CollectOperatorLogsOnFailure(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("==== Test failed, collecting operator logs ====")
+			p := utils.RunCommand(
+				"kubectl logs -n instana-agent deployment/instana-agent-controller-manager --tail=100",
+			)
+			if p.Err() != nil {
+				t.Logf("Could not collect operator logs: %v", p.Err())
+			} else {
+				t.Logf("Operator logs (last 100 lines):\n%s", p.Result())
+			}
+		}
+	})
+}
+
+// RequireFullResetAfterTest ensures that the next test run performs a full cleanup, regardless of the fast-path state.
+func RequireFullResetAfterTest(t *testing.T, reason string) {
+	t.Helper()
+	t.Cleanup(func() {
+		t.Logf("Test requested full reset: %s", reason)
+		MarkFullResetRequired(reason)
+	})
+}
+
+func RequireFullResetBeforeTest(t *testing.T, reason string) {
+	t.Helper()
+	t.Logf("Requesting full reset before test: %s", reason)
+	MarkFullResetRequired(reason)
+}

--- a/e2e/agent_test_api.go
+++ b/e2e/agent_test_api.go
@@ -903,3 +903,41 @@ func PrintOperatorLogs(ctx context.Context, cfg *envconf.Config, t *testing.T) {
 	t.Log(p.Out())
 	t.Log("====== Operator logs end ======", p.Out())
 }
+
+func CleanupSecretAfterTest(t *testing.T, namespace, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		cmd := fmt.Sprintf("kubectl delete secret %s -n %s --ignore-not-found", name, namespace)
+		p := utils.RunCommand(cmd)
+		if p.Err() != nil {
+			t.Logf(
+				"Cleanup: Failed to delete secret %s/%s: %v (%s)",
+				namespace,
+				name,
+				p.Err(),
+				p.Out(),
+			)
+		} else {
+			t.Logf("Cleanup: Deleted secret %s/%s", namespace, name)
+		}
+	})
+}
+
+func CleanupConfigMapAfterTest(t *testing.T, namespace, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		cmd := fmt.Sprintf("kubectl delete configmap %s -n %s --ignore-not-found", name, namespace)
+		p := utils.RunCommand(cmd)
+		if p.Err() != nil {
+			t.Logf(
+				"Cleanup: Failed to delete configmap %s/%s: %v (%s)",
+				namespace,
+				name,
+				p.Err(),
+				p.Out(),
+			)
+		} else {
+			t.Logf("Cleanup: Deleted configmap %s/%s", namespace, name)
+		}
+	})
+}

--- a/e2e/multi_backend_test.go
+++ b/e2e/multi_backend_test.go
@@ -44,6 +44,7 @@ func TestMultiBackendSupportExternalSecret(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			CleanupSecretAfterTest(t, cfg.Namespace(), "instana-agent-key")
 
 			t.Logf("Secret created")
 
@@ -96,6 +97,7 @@ func TestMultiBackendSupportExternalSecretWithSecretMounts(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			CleanupSecretAfterTest(t, cfg.Namespace(), "instana-agent-key")
 
 			t.Logf("Secret created")
 
@@ -129,6 +131,7 @@ func TestMultiBackendSupportExternalSecretWithSecretMounts(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			CleanupSecretAfterTest(t, cfg.Namespace(), "instana-agent-key")
 
 			t.Logf("CR created")
 

--- a/e2e/secret_mounts_test.go
+++ b/e2e/secret_mounts_test.go
@@ -592,51 +592,98 @@ func WaitForPodsToBeRecreatedForComponent(component string) features.Func {
 		const pollInterval = 2 * time.Second
 		const pollTimeout = 2 * time.Minute
 
-		waitErr := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
-			pods := &corev1.PodList{}
-			if err := r.List(ctx, pods, listOps); err != nil {
-				return false, err
-			}
-			if len(pods.Items) == 0 {
-				t.Logf("Waiting for pods with component %q to be recreated...", component)
-				return false, nil
-			}
-			allRunning := true
-			for _, pod := range pods.Items {
-				if pod.Status.Phase != corev1.PodRunning {
-					allRunning = false
-					t.Logf("Pod %s is in phase %s; waiting...", pod.Name, pod.Status.Phase)
-					break
+		waitErr := wait.PollUntilContextTimeout(
+			ctx,
+			pollInterval,
+			pollTimeout,
+			true,
+			func(ctx context.Context) (bool, error) {
+				pods := &corev1.PodList{}
+				if err := r.List(ctx, pods, listOps); err != nil {
+					return false, err
 				}
-			}
-			return allRunning, nil
-		})
+				if len(pods.Items) == 0 {
+					t.Logf("Waiting for pods with component %q to be recreated...", component)
+					return false, nil
+				}
+
+				// Check if all pods are from the same replica set and all are running
+				replicaSets := make(map[string]int)
+				runningCount := 0
+				for _, pod := range pods.Items {
+					// Extract replica set name from pod name (format: deployment-replicaset-pod)
+					// e.g., "instana-agent-r-remote-agent-85959668c5-mjjbq" -> "85959668c5"
+					parts := strings.Split(pod.Name, "-")
+					if len(parts) >= 2 {
+						rsHash := parts[len(parts)-2]
+						replicaSets[rsHash]++
+					}
+
+					if pod.DeletionTimestamp != nil {
+						t.Logf("Pod %s is terminating; waiting for cleanup...", pod.Name)
+						return false, nil
+					}
+
+					if pod.Status.Phase == corev1.PodRunning {
+						runningCount++
+					} else {
+						t.Logf("Pod %s is in phase %s; waiting...", pod.Name, pod.Status.Phase)
+						return false, nil
+					}
+				}
+
+				// Ensure all pods are from the same replica set (no old pods lingering)
+				if len(replicaSets) > 1 {
+					t.Logf(
+						"Multiple replica sets detected (%d), waiting for old pods to terminate...",
+						len(replicaSets),
+					)
+					return false, nil
+				}
+
+				// All pods must be running
+				return runningCount == len(pods.Items), nil
+			},
+		)
 		if waitErr != nil {
-			t.Fatalf("pods with component %q were not ready after configuration change: %v", component, waitErr)
+			t.Fatalf(
+				"pods with component %q were not ready after configuration change: %v",
+				component,
+				waitErr,
+			)
 		}
 
 		pods := &corev1.PodList{}
 		if err := r.List(ctx, pods, listOps); err != nil {
 			t.Fatal("failed to list pods after wait:", err)
 		}
-		t.Logf("Found %d pods with component %q after configuration change", len(pods.Items), component)
+		t.Logf(
+			"Found %d pods with component %q after configuration change",
+			len(pods.Items),
+			component,
+		)
 		return ctx
 	}
 }
 
 // TestSecretMountsDefaultBehavior tests the default behavior with useSecretMounts: true
 func TestSecretMountsDefaultBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCrWithSecretMounts(true)
 
 	defaultBehaviorFeature := features.New("secret mounts default behavior (useSecretMounts: true)").
 		Setup(SetupOperatorDevBuild()).
+
+		// Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
+
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreated(),
+		).
 		Assess("validate secret files are mounted correctly", ValidateSecretFilesMounted()).
 		Assess("validate sensitive environment variables are not set", ValidateSensitiveEnvVarsNotSet()).
 		Assess("validate k8sensor uses agent-key-file argument", ValidateK8sensorAgentKeyFileArg()).
@@ -647,15 +694,12 @@ func TestSecretMountsDefaultBehavior(t *testing.T) {
 
 // TestSecretMountsLegacyBehavior tests the legacy behavior with useSecretMounts: false
 func TestSecretMountsLegacyBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCrWithSecretMounts(false)
 
 	legacyBehaviorFeature := features.New("secret mounts legacy behavior (useSecretMounts: false)").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("validate sensitive environment variables are set", ValidateSensitiveEnvVarsSet()).
@@ -667,15 +711,12 @@ func TestSecretMountsLegacyBehavior(t *testing.T) {
 
 // TestSecretMountsSwitchingModes tests switching between secret mounts modes
 func TestSecretMountsSwitchingModes(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentCrWithSecretMounts(true)
 
 	switchingModesFeature := features.New("switching between secret mounts modes").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("validate secret files are mounted correctly", ValidateSecretFilesMounted()).
@@ -724,18 +765,23 @@ func TestSecretMountsHttpsProxyFile(t *testing.T) {
 
 // TestRemoteSecretMountsDefaultBehavior tests the default behavior with useSecretMounts: true for remote agent
 func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCrWithSecretMounts(true)
 
 	defaultBehaviorFeature := features.New("remote agent secret mounts default behavior (useSecretMounts: true)").
 		Setup(SetupOperatorDevBuild()).
+
+		// Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready", WaitForDeploymentToBecomeReady(
 			AgentRemoteDeploymentName+AgentRemoteCustomResourceName,
 		)).
+
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
+		).
 		Assess("validate secret files are mounted correctly in remote agent", ValidateRemoteSecretFilesMounted()).
 		Assess("validate sensitive environment variables are not set in remote agent",
 			ValidateRemoteSensitiveEnvVarsNotSet(),
@@ -747,15 +793,14 @@ func TestRemoteSecretMountsDefaultBehavior(t *testing.T) {
 
 // TestRemoteSecretMountsLegacyBehavior tests the legacy behavior with useSecretMounts: false for remote agent
 func TestRemoteSecretMountsLegacyBehavior(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCrWithSecretMounts(false)
 
 	legacyBehaviorFeature := features.New("remote agent secret mounts legacy behavior (useSecretMounts: false)").
 		Setup(SetupOperatorDevBuild()).
+
+		// Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).
@@ -767,17 +812,19 @@ func TestRemoteSecretMountsLegacyBehavior(t *testing.T) {
 
 // TestRemoteSecretMountsSwitchingModes tests switching between secret mounts modes for remote agent
 func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	agent := NewAgentRemoteCrWithSecretMounts(true)
 
 	switchingModesFeature := features.New("switching between remote agent secret mounts modes").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
+		).
+		// Add a delay to ensure pods are fully created with secret mounts
+		Assess(
+			"wait for pods to be created with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
 		).
 		Assess("validate secret files are mounted correctly in remote agent", ValidateRemoteSecretFilesMounted()).
 		Setup(UpdateAgentRemoteWithSecretMounts(false)).
@@ -797,6 +844,11 @@ func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
 		Assess("wait for remote agent deployment to become ready after second update",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).
+		// Add a delay to ensure pods are fully recreated with secret mounts
+		Assess(
+			"wait for pods to be recreated with secret mounts",
+			WaitForPodsToBeRecreatedForComponent(constants.ComponentInstanaAgentRemote),
+		).
 		Assess("validate secret files are mounted correctly in remote agent after switching back",
 			ValidateRemoteSecretFilesMounted(),
 		).
@@ -807,6 +859,7 @@ func TestRemoteSecretMountsSwitchingModes(t *testing.T) {
 
 // TestRemoteSecretMountsHttpsProxyFile tests the https-proxy-file functionality for remote agent
 func TestRemoteSecretMountsHttpsProxyFile(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Create a modified agent with proxy settings and ensure the proxy host is set
 	agent := NewAgentRemoteCrWithSecretMountsAndProxy()
 
@@ -816,12 +869,8 @@ func TestRemoteSecretMountsHttpsProxyFile(t *testing.T) {
 	}
 
 	httpsProxyFeature := features.New("remote agent https-proxy-file functionality").
-		Setup(SetupOperatorDevBuild()).
+		Setup(SetupOperatorDevBuild()). // Now waits for operator to be ready
 		Setup(DeployAgentRemoteCr(&agent)).
-		Assess(
-			"wait for instana-agent-controller-manager deployment to become ready",
-			WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName),
-		).
 		Assess("wait for remote agent deployment to become ready",
 			WaitForDeploymentToBecomeReady(AgentRemoteDeploymentName+AgentRemoteCustomResourceName),
 		).

--- a/e2e/selective_monitoring_test.go
+++ b/e2e/selective_monitoring_test.go
@@ -38,6 +38,7 @@ const (
 // It deploys the agent in opt-in mode and verifies that only JVMs in namespaces with the
 // instana-workload-monitoring=true label are monitored.
 func TestSelectiveMonitoring(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
 	// Create a new agent CR with selective monitoring enabled
 	agent := NewAgentCrWithSelectiveMonitoring()
 
@@ -253,6 +254,8 @@ func deployJavaDemoApp(
 }
 
 // VerifySelectiveMonitoring verifies that only the JVM in the opt-in namespace is monitored.
+// This implementation correlates PIDs with container IDs and mapping them
+// back to pods/namespaces using the Kubernetes API.
 func VerifySelectiveMonitoring() features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		t.Log("Verifying selective monitoring...")
@@ -270,11 +273,9 @@ func VerifySelectiveMonitoring() features.Func {
 			NamespaceOptIn,
 		}
 
-		// Find all demo app pods across all namespaces
-		t.Log("Finding all demo app pods...")
-		var demoAppPods []corev1.Pod
-		var demoAppNodes = make(map[string]bool)
-		var podsByNamespace = make(map[string][]corev1.Pod)
+		// Build a map of container ID to pod/namespace for quick lookup
+		t.Log("Building container ID to pod/namespace mapping...")
+		containerToPod := make(map[string]*podInfo)
 
 		for _, ns := range namespaces {
 			podList, err := clientSet.CoreV1().Pods(ns).List(
@@ -288,17 +289,25 @@ func VerifySelectiveMonitoring() features.Func {
 				continue
 			}
 
-			podsByNamespace[ns] = podList.Items
 			for _, pod := range podList.Items {
-				demoAppPods = append(demoAppPods, pod)
-				demoAppNodes[pod.Spec.NodeName] = true
-				t.Logf("Found demo app pod %s in namespace %s on node %s",
-					pod.Name, pod.Namespace, pod.Spec.NodeName)
+				for _, containerStatus := range pod.Status.ContainerStatuses {
+					// Extract container ID (format: containerd://abc123...)
+					containerID := extractContainerID(containerStatus.ContainerID)
+					if containerID != "" {
+						containerToPod[containerID] = &podInfo{
+							name:      pod.Name,
+							namespace: pod.Namespace,
+							nodeName:  pod.Spec.NodeName,
+						}
+						t.Logf("Mapped container ID %s to pod %s in namespace %s on node %s",
+							containerID, pod.Name, pod.Namespace, pod.Spec.NodeName)
+					}
+				}
 			}
 		}
 
-		if len(demoAppPods) == 0 {
-			t.Fatal("No demo app pods found in any namespace")
+		if len(containerToPod) == 0 {
+			t.Fatal("No demo app containers found in any namespace")
 		}
 
 		// Get all agent pods
@@ -312,25 +321,6 @@ func VerifySelectiveMonitoring() features.Func {
 		if len(agentPodList.Items) == 0 {
 			t.Fatal("No agent pods found")
 		}
-
-		// Find agent pods running on the same nodes as our demo apps
-		var relevantAgentPods []corev1.Pod
-		for _, agentPod := range agentPodList.Items {
-			if demoAppNodes[agentPod.Spec.NodeName] {
-				relevantAgentPods = append(relevantAgentPods, agentPod)
-				t.Logf("Found agent pod %s on node %s that has demo app pods",
-					agentPod.Name, agentPod.Spec.NodeName)
-			}
-		}
-
-		if len(relevantAgentPods) == 0 {
-			t.Fatal("No agent pods found on nodes where demo apps are running")
-		}
-
-		// Define regex patterns for finding PIDs and attachment logs
-		vmDiscoveryRegex := regexp.MustCompile(
-			`adding new VM with PID (\d+).*INSTANA_TEST_POD_NAME=([^,\s]+)`,
-		)
 
 		// Track attachment status for each namespace
 		attachmentStatus := map[string]bool{
@@ -353,8 +343,7 @@ func VerifySelectiveMonitoring() features.Func {
 
 		for time.Now().Before(deadline) {
 			// Check if we've already found attachments that shouldn't happen
-			if attachmentStatus[NamespaceNoLabel] ||
-				attachmentStatus[NamespaceOptOut] {
+			if attachmentStatus[NamespaceNoLabel] || attachmentStatus[NamespaceOptOut] {
 				t.Error("Found JVM attachment in namespace that should not be monitored")
 				break
 			}
@@ -365,9 +354,9 @@ func VerifySelectiveMonitoring() features.Func {
 				break
 			}
 
-			// Check logs from all relevant agent pods
-			for _, agentPod := range relevantAgentPods {
-				t.Logf("Checking logs from agent pod %s on worker node %s",
+			// Check logs from all agent pods
+			for _, agentPod := range agentPodList.Items {
+				t.Logf("Checking logs from agent pod %s on node %s",
 					agentPod.Name, agentPod.Spec.NodeName)
 
 				var buf bytes.Buffer
@@ -393,55 +382,11 @@ func VerifySelectiveMonitoring() features.Func {
 				// Store the logs for this agent pod
 				agentLogs[agentPod.Name] = logs
 
-				t.Logf("Agent logs retrieved from pod %s on worker node %s, checking for JVM attachment...",
-					agentPod.Name, agentPod.Spec.NodeName)
+				t.Logf("Agent logs retrieved from pod %s, analyzing for JVM attachments...",
+					agentPod.Name)
 
-				// For each namespace, check if its pods are being monitored
-				for ns, pods := range podsByNamespace {
-					for _, pod := range pods {
-						podName := pod.Name
-
-						// Look for VM discovery log entries for this pod
-						matches := vmDiscoveryRegex.FindAllStringSubmatch(logs, -1)
-						for _, match := range matches {
-							if len(match) >= 3 && strings.Contains(match[2], podName) {
-								// Found a VM discovery log for this pod
-								pid := match[1]
-								t.Logf("Found VM discovery for pod %s in namespace %s with PID %s",
-									podName, ns, pid)
-
-								// Check if there's an initial attach attempt
-								attachAttemptPattern := fmt.Sprintf(
-									"Performing initial attach to JVM with PID %s",
-									pid,
-								)
-								if strings.Contains(logs, attachAttemptPattern) {
-									t.Logf(
-										"Found attach attempt for pod %s (PID %s) in namespace %s",
-										podName,
-										pid,
-										ns,
-									)
-
-									// Check if the attachment was successful
-									attachSuccessPattern := fmt.Sprintf(
-										"Initial attach to JVM with PID %s successful",
-										pid,
-									)
-									if strings.Contains(logs, attachSuccessPattern) {
-										t.Logf(
-											"Found successful attachment for pod %s (PID %s) in namespace %s",
-											podName,
-											pid,
-											ns,
-										)
-										attachmentStatus[ns] = true
-									}
-								}
-							}
-						}
-					}
-				}
+				// Analyze logs using the new correlation approach
+				analyzeLogsForAttachments(t, logs, containerToPod, attachmentStatus)
 			}
 
 			// If we haven't found what we're looking for, wait before checking again
@@ -498,10 +443,91 @@ func VerifySelectiveMonitoring() features.Func {
 		// If we have failures, dump the agent logs for debugging
 		if hasFailures {
 			t.Log("Test failed - dumping agent logs for debugging purposes")
-			dumpAgentLogs(t, agentLogs, relevantAgentPods)
+			dumpAgentLogs(t, agentLogs, agentPodList.Items)
 		}
 
 		return ctx
+	}
+}
+
+// podInfo holds information about a pod for container-to-pod mapping
+type podInfo struct {
+	name      string
+	namespace string
+	nodeName  string
+}
+
+// extractContainerID extracts the actual container ID from the full container ID string
+// (e.g., "containerd://abc123..." -> "abc123...")
+func extractContainerID(fullContainerID string) string {
+	parts := strings.SplitN(fullContainerID, "://", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return fullContainerID
+}
+
+// analyzeLogsForAttachments analyzes agent logs to find JVM attachments and correlates them
+// with pods/namespaces using container ID mapping
+func analyzeLogsForAttachments(
+	t *testing.T,
+	logs string,
+	containerToPod map[string]*podInfo,
+	attachmentStatus map[string]bool,
+) {
+	// Regex patterns for extracting information from logs
+	// Pattern 1: VM discovery with PID and container ID
+	// Example: "adding new VM with PID 57368, ContainerizedVirtualMachineImpl
+	// [pid=57368...containerId=2e88aa9bd86c8fbb..."
+	vmDiscoveryRegex := regexp.MustCompile(
+		`adding new VM with PID (\d+).*containerId=([a-f0-9]+)`,
+	)
+
+	// Pattern 2: Successful JVM attachment
+	// Example: "Initial attach to JVM with PID 57368 successful"
+	attachSuccessRegex := regexp.MustCompile(
+		`Initial attach to JVM with PID (\d+) successful`,
+	)
+
+	// Build a map of PID to container ID from VM discovery logs
+	pidToContainerID := make(map[string]string)
+	vmMatches := vmDiscoveryRegex.FindAllStringSubmatch(logs, -1)
+	for _, match := range vmMatches {
+		if len(match) >= 3 {
+			pid := match[1]
+			containerID := match[2]
+			pidToContainerID[pid] = containerID
+			t.Logf("Found VM discovery: PID %s -> Container ID %s", pid, containerID)
+		}
+	}
+
+	// Find successful attachments and correlate with namespaces
+	attachMatches := attachSuccessRegex.FindAllStringSubmatch(logs, -1)
+	for _, match := range attachMatches {
+		if len(match) >= 2 {
+			pid := match[1]
+			t.Logf("Found successful JVM attachment for PID %s", pid)
+
+			// Look up the container ID for this PID
+			containerID, found := pidToContainerID[pid]
+			if !found {
+				t.Logf("Warning: Could not find container ID for PID %s", pid)
+				continue
+			}
+
+			// Look up the pod info for this container ID
+			podInfo, found := containerToPod[containerID]
+			if !found {
+				t.Logf("Warning: Could not find pod info for container ID %s", containerID)
+				continue
+			}
+
+			t.Logf("Successfully correlated PID %s -> Container %s -> Pod %s in namespace %s",
+				pid, containerID, podInfo.name, podInfo.namespace)
+
+			// Mark this namespace as having an attachment
+			attachmentStatus[podInfo.namespace] = true
+		}
 	}
 }
 

--- a/e2e/state.go
+++ b/e2e/state.go
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+package e2e
+
+import (
+	"sync"
+)
+
+type suiteState struct {
+	mu                 sync.Mutex
+	fullResetRequested bool
+	fullResetReason    string
+}
+
+var currentSuiteState = suiteState{}
+
+// MarkFullResetRequired allows tests to mark the environment as dirty, forcing the next test to perform a full cleanup.
+func MarkFullResetRequired(reason string) {
+	currentSuiteState.mu.Lock()
+	defer currentSuiteState.mu.Unlock()
+	currentSuiteState.fullResetRequested = true
+	currentSuiteState.fullResetReason = reason
+}
+
+// FullResetRequested returns whether a full cleanup has been requested together with the reason.
+func FullResetRequested() (bool, string) {
+	currentSuiteState.mu.Lock()
+	defer currentSuiteState.mu.Unlock()
+	return currentSuiteState.fullResetRequested, currentSuiteState.fullResetReason
+}
+
+// ClearFullResetRequest clears a previously recorded full cleanup request.
+func ClearFullResetRequest() {
+	currentSuiteState.mu.Lock()
+	defer currentSuiteState.mu.Unlock()
+	currentSuiteState.fullResetRequested = false
+	currentSuiteState.fullResetReason = ""
+}
+
+// Made with Bob

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -17,16 +17,34 @@ import (
 )
 
 func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
+	CollectOperatorLogsOnFailure(t)
+	RequireFullResetBeforeTest(
+		t,
+		"TestUpdateInstallFromOldGenericResourceNames requires clean environment before installing legacy operator",
+	)
+	RequireFullResetAfterTest(
+		t,
+		"TestUpdateInstallFromOldGenericResourceNames uses legacy operator build",
+	)
 	agent := NewAgentCr()
 	installLatestFeature := features.New("deploy instana-agent-operator with the generic resource names (controller-manager, manager-role and manager-rolebinding)").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			const oldResourceNamesOperatorYamlUrl string = "https://github.com/instana/instana-agent-operator/releases/download/v2.1.14/instana-agent-operator.yaml"
-			t.Logf("Installing latest operator with the old, generic resource names from %s", oldResourceNamesOperatorYamlUrl)
+			t.Logf(
+				"Installing latest operator with the old, generic resource names from %s",
+				oldResourceNamesOperatorYamlUrl,
+			)
 			p := utils.RunCommand(
 				fmt.Sprintf("kubectl apply -f %s", oldResourceNamesOperatorYamlUrl),
 			)
 			if p.Err() != nil {
-				t.Fatal("Error while applying the old operator yaml", p.Command(), p.Err(), p.Out(), p.ExitCode())
+				t.Fatal(
+					"Error while applying the old operator yaml",
+					p.Command(),
+					p.Err(),
+					p.Out(),
+					p.ExitCode(),
+				)
 			}
 			return ctx
 		}).
@@ -39,7 +57,7 @@ func TestUpdateInstallFromOldGenericResourceNames(t *testing.T) {
 
 	updateInstallDevBuildFeature := features.New("upgrade install from latest released to dev-operator-build").
 		Setup(SetupOperatorDevBuild()).
-		Assess("wait for instana-agent-controller-manager deployment to become ready", WaitForDeploymentToBecomeReady(InstanaOperatorDeploymentName)).
+		// Now waits for operator to be ready
 		Assess("wait for k8sensor deployment to become ready", WaitForDeploymentToBecomeReady(K8sensorDeploymentName)).
 		Assess("wait for agent daemonset to become ready", WaitForAgentDaemonSetToBecomeReady()).
 		Assess("check agent log for successful connection", WaitForAgentSuccessfulBackendConnection()).


### PR DESCRIPTION
Add CleanupSecretAfterTest() and CleanupConfigMapAfterTest() helper functions to properly clean up test resources between test runs. This prevents resource conflicts when tests create secrets or configmaps with the same names.

Apply cleanup in multi_backend tests to fix 'already exists' errors in TestMultiBackendSupportExternalSecret and TestMultiBackendSupportExternalSecretWithSecretMounts.

Backported from commit 1f5e672 on main branch.

## References

<!-- Please include links to other artifacts related to this code change. -->

- NA

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
