### PR TITLE
fix: filter PodSecurity warnings from operator logs

### DIFF
--- a/pkg/k8s/client/warnings.go
+++ b/pkg/k8s/client/warnings.go
@@ -24,7 +24,10 @@ import (
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const sessionAffinityHeadlessWarning = "spec.SessionAffinity is ignored for headless services"
+const (
+	sessionAffinityHeadlessWarning = "spec.SessionAffinity is ignored for headless services"
+	podSecurityWarning             = "would violate PodSecurity"
+)
 
 // ConfigureWarningHandler replaces the default warning handler on the provided REST config with
 // one that suppresses noisy warnings we already account for while delegating everything else to
@@ -32,8 +35,11 @@ const sessionAffinityHeadlessWarning = "spec.SessionAffinity is ignored for head
 func ConfigureWarningHandler(cfg *rest.Config) {
 	delegate := crlog.NewKubeAPIWarningLogger(crlog.KubeAPIWarningLoggerOptions{})
 	cfg.WarningHandlerWithContext = &filteringWarningHandler{
-		delegate:        delegate,
-		ignoredMessages: []string{sessionAffinityHeadlessWarning},
+		delegate: delegate,
+		ignoredMessages: []string{
+			sessionAffinityHeadlessWarning,
+			podSecurityWarning,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Filters out PodSecurity warnings from operator logs to reduce noise.

## Problem

The Instana agent DaemonSet requires privileged capabilities (hostNetwork, hostPID, privileged container) for system monitoring. These intentionally violate Kubernetes PodSecurity 'restricted' standards, causing warnings on every reconciliation:

```
would violate PodSecurity "restricted:latest": host namespaces (hostNetwork=true, hostPID=true), privileged (container "instana-agent" must not set securityContext.privileged=true), ...
```

These warnings are:
- **Expected behavior** for monitoring agents that need host-level access
- **Not actionable** by users - the agent requires these capabilities
- **Noisy** - appear on every reconcile loop, cluttering logs

## Solution

Add PodSecurity warning filter to the existing warning handler in `pkg/k8s/client/warnings.go`, similar to how we already filter the sessionAffinity warning.

The filter matches on the substring `"would violate PodSecurity"` which is the standard format from Kubernetes PodSecurity admission controller.

## Testing

- Existing unit tests pass
- Warning handler already has established pattern for filtering
- No functional changes to operator behavior
- Clean log on reconcile observed:
```
I0609 07:10:49.641502   46489 main.go:325] "Operator Version: snapshot" logger="main"
I0609 07:10:49.641519   46489 main.go:326] "Operator Git Commit SHA: unspecified" logger="main"
I0609 07:10:49.641522   46489 main.go:327] "Go Version: go1.26.2" logger="main"
I0609 07:10:49.641525   46489 main.go:328] "Go OS/Arch: linux/amd64" logger="main"
I0609 07:10:49.642699   46489 main.go:148] "POD_NAMESPACE not set, using default namespace. Consider setting POD_NAMESPACE environment variable." logger="main" namespace="instana-agent"
I0609 07:10:49.642709   46489 main.go:160] "Configuring cache with label-based filtering for operator-managed resources" logger="main"
I0609 07:10:51.092216   46489 main.go:207] "Deleting the controller-manager deployment and RBAC if it's present" logger="main"
I0609 07:10:51.092272   46489 main.go:230] "Delete the old deployment if present" logger="main"
I0609 07:10:52.012191   46489 main.go:247] "Found 0 deployments that match the criteria" logger="main"
I0609 07:10:52.012206   46489 main.go:259] "Delete old RBAC resources if present" logger="main"
I0609 07:10:52.177499   46489 main.go:266] "Old operator clusterrole is not present in the cluster" logger="main"
I0609 07:10:52.339920   46489 main.go:299] "Old operator clusterrolebinding is not present in the cluster" logger="main"
I0609 07:10:52.339956   46489 main.go:217] "Starting manager" logger="main"
I0609 07:10:52.340086   46489 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
I0609 07:10:52.340153   46489 server.go:83] "starting server" name="health probe" addr="[::]:8081"
I0609 07:10:52.340230   46489 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress=":8080" secure=false
I0609 07:10:52.340414   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.Namespace"
I0609 07:10:52.340424   46489 controller.go:369] "Starting EventSource" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" source="kind source: *v1.Service"
I0609 07:10:52.340462   46489 controller.go:369] "Starting EventSource" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" source="kind source: *v1.ConfigMap"
I0609 07:10:52.340459   46489 controller.go:369] "Starting EventSource" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" source="kind source: *v1.Secret"
I0609 07:10:52.340462   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.Deployment"
I0609 07:10:52.340475   46489 controller.go:369] "Starting EventSource" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" source="kind source: *v1.Deployment"
I0609 07:10:52.340490   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.InstanaAgent"
I0609 07:10:52.340526   46489 controller.go:369] "Starting EventSource" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" source="kind source: *v1.InstanaAgentRemote"
I0609 07:10:52.340560   46489 controller.go:369] "Starting EventSource" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" source="kind source: *v1.ServiceAccount"
I0609 07:10:52.340573   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.ClusterRole"
I0609 07:10:52.340461   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.DaemonSet"
I0609 07:10:52.340653   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.PodDisruptionBudget"
I0609 07:10:52.340672   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.ClusterRoleBinding"
I0609 07:10:52.340707   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.Secret"
I0609 07:10:52.340773   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.ConfigMap"
I0609 07:10:52.340809   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.Service"
I0609 07:10:52.340888   46489 controller.go:369] "Starting EventSource" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" source="kind source: *v1.ServiceAccount"
I0609 07:11:15.141635   46489 controller.go:302] "Starting Controller" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote"
I0609 07:11:15.141683   46489 controller.go:305] "Starting workers" controller="instanaagentremote" controllerGroup="instana.io" controllerKind="InstanaAgentRemote" worker count=1
I0609 07:11:15.142779   46489 controller.go:302] "Starting Controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent"
I0609 07:11:15.142795   46489 controller.go:305] "Starting workers" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" worker count=1
I0609 07:11:15.142916   46489 instanaagent_controller.go:144] "reconciling Agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="fabf98a9-1111-4179-9fd8-5937c68f9df8" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:17.626425   46489 instanaagent_controller.go:144] "reconciling Agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:20.113833   46489 client.go:252] "Requesting list of namespaces with label instana-workload-monitoring" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:20.113949   46489 client.go:271] "Received details of namespaces" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" namespaceNames=null
I0609 07:11:20.114027   46489 apply.go:459] "OpenShift ETCD resources found, enabling ETCD monitoring" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:20.288731   46489 apply.go:326] "Successfully copied/updated ETCD CA ConfigMap" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" sourceResourceVersion="573"
I0609 07:11:20.547210   46489 apply.go:355] "Successfully copied/updated ETCD client Secret" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" sourceResourceVersion="574"
I0609 07:11:28.580050   46489 instanaagent_controller.go:217] "successfully finished reconcile on agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="550f3bf3-b7c4-41f6-a8a0-b9ca80ad92ee" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:28.779643   46489 instanaagent_controller.go:144] "reconciling Agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:31.538326   46489 client.go:252] "Requesting list of namespaces with label instana-workload-monitoring" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:31.538414   46489 client.go:271] "Received details of namespaces" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" namespaceNames=null
I0609 07:11:31.538444   46489 apply.go:459] "OpenShift ETCD resources found, enabling ETCD monitoring" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:31.705132   46489 apply.go:326] "Successfully copied/updated ETCD CA ConfigMap" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" sourceResourceVersion="573"
I0609 07:11:31.948546   46489 apply.go:355] "Successfully copied/updated ETCD client Secret" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" sourceResourceVersion="574"
I0609 07:11:40.315530   46489 instanaagent_controller.go:217] "successfully finished reconcile on agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="b4bda3c3-805e-46e1-b6e7-794d1612b951" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:40.555116   46489 instanaagent_controller.go:144] "reconciling Agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:42.745493   46489 client.go:252] "Requesting list of namespaces with label instana-workload-monitoring" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:42.745568   46489 client.go:271] "Received details of namespaces" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" namespaceNames=null
I0609 07:11:42.745596   46489 apply.go:459] "OpenShift ETCD resources found, enabling ETCD monitoring" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
I0609 07:11:42.917278   46489 apply.go:326] "Successfully copied/updated ETCD CA ConfigMap" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" sourceResourceVersion="573"
I0609 07:11:43.086862   46489 apply.go:355] "Successfully copied/updated ETCD client Secret" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e" sourceResourceVersion="574"
I0609 07:11:51.561246   46489 instanaagent_controller.go:217] "successfully finished reconcile on agent CR" logger="agent-controller" controller="instanaagent" controllerGroup="instana.io" controllerKind="InstanaAgent" InstanaAgent="instana-agent/instana-agent" namespace="instana-agent" name="instana-agent" reconcileID="1f168521-3935-42f4-ab70-330bbb5a414d" Generation=1 UID="6f6fa799-f3da-432e-a1eb-45d18f96324e"
```