### PR TITLE
chore: backport dependency updates to release-2.1 via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,17 @@
   "prConcurrentLimit": 2,
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboard": true,
+  "baseBranches": [
+    "main",
+    "release-2.1"
+  ],
+  "packageRules": [
+    {
+      "matchBaseBranches": ["release-2.1"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -12,11 +12,11 @@
   "dependencyDashboard": true,
   "baseBranches": [
     "main",
-    "release-2.1"
+    "/^release-\\d+\\.\\d+$/"
   ],
   "packageRules": [
     {
-      "matchBaseBranches": ["release-2.1"],
+      "matchBaseBranches": ["/^release-\\d+\\.\\d+$/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }
@@ -24,7 +24,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
+      "fileMatch": [
         "/^Makefile$/"
       ],
       "matchStrings": [
@@ -35,7 +35,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
+      "fileMatch": [
         "/^installGolang\\.sh$/"
       ],
       "matchStrings": [


### PR DESCRIPTION
## Why

Renovate currently only opens dependency update PRs against `main`. The `release-2.1` branch receives no automated dependency updates, meaning patch and minor fixes (including security-relevant ones) are never proposed for the release line.

## What

- Added `release-2.1` to `baseBranches` so Renovate scans that branch and opens PRs against it.
- Added a `packageRules` entry that disables `major` version updates when targeting `release-2.1`, keeping only non-breaking `minor` and `patch` updates for the release branch.

## References

- [INSTA-98571](https://jsw.ibm.com/browse/INSTA-98571)

## Checklist

- [x] Backwards compatible?
- [ ] [Release notes](https://github.ibm.com/instana/docs/blob/main/src/pages/releases/agent_operator_notes/index.md) in public docs updated?
- [ ] unit/e2e test coverage added or updated?