### PR TITLE
fix: stop ETCD_TARGETS flapping between reconciles on vanilla Kubernetes

### DIFF
--- a/controllers/apply.go
+++ b/controllers/apply.go
@@ -210,7 +210,9 @@ func etcdTargetsChanged(
 	discoveredTargets []string,
 	log logr.Logger,
 ) bool {
-	log.Info(
+	// These run on every reconcile and say nothing new in steady state, so they are
+	// kept off the default log level
+	log.V(1).Info(
 		"Comparing current ETCD targets with discovered targets to determine if update is needed",
 	)
 
@@ -228,10 +230,10 @@ func etcdTargetsChanged(
 		currentTargets = strings.Join(currentTargetsList, ",")
 	}
 
-	log.Info("Target comparison details",
+	log.V(1).Info("Target comparison details",
 		"currentTargets", currentTargets,
 		"newTargets", newTargets,
-		"needsUpdate", currentTargets != newTargets)
+		"targetsChanged", currentTargets != newTargets)
 
 	// Return true if targets are different (update needed)
 	return currentTargets != newTargets
@@ -576,13 +578,14 @@ func CreateDeploymentContext(
 		// deployment builder always rebuilds the full pod spec, so a nil context
 		// renders a Deployment without ETCD_TARGETS, the server-side apply strips
 		// the env var and rolls the pod, and the next reconcile adds it back again.
-		logger.Info("ETCD targets unchanged, keeping them on the Deployment")
+		// This is the steady state, so it stays off the default log level.
+		logger.V(1).Info("ETCD targets unchanged, keeping them on the Deployment")
 	}
 
 	// Use sorted targets for consistency
 	sortedTargets := getSortedTargets(discoveredETCD.Targets)
 
-	logger.Info("Using discovered ETCD targets", "targets", sortedTargets)
+	logger.V(1).Info("Using discovered ETCD targets", "targets", sortedTargets)
 	deploymentContext := &k8ssensordeployment.DeploymentContext{
 		DiscoveredETCDTargets: sortedTargets,
 	}

--- a/controllers/apply.go
+++ b/controllers/apply.go
@@ -503,13 +503,14 @@ func CreateDeploymentContext(
 
 	if err != nil {
 		logger.Info("K8sensor deployment not found, will create with discovered ETCD targets")
+	} else if compareAndUpdateETCDTargets(existingDeployment, discoveredETCD.Targets, logger) {
+		logger.Info("ETCD targets changed, Deployment will be updated")
 	} else {
-		// Compare current and discovered ETCD targets
-		needsUpdate := compareAndUpdateETCDTargets(existingDeployment, discoveredETCD.Targets, logger)
-		if !needsUpdate {
-			logger.Info("ETCD targets unchanged, skipping Deployment update")
-			return nil, nil
-		}
+		// The context still has to carry the targets when they are unchanged. The
+		// deployment builder always rebuilds the full pod spec, so a nil context
+		// renders a Deployment without ETCD_TARGETS, the server-side apply strips
+		// the env var and rolls the pod, and the next reconcile adds it back again.
+		logger.Info("ETCD targets unchanged, keeping them on the Deployment")
 	}
 
 	// Use sorted targets for consistency

--- a/controllers/apply.go
+++ b/controllers/apply.go
@@ -199,10 +199,13 @@ func retainAppliedETCDTargets(
 	return deploymentContext
 }
 
-// compareAndUpdateETCDTargets compares current ETCD targets with new discovered targets
-// and determines if an update is needed. This function handles environment variable extraction,
-// target sorting, and comparison logic.
-func compareAndUpdateETCDTargets(
+// etcdTargetsChanged reports whether the discovered ETCD targets differ from the ones
+// already applied to the given Deployment, handling environment variable extraction,
+// target sorting and comparison. The result is informational: the deployment context
+// is built the same way either way, and only the log message differs. It must not be
+// used to skip building the context, because the builder rebuilds the whole pod spec
+// and a context without the targets makes the apply strip ETCD_TARGETS.
+func etcdTargetsChanged(
 	existingDeployment *appsv1.Deployment,
 	discoveredTargets []string,
 	log logr.Logger,
@@ -553,7 +556,10 @@ func CreateDeploymentContext(
 		return nil, nil
 	}
 
-	// Check if we need to update the Deployment with new ETCD targets
+	// Read the Deployment purely to log whether the targets moved. Every backend
+	// shares a single deployment context and the targets are cluster wide, so the
+	// primary Deployment stands in for all of them and the missing backend resource
+	// suffix on the name does not matter here.
 	existingDeployment := &appsv1.Deployment{}
 	helperInstance := helpers.NewHelpers(agent)
 	err = c.Get(ctx, types.NamespacedName{
@@ -563,7 +569,7 @@ func CreateDeploymentContext(
 
 	if err != nil {
 		logger.Info("K8sensor deployment not found, will create with discovered ETCD targets")
-	} else if compareAndUpdateETCDTargets(existingDeployment, discoveredETCD.Targets, logger) {
+	} else if etcdTargetsChanged(existingDeployment, discoveredETCD.Targets, logger) {
 		logger.Info("ETCD targets changed, Deployment will be updated")
 	} else {
 		// The context still has to carry the targets when they are unchanged. The

--- a/controllers/apply.go
+++ b/controllers/apply.go
@@ -138,6 +138,67 @@ func getSortedTargets(targets []string) []string {
 	return sortedTargets
 }
 
+// k8sSensorEnvValue returns the value of the named environment variable on the
+// k8sensor container of the given Deployment, or "" when it is not set.
+func k8sSensorEnvValue(existingDeployment *appsv1.Deployment, name string) string {
+	for _, container := range existingDeployment.Spec.Template.Spec.Containers {
+		if container.Name != constants.ContainerK8Sensor {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == name {
+				return env.Value
+			}
+		}
+		break
+	}
+
+	return ""
+}
+
+// retainAppliedETCDTargets rebuilds the deployment context from the ETCD settings
+// already applied to the live k8sensor Deployment. It is used when discovery cannot
+// establish the current targets, so that a transient failure does not strip
+// ETCD_TARGETS and roll the pod. It returns nil when there is nothing to retain.
+func retainAppliedETCDTargets(
+	ctx context.Context,
+	c client.InstanaAgentClient,
+	agent *instanav1.InstanaAgent,
+	log logr.Logger,
+) *k8ssensordeployment.DeploymentContext {
+	// Every backend shares a single deployment context and the targets are cluster
+	// wide, so the primary Deployment is a good enough source for the applied values.
+	existingDeployment := &appsv1.Deployment{}
+	helperInstance := helpers.NewHelpers(agent)
+	if err := c.Get(ctx, types.NamespacedName{
+		Namespace: agent.Namespace,
+		Name:      helperInstance.K8sSensorResourcesName(),
+	}, existingDeployment); err != nil {
+		log.Info("No existing k8sensor deployment to retain ETCD targets from")
+		return nil
+	}
+
+	appliedTargets := k8sSensorEnvValue(existingDeployment, constants.EnvETCDTargets)
+	if appliedTargets == "" {
+		return nil
+	}
+
+	log.Info("Retaining the ETCD targets already applied", "targets", appliedTargets)
+
+	deploymentContext := &k8ssensordeployment.DeploymentContext{
+		DiscoveredETCDTargets: strings.Split(appliedTargets, ","),
+	}
+
+	// Only treat the CA as discovered when the applied file matches the path the
+	// discovery path mounts it at, so a CA configured on the CR is left alone.
+	if k8sSensorEnvValue(existingDeployment, constants.EnvETCDCAFile) ==
+		constants.ETCDCAMountPath+"/ca.crt" {
+		deploymentContext.ETCDCASecretName = constants.ETCDCASecretName
+	}
+
+	return deploymentContext
+}
+
 // compareAndUpdateETCDTargets compares current ETCD targets with new discovered targets
 // and determines if an update is needed. This function handles environment variable extraction,
 // target sorting, and comparison logic.
@@ -151,18 +212,7 @@ func compareAndUpdateETCDTargets(
 	)
 
 	// Extract current ETCD targets from deployment environment variables
-	currentTargets := ""
-	for _, container := range existingDeployment.Spec.Template.Spec.Containers {
-		if container.Name == constants.ContainerK8Sensor {
-			for _, env := range container.Env {
-				if env.Name == constants.EnvETCDTargets {
-					currentTargets = env.Value
-					break
-				}
-			}
-			break
-		}
-	}
+	currentTargets := k8sSensorEnvValue(existingDeployment, constants.EnvETCDTargets)
 
 	// Sort discovered targets to ensure consistent comparison
 	sortedDiscoveredTargets := getSortedTargets(discoveredTargets)
@@ -484,11 +534,21 @@ func CreateDeploymentContext(
 	// For vanilla Kubernetes, discover ETCD endpoints
 	discoveredETCD, err := discoverETCD(ctx, agent)
 	if err != nil {
-		logger.Error(err, "Failed to discover ETCD endpoints")
+		// A discovery failure means the targets are unknown, not that there are none.
+		// Clearing them here would strip ETCD_TARGETS and roll the k8sensor pod on
+		// every transient API error, then roll it again once discovery recovers.
+		logger.Error(err, "Failed to discover ETCD endpoints, retaining the applied targets")
 		// Continue with reconciliation, don't fail the whole process
-		return nil, nil
+		return retainAppliedETCDTargets(ctx, c, agent, logger), nil
 	}
 
+	if discoveredETCD != nil && discoveredETCD.Indeterminate {
+		logger.Info("ETCD discovery was inconclusive, retaining the applied targets")
+		return retainAppliedETCDTargets(ctx, c, agent, logger), nil
+	}
+
+	// Discovery positively established that there is no etcd to monitor, so the
+	// targets are dropped and the k8sensor stops scraping them.
 	if discoveredETCD == nil || len(discoveredETCD.Targets) == 0 {
 		return nil, nil
 	}

--- a/controllers/apply_etcd_flap_test.go
+++ b/controllers/apply_etcd_flap_test.go
@@ -1,0 +1,172 @@
+/*
+(c) Copyright IBM Corp. 2025
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	"github.com/instana/instana-agent-operator/internal/mocks"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
+	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
+	k8ssensordeployment "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/k8s-sensor/deployment"
+	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
+)
+
+// renderK8sSensorDeployment builds the k8s-sensor Deployment the way applyResources
+// does, so the test sees exactly what would be sent to the server-side apply.
+func renderK8sSensorDeployment(
+	t *testing.T,
+	agent *instanav1.InstanaAgent,
+	deploymentContext *k8ssensordeployment.DeploymentContext,
+) *appsv1.Deployment {
+	t.Helper()
+
+	backend := backends.NewK8SensorBackend("", "test-key", "", "test-host", "443")
+	built := k8ssensordeployment.NewDeploymentBuilder(
+		agent,
+		false,
+		&status.MockAgentStatusManager{},
+		*backend,
+		nil,
+		deploymentContext,
+	).Build()
+
+	require.True(t, built.IsPresent(), "deployment builder should produce a Deployment")
+
+	deployment, ok := built.Get().(*appsv1.Deployment)
+	require.True(t, ok, "builder should produce a *appsv1.Deployment")
+	return deployment
+}
+
+// etcdTargetsEnvOf returns the ETCD_TARGETS value on the k8sensor container, or ""
+// when the env var is absent.
+func etcdTargetsEnvOf(deployment *appsv1.Deployment) string {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != constants.ContainerK8Sensor {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == constants.EnvETCDTargets {
+				return env.Value
+			}
+		}
+	}
+	return ""
+}
+
+// TestETCDTargetsRemainStableAcrossReconciles reproduces INSTA-105465: on the
+// reconcile after the targets were applied, discovery finds the same targets, and
+// the rendered Deployment used to drop ETCD_TARGETS entirely. Server-side apply then
+// stripped the env var and rolled the pod, and the next reconcile added it back,
+// leaving the k8sensor pod in a restart loop.
+func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoveredTargets := []string{"http://9.60.248.41:2381/metrics"}
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return &DiscoveredETCDTargets{Targets: discoveredTargets, CAFound: false}, nil
+	}
+
+	// First reconcile: no Deployment exists yet, so the targets get applied.
+	firstClient := &mocks.MockInstanaAgentClient{}
+	firstClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+	firstContext, err := CreateDeploymentContext(
+		ctx,
+		firstClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	firstDeployment := renderK8sSensorDeployment(t, agent, firstContext)
+	assert.Equal(
+		t,
+		"http://9.60.248.41:2381/metrics",
+		etcdTargetsEnvOf(firstDeployment),
+		"first reconcile should set ETCD_TARGETS",
+	)
+
+	// Second reconcile: the Deployment now exists and discovery returns the same
+	// targets, which is the case that used to strip the env var.
+	secondClient := &mocks.MockInstanaAgentClient{}
+	secondClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *firstDeployment
+		})
+
+	secondContext, err := CreateDeploymentContext(
+		ctx,
+		secondClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	secondDeployment := renderK8sSensorDeployment(t, agent, secondContext)
+	assert.Equal(
+		t,
+		etcdTargetsEnvOf(firstDeployment),
+		etcdTargetsEnvOf(secondDeployment),
+		"ETCD_TARGETS must survive a reconcile where the discovered targets are unchanged",
+	)
+
+	// The pod spec must be byte for byte identical, otherwise the apply rolls the pod.
+	assert.Equal(
+		t,
+		firstDeployment.Spec.Template.Spec.Containers[0].Env,
+		secondDeployment.Spec.Template.Spec.Containers[0].Env,
+		"an unchanged reconcile must not change the container env at all",
+	)
+
+	firstClient.AssertExpectations(t)
+	secondClient.AssertExpectations(t)
+}

--- a/controllers/apply_etcd_flap_test.go
+++ b/controllers/apply_etcd_flap_test.go
@@ -165,16 +165,170 @@ func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
 		"ETCD_TARGETS must survive a reconcile where the discovered targets are unchanged",
 	)
 
-	// The pod spec must be byte for byte identical, otherwise the apply rolls the pod.
+	// The whole pod template must be identical, not just the env: any difference at
+	// all changes the pod template hash and rolls the pod.
 	assert.Equal(
 		t,
-		firstDeployment.Spec.Template.Spec.Containers[0].Env,
-		secondDeployment.Spec.Template.Spec.Containers[0].Env,
-		"an unchanged reconcile must not change the container env at all",
+		firstDeployment.Spec.Template,
+		secondDeployment.Spec.Template,
+		"an unchanged reconcile must not change the pod template at all",
 	)
 
 	firstClient.AssertExpectations(t)
 	secondClient.AssertExpectations(t)
+}
+
+// etcdCAFileEnvOf returns the ETCD_CA_FILE value on the k8sensor container, or ""
+// when the env var is absent.
+func etcdCAFileEnvOf(deployment *appsv1.Deployment) string {
+	return k8sSensorEnvValue(deployment, constants.EnvETCDCAFile)
+}
+
+// TestETCDCASettingsRemainStableAcrossReconciles is the CA counterpart of the
+// stability test. The discovered CA drives an env var, a volume and a volume mount,
+// all of them off the same deployment context, so they flapped in lockstep with the
+// targets and all of them have to stay put on an unchanged reconcile.
+func TestETCDCASettingsRemainStableAcrossReconciles(t *testing.T) {
+	agent := agentForETCDTests()
+
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return &DiscoveredETCDTargets{
+			Targets: []string{"https://9.60.248.41:2379/metrics"},
+			CAFound: true,
+		}, nil
+	}
+
+	// First reconcile: nothing applied yet
+	firstClient := &mocks.MockInstanaAgentClient{}
+	firstClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+	firstContext, err := CreateDeploymentContext(
+		ctx,
+		firstClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	firstDeployment := renderK8sSensorDeployment(t, agent, firstContext)
+	require.Equal(
+		t,
+		constants.ETCDCAMountPath+"/ca.crt",
+		etcdCAFileEnvOf(firstDeployment),
+		"first reconcile should mount the discovered CA",
+	)
+	require.NotNil(
+		t,
+		findVolumeNamed(firstDeployment.Spec.Template.Spec.Volumes, "etcd-ca"),
+		"first reconcile should add the etcd-ca volume",
+	)
+
+	// Second reconcile: same targets, the case that used to strip everything
+	secondClient := &mocks.MockInstanaAgentClient{}
+	secondClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *firstDeployment
+		})
+
+	secondContext, err := CreateDeploymentContext(
+		ctx,
+		secondClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	secondDeployment := renderK8sSensorDeployment(t, agent, secondContext)
+	assert.Equal(
+		t,
+		etcdCAFileEnvOf(firstDeployment),
+		etcdCAFileEnvOf(secondDeployment),
+		"ETCD_CA_FILE must survive an unchanged reconcile",
+	)
+	assert.Equal(
+		t,
+		firstDeployment.Spec.Template,
+		secondDeployment.Spec.Template,
+		"the CA volume and mount must survive an unchanged reconcile too",
+	)
+
+	firstClient.AssertExpectations(t)
+	secondClient.AssertExpectations(t)
+}
+
+// TestETCDCASettingsRetainedWhenDiscoveryFails checks that the CA settings are
+// retained alongside the targets when discovery cannot determine them.
+func TestETCDCASettingsRetainedWhenDiscoveryFails(t *testing.T) {
+	agent := agentForETCDTests()
+
+	ctx := context.Background()
+	logger := zap.New()
+
+	// Stand in for what a previous reconcile applied: targets plus the discovered CA
+	applied := deploymentWithETCDTargets("https://9.60.248.41:2379/metrics")
+	applied.Spec.Template.Spec.Containers[0].Env = append(
+		applied.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  constants.EnvETCDCAFile,
+			Value: constants.ETCDCAMountPath + "/ca.crt",
+		},
+	)
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return nil, assert.AnError
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *applied
+		})
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
+	assert.Equal(
+		t,
+		constants.ETCDCAMountPath+"/ca.crt",
+		etcdCAFileEnvOf(deployment),
+		"a failed discovery must not strip the applied ETCD_CA_FILE",
+	)
+	assert.NotNil(
+		t,
+		findVolumeNamed(deployment.Spec.Template.Spec.Volumes, "etcd-ca"),
+		"a failed discovery must not strip the etcd-ca volume",
+	)
+	mockClient.AssertExpectations(t)
+}
+
+// findVolumeNamed returns the named volume, or nil when it is absent.
+func findVolumeNamed(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
 }
 
 // TestETCDTargetsUpdateWhenDiscoveryChanges makes sure the fix does not pin the env

--- a/controllers/apply_etcd_flap_test.go
+++ b/controllers/apply_etcd_flap_test.go
@@ -38,6 +38,24 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
 )
 
+// agentForETCDTests returns a minimal agent that renders a k8sensor Deployment.
+func agentForETCDTests() *instanav1.InstanaAgent {
+	return &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+		},
+	}
+}
+
 // renderK8sSensorDeployment builds the k8s-sensor Deployment the way applyResources
 // does, so the test sees exactly what would be sent to the server-side apply.
 func renderK8sSensorDeployment(
@@ -86,20 +104,7 @@ func etcdTargetsEnvOf(deployment *appsv1.Deployment) string {
 // stripped the env var and rolled the pod, and the next reconcile added it back,
 // leaving the k8sensor pod in a restart loop.
 func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
-	agent := &instanav1.InstanaAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-agent",
-			Namespace: "test-namespace",
-		},
-		Spec: instanav1.InstanaAgentSpec{
-			Agent: instanav1.BaseAgentSpec{
-				Key: "test-key",
-			},
-			Zone: instanav1.Name{
-				Name: "test-zone",
-			},
-		},
-	}
+	agent := agentForETCDTests()
 
 	ctx := context.Background()
 	logger := zap.New()
@@ -175,43 +180,12 @@ func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
 // TestETCDTargetsUpdateWhenDiscoveryChanges makes sure the fix does not pin the env
 // var: a genuine change in the discovered targets still rolls through.
 func TestETCDTargetsUpdateWhenDiscoveryChanges(t *testing.T) {
-	agent := &instanav1.InstanaAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-agent",
-			Namespace: "test-namespace",
-		},
-		Spec: instanav1.InstanaAgentSpec{
-			Agent: instanav1.BaseAgentSpec{
-				Key: "test-key",
-			},
-			Zone: instanav1.Name{
-				Name: "test-zone",
-			},
-		},
-	}
+	agent := agentForETCDTests()
 
 	ctx := context.Background()
 	logger := zap.New()
 
-	existingDeployment := &appsv1.Deployment{
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: constants.ContainerK8Sensor,
-							Env: []corev1.EnvVar{
-								{
-									Name:  constants.EnvETCDTargets,
-									Value: "http://9.60.248.41:2381/metrics",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	existingDeployment := deploymentWithETCDTargets("http://9.60.248.41:2381/metrics")
 
 	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
 		return &DiscoveredETCDTargets{
@@ -245,5 +219,170 @@ func TestETCDTargetsUpdateWhenDiscoveryChanges(t *testing.T) {
 		etcdTargetsEnvOf(deployment),
 		"a changed discovery result should update ETCD_TARGETS",
 	)
+	mockClient.AssertExpectations(t)
+}
+
+// deploymentWithETCDTargets returns a k8sensor Deployment carrying the given
+// ETCD_TARGETS value, standing in for what a previous reconcile applied.
+func deploymentWithETCDTargets(targets string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.ContainerK8Sensor,
+							Env: []corev1.EnvVar{
+								{
+									Name:  constants.EnvETCDTargets,
+									Value: targets,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestETCDTargetsRetainedWhenDiscoveryFails covers the transient failure half of the
+// flap: discovery erroring means the targets are unknown, not that etcd is gone, so
+// the applied targets have to survive rather than be stripped and rolled.
+func TestETCDTargetsRetainedWhenDiscoveryFails(t *testing.T) {
+	agent := agentForETCDTests()
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return nil, assert.AnError
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *deploymentWithETCDTargets("http://9.60.248.41:2381/metrics")
+		})
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
+	assert.Equal(
+		t,
+		"http://9.60.248.41:2381/metrics",
+		etcdTargetsEnvOf(deployment),
+		"a failed discovery must not strip the already applied ETCD_TARGETS",
+	)
+	mockClient.AssertExpectations(t)
+}
+
+// TestETCDTargetsRetainedWhenDiscoveryInconclusive covers the other transient half:
+// the etcd service is still there but no endpoint is ready on this pass.
+func TestETCDTargetsRetainedWhenDiscoveryInconclusive(t *testing.T) {
+	agent := agentForETCDTests()
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return &DiscoveredETCDTargets{Indeterminate: true}, nil
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *deploymentWithETCDTargets("http://9.60.248.41:2381/metrics")
+		})
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
+	assert.Equal(
+		t,
+		"http://9.60.248.41:2381/metrics",
+		etcdTargetsEnvOf(deployment),
+		"an inconclusive discovery must not strip the already applied ETCD_TARGETS",
+	)
+	mockClient.AssertExpectations(t)
+}
+
+// TestETCDTargetsClearedWhenETCDIsGone makes sure retaining the applied targets does
+// not pin them forever: when discovery positively reports that there is no etcd
+// service, the env var is still dropped so the k8sensor stops scraping it.
+func TestETCDTargetsClearedWhenETCDIsGone(t *testing.T) {
+	agent := agentForETCDTests()
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return nil, nil
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, deploymentContext)
+
+	deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
+	assert.Empty(
+		t,
+		etcdTargetsEnvOf(deployment),
+		"ETCD_TARGETS should be dropped once etcd is positively gone",
+	)
+	mockClient.AssertExpectations(t)
+}
+
+// TestETCDTargetsNotRetainedWithoutExistingDeployment covers the first reconcile on a
+// fresh install, where discovery fails and there is nothing applied yet to fall back on.
+func TestETCDTargetsNotRetainedWithoutExistingDeployment(t *testing.T) {
+	agent := agentForETCDTests()
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return nil, assert.AnError
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, deploymentContext, "there is nothing to retain on a fresh install")
 	mockClient.AssertExpectations(t)
 }

--- a/controllers/apply_etcd_flap_test.go
+++ b/controllers/apply_etcd_flap_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -169,4 +170,80 @@ func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
 
 	firstClient.AssertExpectations(t)
 	secondClient.AssertExpectations(t)
+}
+
+// TestETCDTargetsUpdateWhenDiscoveryChanges makes sure the fix does not pin the env
+// var: a genuine change in the discovered targets still rolls through.
+func TestETCDTargetsUpdateWhenDiscoveryChanges(t *testing.T) {
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	logger := zap.New()
+
+	existingDeployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.ContainerK8Sensor,
+							Env: []corev1.EnvVar{
+								{
+									Name:  constants.EnvETCDTargets,
+									Value: "http://9.60.248.41:2381/metrics",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return &DiscoveredETCDTargets{
+			Targets: []string{"http://9.60.248.42:2381/metrics"},
+			CAFound: false,
+		}, nil
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *existingDeployment
+		})
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
+	assert.Equal(
+		t,
+		"http://9.60.248.42:2381/metrics",
+		etcdTargetsEnvOf(deployment),
+		"a changed discovery result should update ETCD_TARGETS",
+	)
+	mockClient.AssertExpectations(t)
 }

--- a/controllers/apply_helper_test.go
+++ b/controllers/apply_helper_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
 )
 
-func TestCompareAndUpdateETCDTargets(t *testing.T) {
+func TestETCDTargetsChanged(t *testing.T) {
 	// Test cases
 	testCases := []struct {
 		name              string
@@ -125,7 +125,7 @@ func TestCompareAndUpdateETCDTargets(t *testing.T) {
 
 			// Test the function
 			logger := zap.New()
-			needsUpdate := compareAndUpdateETCDTargets(deployment, tc.discoveredTargets, logger)
+			needsUpdate := etcdTargetsChanged(deployment, tc.discoveredTargets, logger)
 
 			// Verify the result
 			assert.Equal(t, tc.expectUpdate, needsUpdate, tc.description)
@@ -133,7 +133,7 @@ func TestCompareAndUpdateETCDTargets(t *testing.T) {
 	}
 }
 
-func TestCompareAndUpdateETCDTargetsWithoutK8SensorContainer(t *testing.T) {
+func TestETCDTargetsChangedWithoutK8SensorContainer(t *testing.T) {
 	// Test case where deployment doesn't have k8s-sensor container
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -161,13 +161,13 @@ func TestCompareAndUpdateETCDTargetsWithoutK8SensorContainer(t *testing.T) {
 
 	discoveredTargets := []string{"https://10.0.0.1:2379/metrics"}
 	logger := zap.New()
-	needsUpdate := compareAndUpdateETCDTargets(deployment, discoveredTargets, logger)
+	needsUpdate := etcdTargetsChanged(deployment, discoveredTargets, logger)
 
 	// Should need update because no existing targets found (empty string) vs discovered targets
 	assert.True(t, needsUpdate, "Should need update when k8s-sensor container is not found")
 }
 
-func TestCompareAndUpdateETCDTargetsWithoutETCDTargetsEnv(t *testing.T) {
+func TestETCDTargetsChangedWithoutETCDTargetsEnv(t *testing.T) {
 	// Test case where k8s-sensor container exists but doesn't have ETCD_TARGETS env var
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +195,7 @@ func TestCompareAndUpdateETCDTargetsWithoutETCDTargetsEnv(t *testing.T) {
 
 	discoveredTargets := []string{"https://10.0.0.1:2379/metrics"}
 	logger := zap.New()
-	needsUpdate := compareAndUpdateETCDTargets(deployment, discoveredTargets, logger)
+	needsUpdate := etcdTargetsChanged(deployment, discoveredTargets, logger)
 
 	// Should need update because no ETCD_TARGETS env var found (empty string) vs discovered targets
 	assert.True(t, needsUpdate, "Should need update when ETCD_TARGETS env var is not found")

--- a/controllers/apply_test.go
+++ b/controllers/apply_test.go
@@ -64,12 +64,8 @@ func (m *mockOperatorUtils) DeleteAll() error {
 var _ operator_utils.OperatorUtils = (*mockOperatorUtils)(nil)
 
 func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
-	agent := &instanav1.InstanaAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-agent",
-			Namespace: "test-namespace",
-		},
-	}
+	// Carries a key and a zone so the context can also be rendered into a Deployment
+	agent := agentForETCDTests()
 
 	ctx := context.Background()
 	logger := zap.New()
@@ -241,15 +237,23 @@ func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		// The context must keep the targets even when nothing changed, otherwise the
-		// rendered Deployment drops ETCD_TARGETS and the apply strips it.
 		require.NotNil(t, deploymentContext)
+
+		// What actually matters is the object that would be applied: the rendered
+		// Deployment has to keep ETCD_TARGETS, otherwise the apply strips it
+		deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
 		assert.Equal(
 			t,
-			[]string{"https://etcd-1:2379/metrics", "https://etcd-2:2379/metrics"},
-			deploymentContext.DiscoveredETCDTargets,
+			"https://etcd-1:2379/metrics,https://etcd-2:2379/metrics",
+			etcdTargetsEnvOf(deployment),
+			"an unchanged reconcile must still render ETCD_TARGETS",
 		)
-		assert.Equal(t, constants.ETCDCASecretName, deploymentContext.ETCDCASecretName)
+		assert.Equal(
+			t,
+			constants.ETCDCAMountPath+"/ca.crt",
+			etcdCAFileEnvOf(deployment),
+			"an unchanged reconcile must still render the discovered CA",
+		)
 		mockClient.AssertExpectations(t)
 	})
 

--- a/controllers/apply_test.go
+++ b/controllers/apply_test.go
@@ -320,6 +320,10 @@ func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
 			return nil, assert.AnError
 		}
 
+		// There is no Deployment yet, so there are no applied targets to retain
+		mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
 		deploymentContext, err := CreateDeploymentContext(
 			ctx,
 			mockClient,

--- a/controllers/apply_test.go
+++ b/controllers/apply_test.go
@@ -192,7 +192,7 @@ func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-	t.Run("Deployment exists with same ETCD targets - no update", func(t *testing.T) {
+	t.Run("Deployment exists with same ETCD targets - targets retained", func(t *testing.T) {
 		mockClient := &mocks.MockInstanaAgentClient{}
 
 		// Mock ETCD discover function
@@ -241,7 +241,15 @@ func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Nil(t, deploymentContext) // Should return nil when no update needed
+		// The context must keep the targets even when nothing changed, otherwise the
+		// rendered Deployment drops ETCD_TARGETS and the apply strips it.
+		require.NotNil(t, deploymentContext)
+		assert.Equal(
+			t,
+			[]string{"https://etcd-1:2379/metrics", "https://etcd-2:2379/metrics"},
+			deploymentContext.DiscoveredETCDTargets,
+		)
+		assert.Equal(t, constants.ETCDCASecretName, deploymentContext.ETCDCASecretName)
 		mockClient.AssertExpectations(t)
 	})
 

--- a/controllers/etcd_discoverer.go
+++ b/controllers/etcd_discoverer.go
@@ -70,7 +70,7 @@ type ETCDDiscoverer interface {
 	) ([]string, error)
 
 	// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace
-	CheckCASecretExists(ctx context.Context, agent *instanav1.InstanaAgent) bool
+	CheckCASecretExists(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error)
 }
 
 // DefaultETCDDiscoverer is the production implementation of ETCDDiscoverer
@@ -296,23 +296,29 @@ func (d *DefaultETCDDiscoverer) BuildTargetsFromLegacyEndpoints(
 	return targets, nil
 }
 
-// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace
+// CheckCASecretExists checks if the etcd-ca secret exists in the agent namespace.
+// Only a clean not-found means the secret is absent. Any other error leaves the CA
+// state unknown and is returned, so the caller keeps what it already applied rather
+// than dropping the CA mount and rolling the k8sensor pod over a transient failure.
 func (d *DefaultETCDDiscoverer) CheckCASecretExists(
 	ctx context.Context,
 	agent *instanav1.InstanaAgent,
-) bool {
+) (bool, error) {
 	caSecret := &corev1.Secret{} // pragma: whitelist secret
 	err := d.client.Get(ctx, client.ObjectKey{
 		Namespace: agent.Namespace,
 		Name:      constants.ETCDCASecretName,
 	}, caSecret)
 
-	if err == nil {
+	switch {
+	case err == nil:
 		d.reconciler.loggerFor(ctx, agent).Info("Found etcd-ca secret in agent namespace")
-		return true
+		return true, nil
+	case errors.IsNotFound(err):
+		return false, nil
+	default:
+		return false, err
 	}
-
-	return false
 }
 
 func buildTargetsFromEndpointSlice(

--- a/controllers/etcd_discoverer_mock_test.go
+++ b/controllers/etcd_discoverer_mock_test.go
@@ -47,7 +47,7 @@ type MockETCDDiscoverer struct {
 		metricsPort int32,
 		scheme string,
 	) ([]string, error)
-	CheckCASecretExistsFunc func(ctx context.Context, agent *instanav1.InstanaAgent) bool
+	CheckCASecretExistsFunc func(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error)
 }
 
 func (m *MockETCDDiscoverer) ShouldSkipDiscovery(
@@ -123,9 +123,9 @@ func (m *MockETCDDiscoverer) BuildTargetsFromLegacyEndpoints(
 
 func (m *MockETCDDiscoverer) CheckCASecretExists(
 	ctx context.Context, agent *instanav1.InstanaAgent,
-) bool {
+) (bool, error) {
 	if m.CheckCASecretExistsFunc != nil {
 		return m.CheckCASecretExistsFunc(ctx, agent)
 	}
-	return false
+	return false, nil
 }

--- a/controllers/etcd_discovery.go
+++ b/controllers/etcd_discovery.go
@@ -55,7 +55,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 		return nil, err
 	}
 	if shouldSkip {
-		log.Info("Skipping ETCD discovery based on configuration or environment")
+		log.V(1).Info("Skipping ETCD discovery based on configuration or environment")
 		return nil, nil
 	}
 
@@ -65,16 +65,16 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 		return nil, err
 	}
 	if etcdService == nil {
-		log.Info("No ETCD service found in kube-system namespace")
+		log.V(1).Info("No ETCD service found in kube-system namespace")
 		return nil, nil
 	}
 
-	log.Info("Found etcd service", "name", etcdService.Name)
+	log.V(1).Info("Found etcd service", "name", etcdService.Name)
 
 	// Step 3: Find metrics port and determine scheme
 	metricsPortPtr, scheme := r.etcdDiscoverer.FindMetricsPortAndScheme(etcdService)
 	if metricsPortPtr == nil {
-		log.Info("No metrics port found in etcd service")
+		log.V(1).Info("No metrics port found in etcd service")
 		return nil, nil
 	}
 	metricsPort := *metricsPortPtr
@@ -102,7 +102,7 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 		return nil, err
 	}
 
-	log.Info("Discovered etcd targets", "targets", targets, "caFound", caSecretExists)
+	log.V(1).Info("Discovered etcd targets", "targets", targets, "caFound", caSecretExists)
 
 	return &DiscoveredETCDTargets{
 		Targets: targets,

--- a/controllers/etcd_discovery.go
+++ b/controllers/etcd_discovery.go
@@ -97,7 +97,10 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 	}
 
 	// Step 5: Check for CA secret and return results
-	caSecretExists := r.etcdDiscoverer.CheckCASecretExists(ctx, agent)
+	caSecretExists, err := r.etcdDiscoverer.CheckCASecretExists(ctx, agent)
+	if err != nil {
+		return nil, err
+	}
 
 	log.Info("Discovered etcd targets", "targets", targets, "caFound", caSecretExists)
 

--- a/controllers/etcd_discovery.go
+++ b/controllers/etcd_discovery.go
@@ -31,6 +31,13 @@ type DiscoveredETCDTargets struct {
 	// CAFound indicates whether the etcd-ca secret was found in the agent's namespace,
 	// which is needed for secure HTTPS connections to etcd endpoints
 	CAFound bool
+
+	// Indeterminate is set when discovery could not establish the current set of
+	// targets, as opposed to establishing that there are none. The etcd service and
+	// its metrics port exist but no endpoint is ready, which is usually a transient
+	// state. Callers should keep the targets they already applied instead of
+	// clearing them, so a blip does not roll the k8sensor pod.
+	Indeterminate bool
 }
 
 const kubeSystemNamespace = "kube-system"
@@ -83,8 +90,10 @@ func (r *InstanaAgentReconciler) DiscoverETCDEndpoints(
 		return nil, err
 	}
 	if len(targets) == 0 {
-		log.Info("No endpoints found for etcd service")
-		return nil, nil
+		// The service and its metrics port are still there, so etcd has not gone
+		// away, we just cannot enumerate ready endpoints on this pass.
+		log.Info("No ready endpoints found for etcd service, discovery is inconclusive")
+		return &DiscoveredETCDTargets{Indeterminate: true}, nil
 	}
 
 	// Step 5: Check for CA secret and return results

--- a/controllers/etcd_discovery_test.go
+++ b/controllers/etcd_discovery_test.go
@@ -997,7 +997,9 @@ func TestCheckCASecretExists(t *testing.T) {
 	testCases := []struct {
 		name          string
 		createSecret  bool
+		clientErr     error
 		expectedFound bool
+		expectError   bool
 	}{
 		{
 			name:          "Should find CA secret when it exists",
@@ -1008,6 +1010,15 @@ func TestCheckCASecretExists(t *testing.T) {
 			name:          "Should not find CA secret when it doesn't exist",
 			createSecret:  false,
 			expectedFound: false,
+		},
+		{
+			// A failed lookup must not be reported as a clean absence, otherwise the
+			// CA mount is dropped and the k8sensor pod is rolled over a transient blip
+			name:          "Should return error when the lookup fails",
+			createSecret:  false,
+			clientErr:     fmt.Errorf("apiserver temporary failure"),
+			expectedFound: false,
+			expectError:   true,
 		},
 	}
 
@@ -1036,20 +1047,28 @@ func TestCheckCASecretExists(t *testing.T) {
 			}
 
 			// Build the client
-			fakeClient := clientBuilder.Build()
+			var builtClient client.Client = clientBuilder.Build()
+			if tc.clientErr != nil {
+				builtClient = &errorMockClient{Client: builtClient, err: tc.clientErr}
+			}
 
 			// Create real reconciler
 			reconciler := &InstanaAgentReconciler{
-				client: instanaclient.NewInstanaAgentClient(fakeClient),
+				client: instanaclient.NewInstanaAgentClient(builtClient),
 				scheme: scheme,
 			}
 
 			// Create discoverer and test
 			discoverer := NewDefaultETCDDiscoverer(reconciler.client, reconciler)
 			ctx := context.Background()
-			found := discoverer.CheckCASecretExists(ctx, agent)
+			found, err := discoverer.CheckCASecretExists(ctx, agent)
 
 			// Verify
+			if tc.expectError {
+				assert.Error(t, err, "Should return an error")
+			} else {
+				assert.NoError(t, err, "Should not return an error")
+			}
 			assert.Equal(t, tc.expectedFound, found, "CA secret found status should match expected")
 		})
 	}
@@ -1074,6 +1093,7 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 		buildTargetsResult  []string
 		buildTargetsErr     error
 		caSecretExists      bool
+		caSecretErr         error
 		expectedTargets     []string
 		expectedCAFound     bool
 		expectError         bool
@@ -1151,6 +1171,20 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 			expectError:         false,
 		},
 		{
+			name:               "Should return error when the CA secret check fails",
+			shouldSkip:         false,
+			shouldSkipErr:      nil,
+			findServiceResult:  &corev1.Service{},
+			findServiceErr:     nil,
+			metricsPort:        2379,
+			scheme:             "https",
+			buildTargetsResult: []string{"https://10.0.0.1:2379/metrics"},
+			buildTargetsErr:    nil,
+			caSecretErr:        fmt.Errorf("ca secret error"),
+			expectNilResult:    true,
+			expectError:        true,
+		},
+		{
 			name:               "Should return targets and CA status when everything succeeds",
 			shouldSkip:         false,
 			shouldSkipErr:      nil,
@@ -1207,8 +1241,8 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 				) ([]string, error) {
 					return tc.buildTargetsResult, tc.buildTargetsErr
 				},
-				CheckCASecretExistsFunc: func(ctx context.Context, agent *instanav1.InstanaAgent) bool {
-					return tc.caSecretExists
+				CheckCASecretExistsFunc: func(ctx context.Context, agent *instanav1.InstanaAgent) (bool, error) {
+					return tc.caSecretExists, tc.caSecretErr
 				},
 			}
 			reconciler.etcdDiscoverer = mockDiscoverer

--- a/controllers/etcd_discovery_test.go
+++ b/controllers/etcd_discovery_test.go
@@ -1064,20 +1064,21 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 
 	// Test cases
 	testCases := []struct {
-		name               string
-		shouldSkip         bool
-		shouldSkipErr      error
-		findServiceResult  *corev1.Service
-		findServiceErr     error
-		metricsPort        int32
-		scheme             string
-		buildTargetsResult []string
-		buildTargetsErr    error
-		caSecretExists     bool
-		expectedTargets    []string
-		expectedCAFound    bool
-		expectError        bool
-		expectNilResult    bool
+		name                string
+		shouldSkip          bool
+		shouldSkipErr       error
+		findServiceResult   *corev1.Service
+		findServiceErr      error
+		metricsPort         int32
+		scheme              string
+		buildTargetsResult  []string
+		buildTargetsErr     error
+		caSecretExists      bool
+		expectedTargets     []string
+		expectedCAFound     bool
+		expectError         bool
+		expectNilResult     bool
+		expectIndeterminate bool
 	}{
 		{
 			name:            "Should return nil when shouldSkipDiscovery returns true",
@@ -1136,17 +1137,18 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 			expectError:        true,
 		},
 		{
-			name:               "Should return nil when no targets found",
-			shouldSkip:         false,
-			shouldSkipErr:      nil,
-			findServiceResult:  &corev1.Service{},
-			findServiceErr:     nil,
-			metricsPort:        2379,
-			scheme:             "https",
-			buildTargetsResult: []string{},
-			buildTargetsErr:    nil,
-			expectNilResult:    true,
-			expectError:        false,
+			name:                "Should report inconclusive when no ready endpoints found",
+			shouldSkip:          false,
+			shouldSkipErr:       nil,
+			findServiceResult:   &corev1.Service{},
+			findServiceErr:      nil,
+			metricsPort:         2379,
+			scheme:              "https",
+			buildTargetsResult:  []string{},
+			buildTargetsErr:     nil,
+			expectNilResult:     false,
+			expectIndeterminate: true,
+			expectError:         false,
 		},
 		{
 			name:               "Should return targets and CA status when everything succeeds",
@@ -1225,9 +1227,14 @@ func TestDiscoverETCDEndpoints(t *testing.T) {
 				assert.NoError(t, err, "Should not return an error")
 			}
 
-			if tc.expectNilResult {
+			switch {
+			case tc.expectNilResult:
 				assert.Nil(t, result, "Result should be nil")
-			} else {
+			case tc.expectIndeterminate:
+				assert.NotNil(t, result, "Result should not be nil")
+				assert.True(t, result.Indeterminate, "Result should be marked inconclusive")
+				assert.Empty(t, result.Targets, "Inconclusive result should carry no targets")
+			default:
 				assert.NotNil(t, result, "Result should not be nil")
 				assert.Equal(t, tc.expectedTargets, result.Targets, "Targets should match expected")
 				assert.Equal(t, tc.expectedCAFound, result.CAFound, "CAFound should match expected")

--- a/controllers/feedback_test.go
+++ b/controllers/feedback_test.go
@@ -70,8 +70,8 @@ func TestGetSortedTargets(t *testing.T) {
 	}
 }
 
-// TestCompareAndUpdateETCDTargetsFocused tests our key extracted function
-func TestCompareAndUpdateETCDTargetsFocused(t *testing.T) {
+// TestETCDTargetsChangedFocused tests our key extracted function
+func TestETCDTargetsChangedFocused(t *testing.T) {
 	testCases := []struct {
 		name              string
 		existingTargets   string
@@ -132,7 +132,7 @@ func TestCompareAndUpdateETCDTargetsFocused(t *testing.T) {
 			}
 
 			logger := zap.New()
-			needsUpdate := compareAndUpdateETCDTargets(deployment, tc.discoveredTargets, logger)
+			needsUpdate := etcdTargetsChanged(deployment, tc.discoveredTargets, logger)
 
 			assert.Equal(t, tc.expectUpdate, needsUpdate, "Update expectation should match")
 		})

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -138,8 +138,12 @@ func (d *deploymentBuilder) getEnvVars() []corev1.EnvVar {
 					Value: strings.Join(d.deploymentContext.DiscoveredETCDTargets, ","),
 				})
 
-				// Add CA file env var if CA secret is available
-				if d.deploymentContext.ETCDCASecretName != "" {
+				// Add CA file env var if CA secret is available. A CA mount path on the
+				// CR already produces ETCD_CA_FILE via ETCDCAFileEnv, so the CR wins and
+				// the discovered one is skipped, otherwise the container would carry the
+				// env var twice and the apply would reject it.
+				if d.deploymentContext.ETCDCASecretName != "" &&
+					d.Spec.K8sSensor.ETCD.CA.MountPath == "" {
 					envVars = append(envVars, corev1.EnvVar{
 						Name:  constants.EnvETCDCAFile,
 						Value: constants.ETCDCAMountPath + "/ca.crt",
@@ -202,8 +206,12 @@ func (d *deploymentBuilder) getVolumes() ([]corev1.Volume, []corev1.VolumeMount)
 
 	volumes, mounts := d.VolumeBuilder.Build(volumesToBuild...)
 
-	// Add CA cert if available from discovery
-	if d.deploymentContext != nil && d.deploymentContext.ETCDCASecretName != "" && len(d.Spec.K8sSensor.ETCD.Targets) == 0 {
+	// Add CA cert if available from discovery. A CA secret on the CR already produces
+	// an etcd-ca volume and mount above, so the CR wins and the discovered one is
+	// skipped, otherwise the pod would carry two volumes with the same name.
+	if d.deploymentContext != nil && d.deploymentContext.ETCDCASecretName != "" &&
+		len(d.Spec.K8sSensor.ETCD.Targets) == 0 &&
+		d.Spec.K8sSensor.ETCD.CA.SecretName == "" {
 		volumes = append(volumes, corev1.Volume{
 			Name: "etcd-ca",
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
@@ -1,0 +1,210 @@
+/*
+(c) Copyright IBM Corp. 2025
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	backend "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
+	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
+	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
+)
+
+func countEnvVars(envVars []corev1.EnvVar, name string) int {
+	count := 0
+	for _, env := range envVars {
+		if env.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func countVolumes(volumes []corev1.Volume, name string) int {
+	count := 0
+	for _, vol := range volumes {
+		if vol.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func countVolumeMounts(mounts []corev1.VolumeMount, name string) int {
+	count := 0
+	for _, mount := range mounts {
+		if mount.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+// agentWithCustomETCDCA returns an agent that configures its own ETCD CA, without
+// pinning the targets, so ETCD discovery still runs and reports a CA of its own.
+func agentWithCustomETCDCA() *instanav1.InstanaAgent {
+	return &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+			K8sSensor: instanav1.K8sSpec{
+				ETCD: instanav1.ETCDSpec{
+					CA: instanav1.CASpec{
+						SecretName: "custom-etcd-ca",
+						MountPath:  "/custom/etcd",
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA covers a CR that configures
+// its own ETCD CA on a cluster where discovery also finds one. Both used to be
+// emitted, giving the container two ETCD_CA_FILE entries and the pod two volumes
+// named etcd-ca, which the API server rejects as duplicates.
+func TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA(t *testing.T) {
+	// Given
+	agent := agentWithCustomETCDCA()
+
+	mockStatusManager := &status.MockAgentStatusManager{}
+	backendObj := backend.NewK8SensorBackend("", "test-key", "", "test-host", "443")
+
+	deploymentContext := &DeploymentContext{
+		DiscoveredETCDTargets: []string{"https://10.0.0.1:2379/metrics"},
+		ETCDCASecretName:      constants.ETCDCASecretName,
+	}
+
+	builder := NewDeploymentBuilder(
+		agent,
+		false,
+		mockStatusManager,
+		*backendObj,
+		nil,
+		deploymentContext,
+	).(*deploymentBuilder)
+
+	// When
+	envVars := builder.getEnvVars()
+	volumes, mounts := builder.getVolumes()
+
+	// Then - the CR configuration wins and nothing is emitted twice
+	assert.Equal(
+		t,
+		1,
+		countEnvVars(envVars, constants.EnvETCDCAFile),
+		"ETCD_CA_FILE should be set exactly once",
+	)
+	assert.Equal(
+		t,
+		"/custom/etcd/ca.crt",
+		findEnvVar(envVars, constants.EnvETCDCAFile).Value,
+		"the CA file configured on the CR should win over the discovered one",
+	)
+
+	assert.Equal(t, 1, countVolumes(volumes, "etcd-ca"), "there should be one etcd-ca volume")
+	assert.Equal(
+		t,
+		"custom-etcd-ca",
+		findVolume(volumes, "etcd-ca").Secret.SecretName,
+		"the CA secret configured on the CR should win over the discovered one",
+	)
+	assert.Equal(
+		t,
+		1,
+		countVolumeMounts(mounts, "etcd-ca"),
+		"there should be one etcd-ca mount",
+	)
+
+	// The discovered targets are still applied, only the CA is left to the CR
+	assert.Equal(
+		t,
+		"https://10.0.0.1:2379/metrics",
+		findEnvVar(envVars, constants.EnvETCDTargets).Value,
+		"discovered targets should still be applied",
+	)
+}
+
+// TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA is the counterpart: with
+// no CA on the CR, the discovered one is still mounted as before.
+func TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA(t *testing.T) {
+	// Given
+	agent := agentWithCustomETCDCA()
+	agent.Spec.K8sSensor.ETCD.CA = instanav1.CASpec{}
+
+	mockStatusManager := &status.MockAgentStatusManager{}
+	backendObj := backend.NewK8SensorBackend("", "test-key", "", "test-host", "443")
+
+	deploymentContext := &DeploymentContext{
+		DiscoveredETCDTargets: []string{"https://10.0.0.1:2379/metrics"},
+		ETCDCASecretName:      constants.ETCDCASecretName,
+	}
+
+	builder := NewDeploymentBuilder(
+		agent,
+		false,
+		mockStatusManager,
+		*backendObj,
+		nil,
+		deploymentContext,
+	).(*deploymentBuilder)
+
+	// When
+	envVars := builder.getEnvVars()
+	volumes, mounts := builder.getVolumes()
+
+	// Then
+	assert.Equal(
+		t,
+		1,
+		countEnvVars(envVars, constants.EnvETCDCAFile),
+		"ETCD_CA_FILE should be set exactly once",
+	)
+	assert.Equal(
+		t,
+		constants.ETCDCAMountPath+"/ca.crt",
+		findEnvVar(envVars, constants.EnvETCDCAFile).Value,
+		"the discovered CA file should be used when the CR configures none",
+	)
+
+	assert.Equal(t, 1, countVolumes(volumes, "etcd-ca"), "there should be one etcd-ca volume")
+	assert.Equal(
+		t,
+		constants.ETCDCASecretName,
+		findVolume(volumes, "etcd-ca").Secret.SecretName,
+		"the discovered CA secret should be mounted",
+	)
+	assert.Equal(
+		t,
+		1,
+		countVolumeMounts(mounts, "etcd-ca"),
+		"there should be one etcd-ca mount",
+	)
+}


### PR DESCRIPTION
## Why

On a K3s cluster with etcd metrics enabled, the k8sensor pod restart-loops for around an hour before it settles. A test engineer captured the Deployment flipping back and forth on alternating reconciles:

```
SpecUpdated  Env.6.Name:  <nil> -> ETCD_TARGETS
SpecUpdated  Env.6.Value: <nil> -> http://9.60.248.41:2381/metrics
SpecUpdated  Env.6.Name:  ETCD_TARGETS -> <nil>
SpecUpdated  Env.6.Value: http://9.60.248.41:2381/metrics -> <nil>
Killing      Stopping container instana-agent
```

Every flip is a new pod template hash, so every reconcile rolls the k8sensor pod. While that is happening the sensor is repeatedly killed and restarted, which means gaps in Kubernetes entity and control plane data for the cluster.

## What

`CreateDeploymentContext` discovers the etcd endpoints and compares them against the ones already on the Deployment. When they matched, it returned a `nil` deployment context as a "nothing to do" optimization.

That optimization does not hold, because the deployment builder does not patch the live object. It rebuilds the whole pod spec from scratch on every reconcile, and it only emits `ETCD_TARGETS` when the context is non-nil and carries targets. A `nil` context therefore renders a Deployment with no `ETCD_TARGETS` at all. Since the operator applies with server-side apply and `ForceOwnership`, and `Container.Env` is a map-typed list keyed on the env var name, the previously owned entry is not merged forward but removed. The next reconcile sees the env var missing, decides an update is needed, adds it back, and the cycle repeats.

The fix is to let the unchanged case fall through and build the same context as the changed case, so the discovered targets are always carried. The rendered Deployment is then byte identical between reconciles, the apply is a no-op, and the pod is only rolled when the discovered targets genuinely change. `compareAndUpdateETCDTargets` is now used only to choose the log message.

The same strip-and-roll cycle was reachable through two more doors, so those are closed here too. Both returned a nil context, with exactly the same downstream effect:

- **Discovery failing.** `ShouldSkipDiscovery` does a live `Exists` call to decide whether the cluster is OpenShift, and `BuildTargetsFromEndpoints` lists EndpointSlices. A single transient API error turned into "no targets", stripped `ETCD_TARGETS` and rolled the pod, and the next reconcile rolled it back. An error means the targets are unknown, not that there are none, so the targets already applied to the live Deployment are now retained.
- **No ready endpoints.** If the etcd service and its metrics port are still present but no endpoint is currently ready, discovery reported zero targets, which is indistinguishable from etcd having been removed. On a single node K3s cluster one unready pass was enough to roll the sensor. `DiscoveredETCDTargets` now carries an `Indeterminate` flag for that case and the applied targets are retained.

Retention is deliberately not unconditional, so the env var cannot get pinned forever: when discovery positively establishes that there is no etcd, meaning the service is gone, it has no metrics port, or discovery was skipped, the targets are still dropped and the k8sensor stops scraping them.

Two smaller things in the same area came out of review and are fixed here as well:

- `CheckCASecretExists` treated every error from its lookup as "the secret is not there", so one failed call dropped the CA mount and rolled the pod, exactly the same shape of bug as above. Only a clean not-found now means absent; anything else is reported and the applied settings are retained.
- A CR that configured its own `k8sSensor.etcd.ca` on a cluster where discovery also found a CA produced the CR volume and the discovered volume, both named `etcd-ca`, plus two `ETCD_CA_FILE` env vars. The API server rejects both as duplicates. The CR configuration now wins and the discovered CA is skipped, which matches how explicitly configured targets already take precedence.

`compareAndUpdateETCDTargets` was renamed to `etcdTargetsChanged`. It never updated anything, and now that it no longer gates the update either, the old name invited exactly the mistake this PR is fixing.

Finally, the ETCD discovery log lines that fire on every reconcile and say nothing new in steady state moved to `V(1)`. The inconclusive-discovery line stays at the default level, since that one is an anomaly worth seeing.

Scope notes:

- The OpenShift path is not affected. `setupOpenShiftETCDMonitoring` returns early and always hands back a non-nil context, so it never hits this skip.
- This is independent of the cross-namespace ownerReference issue on the etcd-reader Role and RoleBinding. Those builders only take the agent and never see the deployment context.

Test coverage:

- `TestETCDTargetsRemainStableAcrossReconciles` drives two consecutive reconciles and asserts the whole pod template is unchanged the second time round, since any difference at all changes the pod template hash and rolls the pod. Against the old code it fails with `ETCD_TARGETS` missing from the second render, which is the reported bug reproduced as a unit test.
- `TestETCDCASettingsRemainStableAcrossReconciles` and `TestETCDCASettingsRetainedWhenDiscoveryFails` do the same for the CA, which drives an env var, a volume and a volume mount off the same context and so flapped in lockstep with the targets.
- `TestETCDTargetsRetainedWhenDiscoveryFails` and `TestETCDTargetsRetainedWhenDiscoveryInconclusive` cover the two transient paths. Both fail against the old code with the env var stripped.
- `TestETCDTargetsClearedWhenETCDIsGone` and `TestETCDTargetsUpdateWhenDiscoveryChanges` are the guards in the other direction: retention must not pin the env var, and a real change in the discovered targets still propagates.
- `TestETCDTargetsNotRetainedWithoutExistingDeployment` covers a fresh install where discovery fails before anything has been applied.
- `TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA` pins the CA precedence. Against the old code it fails three times over, with two `ETCD_CA_FILE` env vars, two `etcd-ca` volumes and two `etcd-ca` mounts. `TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA` is its counterpart, confirming the discovered CA is still mounted when the CR configures none.
- `TestCheckCASecretExists` gained a case for a failing lookup, and `TestDiscoverETCDEndpoints` one for the error propagating.
- Two existing expectations changed with the behaviour: the "same targets" case in `TestCreateDeploymentContext_SimplifiedTests` asserted the nil context, and `TestDiscoverETCDEndpoints` asserted a nil result when no endpoints were ready.

## References

- [Story / Card](https://jsw.ibm.com/browse/INSTA-105465)

## Checklist

- [x] Backwards compatible?
- [x] unit/e2e test coverage added or updated?

Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
