### PR TITLE
fix: stop ETCD_TARGETS flapping when the discovered targets are unchanged

### DIFF
--- a/controllers/apply.go
+++ b/controllers/apply.go
@@ -503,13 +503,14 @@ func CreateDeploymentContext(
 
 	if err != nil {
 		logger.Info("K8sensor deployment not found, will create with discovered ETCD targets")
+	} else if compareAndUpdateETCDTargets(existingDeployment, discoveredETCD.Targets, logger) {
+		logger.Info("ETCD targets changed, Deployment will be updated")
 	} else {
-		// Compare current and discovered ETCD targets
-		needsUpdate := compareAndUpdateETCDTargets(existingDeployment, discoveredETCD.Targets, logger)
-		if !needsUpdate {
-			logger.Info("ETCD targets unchanged, skipping Deployment update")
-			return nil, nil
-		}
+		// The context still has to carry the targets when they are unchanged. The
+		// deployment builder always rebuilds the full pod spec, so a nil context
+		// renders a Deployment without ETCD_TARGETS, the server-side apply strips
+		// the env var and rolls the pod, and the next reconcile adds it back again.
+		logger.Info("ETCD targets unchanged, keeping them on the Deployment")
 	}
 
 	// Use sorted targets for consistency

--- a/controllers/apply_etcd_flap_test.go
+++ b/controllers/apply_etcd_flap_test.go
@@ -1,0 +1,172 @@
+/*
+(c) Copyright IBM Corp. 2025
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	"github.com/instana/instana-agent-operator/internal/mocks"
+	backends "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
+	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
+	k8ssensordeployment "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/k8s-sensor/deployment"
+	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
+)
+
+// renderK8sSensorDeployment builds the k8s-sensor Deployment the way applyResources
+// does, so the test sees exactly what would be sent to the server-side apply.
+func renderK8sSensorDeployment(
+	t *testing.T,
+	agent *instanav1.InstanaAgent,
+	deploymentContext *k8ssensordeployment.DeploymentContext,
+) *appsv1.Deployment {
+	t.Helper()
+
+	backend := backends.NewK8SensorBackend("", "test-key", "", "test-host", "443")
+	built := k8ssensordeployment.NewDeploymentBuilder(
+		agent,
+		false,
+		&status.MockAgentStatusManager{},
+		*backend,
+		nil,
+		deploymentContext,
+	).Build()
+
+	require.True(t, built.IsPresent(), "deployment builder should produce a Deployment")
+
+	deployment, ok := built.Get().(*appsv1.Deployment)
+	require.True(t, ok, "builder should produce a *appsv1.Deployment")
+	return deployment
+}
+
+// etcdTargetsEnvOf returns the ETCD_TARGETS value on the k8sensor container, or ""
+// when the env var is absent.
+func etcdTargetsEnvOf(deployment *appsv1.Deployment) string {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != constants.ContainerK8Sensor {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == constants.EnvETCDTargets {
+				return env.Value
+			}
+		}
+	}
+	return ""
+}
+
+// TestETCDTargetsRemainStableAcrossReconciles reproduces INSTA-105465: on the
+// reconcile after the targets were applied, discovery finds the same targets, and
+// the rendered Deployment used to drop ETCD_TARGETS entirely. Server-side apply then
+// stripped the env var and rolled the pod, and the next reconcile added it back,
+// leaving the k8sensor pod in a restart loop.
+func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	logger := zap.New()
+
+	discoveredTargets := []string{"http://9.60.248.41:2381/metrics"}
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return &DiscoveredETCDTargets{Targets: discoveredTargets, CAFound: false}, nil
+	}
+
+	// First reconcile: no Deployment exists yet, so the targets get applied.
+	firstClient := &mocks.MockInstanaAgentClient{}
+	firstClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+	firstContext, err := CreateDeploymentContext(
+		ctx,
+		firstClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	firstDeployment := renderK8sSensorDeployment(t, agent, firstContext)
+	assert.Equal(
+		t,
+		"http://9.60.248.41:2381/metrics",
+		etcdTargetsEnvOf(firstDeployment),
+		"first reconcile should set ETCD_TARGETS",
+	)
+
+	// Second reconcile: the Deployment now exists and discovery returns the same
+	// targets, which is the case that used to strip the env var.
+	secondClient := &mocks.MockInstanaAgentClient{}
+	secondClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *firstDeployment
+		})
+
+	secondContext, err := CreateDeploymentContext(
+		ctx,
+		secondClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	secondDeployment := renderK8sSensorDeployment(t, agent, secondContext)
+	assert.Equal(
+		t,
+		etcdTargetsEnvOf(firstDeployment),
+		etcdTargetsEnvOf(secondDeployment),
+		"ETCD_TARGETS must survive a reconcile where the discovered targets are unchanged",
+	)
+
+	// The pod spec must be byte for byte identical, otherwise the apply rolls the pod.
+	assert.Equal(
+		t,
+		firstDeployment.Spec.Template.Spec.Containers[0].Env,
+		secondDeployment.Spec.Template.Spec.Containers[0].Env,
+		"an unchanged reconcile must not change the container env at all",
+	)
+
+	firstClient.AssertExpectations(t)
+	secondClient.AssertExpectations(t)
+}

--- a/controllers/apply_etcd_flap_test.go
+++ b/controllers/apply_etcd_flap_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -169,4 +170,80 @@ func TestETCDTargetsRemainStableAcrossReconciles(t *testing.T) {
 
 	firstClient.AssertExpectations(t)
 	secondClient.AssertExpectations(t)
+}
+
+// TestETCDTargetsUpdateWhenDiscoveryChanges makes sure the fix does not pin the env
+// var: a genuine change in the discovered targets still rolls through.
+func TestETCDTargetsUpdateWhenDiscoveryChanges(t *testing.T) {
+	agent := &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-namespace",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	logger := zap.New()
+
+	existingDeployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.ContainerK8Sensor,
+							Env: []corev1.EnvVar{
+								{
+									Name:  constants.EnvETCDTargets,
+									Value: "http://9.60.248.41:2381/metrics",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	discoverETCD := func(ctx context.Context, agent *instanav1.InstanaAgent) (*DiscoveredETCDTargets, error) {
+		return &DiscoveredETCDTargets{
+			Targets: []string{"http://9.60.248.42:2381/metrics"},
+			CAFound: false,
+		}, nil
+	}
+
+	mockClient := &mocks.MockInstanaAgentClient{}
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1.Deployment"), mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			deployment := args.Get(2).(*appsv1.Deployment)
+			*deployment = *existingDeployment
+		})
+
+	deploymentContext, err := CreateDeploymentContext(
+		ctx,
+		mockClient,
+		agent,
+		false,
+		logger,
+		discoverETCD,
+	)
+	require.NoError(t, err)
+
+	deployment := renderK8sSensorDeployment(t, agent, deploymentContext)
+	assert.Equal(
+		t,
+		"http://9.60.248.42:2381/metrics",
+		etcdTargetsEnvOf(deployment),
+		"a changed discovery result should update ETCD_TARGETS",
+	)
+	mockClient.AssertExpectations(t)
 }

--- a/controllers/apply_test.go
+++ b/controllers/apply_test.go
@@ -192,7 +192,7 @@ func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-	t.Run("Deployment exists with same ETCD targets - no update", func(t *testing.T) {
+	t.Run("Deployment exists with same ETCD targets - targets retained", func(t *testing.T) {
 		mockClient := &mocks.MockInstanaAgentClient{}
 
 		// Mock ETCD discover function
@@ -241,7 +241,15 @@ func TestCreateDeploymentContext_SimplifiedTests(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		assert.Nil(t, deploymentContext) // Should return nil when no update needed
+		// The context must keep the targets even when nothing changed, otherwise the
+		// rendered Deployment drops ETCD_TARGETS and the apply strips it.
+		require.NotNil(t, deploymentContext)
+		assert.Equal(
+			t,
+			[]string{"https://etcd-1:2379/metrics", "https://etcd-2:2379/metrics"},
+			deploymentContext.DiscoveredETCDTargets,
+		)
+		assert.Equal(t, constants.ETCDCASecretName, deploymentContext.ETCDCASecretName)
 		mockClient.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
## Why

On a K3s cluster with etcd metrics enabled, the k8sensor pod restart-loops for around an hour before it settles. A test engineer captured the Deployment flipping back and forth on alternating reconciles:

```
SpecUpdated  Env.6.Name:  <nil> -> ETCD_TARGETS
SpecUpdated  Env.6.Value: <nil> -> http://9.60.248.41:2381/metrics
SpecUpdated  Env.6.Name:  ETCD_TARGETS -> <nil>
SpecUpdated  Env.6.Value: http://9.60.248.41:2381/metrics -> <nil>
Killing      Stopping container instana-agent
```

Every flip is a new pod template hash, so every reconcile rolls the k8sensor pod. While that is happening the sensor is repeatedly killed and restarted, which means gaps in Kubernetes entity and control plane data for the cluster.

## What

`CreateDeploymentContext` discovers the etcd endpoints and compares them against the ones already on the Deployment. When they matched, it returned a `nil` deployment context as a "nothing to do" optimization.

That optimization does not hold, because the deployment builder does not patch the live object. It rebuilds the whole pod spec from scratch on every reconcile, and it only emits `ETCD_TARGETS` when the context is non-nil and carries targets. A `nil` context therefore renders a Deployment with no `ETCD_TARGETS` at all. Since the operator applies with server-side apply and `ForceOwnership`, and `Container.Env` is a map-typed list keyed on the env var name, the previously owned entry is not merged forward but removed. The next reconcile sees the env var missing, decides an update is needed, adds it back, and the cycle repeats.

The fix is to let the unchanged case fall through and build the same context as the changed case, so the discovered targets are always carried. The rendered Deployment is then byte identical between reconciles, the apply is a no-op, and the pod is only rolled when the discovered targets genuinely change.

The production change is nine lines in `controllers/apply.go`; the rest is test coverage.

Scope notes:

- The OpenShift path is not affected. `setupOpenShiftETCDMonitoring` returns early and always hands back a non-nil context, so it never hits this skip.
- This is independent of the cross-namespace ownerReference issue on the etcd-reader Role and RoleBinding. Those builders only take the agent and never see the deployment context.
- Review of this change surfaced several related problems in the same area: the targets are also dropped when discovery fails or returns no ready endpoints, `CheckCASecretExists` reports every lookup error as a clean absence, and a CR configured ETCD CA collides with a discovered one. Those are deliberately **not** fixed here, to keep this PR to the reported bug. 

Test coverage:

- `TestETCDTargetsRemainStableAcrossReconciles` drives two consecutive reconciles and asserts the container env is unchanged the second time round. Against the old code it fails with `ETCD_TARGETS` missing from the second render, which is the reported bug reproduced as a unit test.
- `TestETCDTargetsUpdateWhenDiscoveryChanges` confirms the env var is not pinned and a real change in the discovered targets still propagates.
- The existing "same targets" case in `TestCreateDeploymentContext_SimplifiedTests` asserted the nil context, so it was updated to expect the targets to be retained.

Note that `TestInstanaAgentControllerTestSuite` fails on this branch, but it fails identically on unmodified `main` with envtest assets provisioned, so it is pre-existing and not caused by this change.

## References

- [Story / Card](https://jsw.ibm.com/browse/INSTA-105465)

## Checklist

- [x] Backwards compatible?
- [x] unit/e2e test coverage added or updated?

Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
