### PR TITLE
chore(deps): update dependency golang to v1.26.5

### DIFF
--- a/installGolang.sh
+++ b/installGolang.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# (c) Copyright IBM Corp. 2025
+# (c) Copyright IBM Corp. 2025, 2026
 set -euo pipefail
 # renovate: datasource=golang-version depName=golang
-GO_VERSION="1.26.4"
+GO_VERSION="1.26.5"
 ARCHITECTURE="${1}"
 
 # Make sure to remove the old go version, otherwise weird runtime errors may occur


### PR DESCRIPTION
## Why

Golang 1.26.5 was released but Renovate missed the update due to a stale extraction cache on `main` (the cached extract SHA matched the previous run and was reused, skipping the regex custom manager entirely). Bumping manually to keep the runtime up to date and to bust the cache for future automated updates.

## What

- Bumped `GO_VERSION` from `1.26.4` to `1.26.5` in `installGolang.sh`
- Updated copyright header to `2025, 2026`

## References



## Checklist

- [x] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?