### PR TITLE
ci: add digest to save_artifact to run image scans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 #
 # (c) Copyright IBM Corp. 2021, 2025
 #
-ARG BUILDPLATFORM
+ARG BUILDPLATFORM=linux/amd64
 
 FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
 
-ARG BUILDPLATFORM
-ARG TARGETPLATFORM
+ARG BUILDPLATFORM=linux/amd64
+ARG TARGETPLATFORM=linux/amd64
 ARG VERSION=dev
 ARG GIT_COMMIT=unspecified
 WORKDIR /workspace
@@ -47,7 +47,7 @@ RUN export TARGET_ARCHITECTURE="$(echo ${TARGETPLATFORM} | cut -d'/' -f2)" \
 # Resulting image with actual Operator
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ARG TARGETPLATFORM
+ARG TARGETPLATFORM=linux/amd64
 ARG VERSION=dev
 ARG BUILD=1
 ARG GIT_COMMIT=unspecified

--- a/ci/sps-scripts/sps-build-multiarch-images.sh
+++ b/ci/sps-scripts/sps-build-multiarch-images.sh
@@ -50,4 +50,4 @@ docker buildx build \
     "$BUILD_CONTEXT"
 
 # mark for scanning
-pipelinectl save_artifact operator_image "name=${REGISTRY_IMAGE_TAG_ICR}" "type=image"
+pipelinectl save_artifact operator_image "name=${REGISTRY_IMAGE_TAG_ICR}" "type=image" "digest=$(skopeo inspect "docker://${REGISTRY_IMAGE_TAG_ICR}" --format '{{.Digest}}')"


### PR DESCRIPTION
## Why

I want to run container image scans on every PR.

## What

The SPS pipeline can scan images, but apparently requires digests being published, not only image names and tags.

## References

n/a

## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated? n/a
- [ ] unit/e2e test coverage added or updated? n/a


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
