### PR TITLE
fix: restore single-slash regex in managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "//^Makefile$//"
+        "/^Makefile$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
@@ -36,7 +36,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "//^installGolang\\.sh$//"
+        "/^installGolang\\.sh$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s*GO_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""


### PR DESCRIPTION
## Why

PR #536 (Renovate config migration) automatically changed the `fileMatch` patterns from single-slash (`/^Makefile$/`) to double-slash (`//^Makefile$//`) format in `managerFilePatterns`. The double-slash form does not match any files in practice as confirmed by the 2026-07-13 Renovate run log which shows zero files matched for the `regex` manager on both `main` and `release-2.1`, causing custom managers for `Makefile` (golangci-lint) and `installGolang.sh` (golang) to silently stop detecting updates.

## What

Reverts the two `managerFilePatterns` entries from `//^Makefile$//` / `//^installGolang\.sh$//` back to the working single-slash form `/^Makefile$/` / `/^installGolang\.sh$/`.

## References


## Checklist

- [x] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?