### PR TITLE
fix: let a CR configured ETCD CA win over the discovered one

### DIFF
--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -138,8 +138,12 @@ func (d *deploymentBuilder) getEnvVars() []corev1.EnvVar {
 					Value: strings.Join(d.deploymentContext.DiscoveredETCDTargets, ","),
 				})
 
-				// Add CA file env var if CA secret is available
-				if d.deploymentContext.ETCDCASecretName != "" {
+				// Add CA file env var if CA secret is available. A CA mount path on the
+				// CR already produces ETCD_CA_FILE via ETCDCAFileEnv, so the CR wins and
+				// the discovered one is skipped, otherwise the container would carry the
+				// env var twice and the apply would reject it.
+				if d.deploymentContext.ETCDCASecretName != "" &&
+					d.Spec.K8sSensor.ETCD.CA.MountPath == "" {
 					envVars = append(envVars, corev1.EnvVar{
 						Name:  constants.EnvETCDCAFile,
 						Value: constants.ETCDCAMountPath + "/ca.crt",
@@ -202,8 +206,12 @@ func (d *deploymentBuilder) getVolumes() ([]corev1.Volume, []corev1.VolumeMount)
 
 	volumes, mounts := d.VolumeBuilder.Build(volumesToBuild...)
 
-	// Add CA cert if available from discovery
-	if d.deploymentContext != nil && d.deploymentContext.ETCDCASecretName != "" && len(d.Spec.K8sSensor.ETCD.Targets) == 0 {
+	// Add CA cert if available from discovery. A CA secret on the CR already produces
+	// an etcd-ca volume and mount above, so the CR wins and the discovered one is
+	// skipped, otherwise the pod would carry two volumes with the same name.
+	if d.deploymentContext != nil && d.deploymentContext.ETCDCASecretName != "" &&
+		len(d.Spec.K8sSensor.ETCD.Targets) == 0 &&
+		d.Spec.K8sSensor.ETCD.CA.SecretName == "" {
 		volumes = append(volumes, corev1.Volume{
 			Name: "etcd-ca",
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go
@@ -89,11 +89,23 @@ func (d *deploymentBuilder) getEnvVars() []corev1.EnvVar {
 		env.CrdMonitoring,
 	}
 
-	// Include ETCDCAFileEnv unless we're on OpenShift with auto-discovered ETCD resources
-	// (in that case, it's added in the OpenShift-specific section below)
-	includeETCDCAFileEnv := !d.isOpenShift ||
+	// A CA found by discovery is used unless the CR configures one of its own. Note
+	// that the CR's CA mount path cannot be used to tell those apart, because it is
+	// defaulted to the service account path, so the secret name is the real signal.
+	useDiscoveredETCDCA := !d.isOpenShift &&
+		d.deploymentContext != nil &&
+		d.deploymentContext.ETCDCASecretName != "" &&
+		len(d.Spec.K8sSensor.ETCD.Targets) == 0 &&
+		d.Spec.K8sSensor.ETCD.CA.SecretName == ""
+
+	// Include ETCDCAFileEnv unless the ETCD CA comes from somewhere else, either
+	// OpenShift auto-discovered resources or the discovered CA below. In both of those
+	// cases ETCD_CA_FILE is set further down, and emitting it here as well would leave
+	// the container with the env var twice.
+	includeETCDCAFileEnv := (!d.isOpenShift ||
 		d.deploymentContext == nil ||
-		!d.deploymentContext.OpenShiftETCDResourcesExist
+		!d.deploymentContext.OpenShiftETCDResourcesExist) &&
+		!useDiscoveredETCDCA
 
 	if includeETCDCAFileEnv {
 		envVarsToInclude = append(envVarsToInclude, env.ETCDCAFileEnv)
@@ -138,12 +150,10 @@ func (d *deploymentBuilder) getEnvVars() []corev1.EnvVar {
 					Value: strings.Join(d.deploymentContext.DiscoveredETCDTargets, ","),
 				})
 
-				// Add CA file env var if CA secret is available. A CA mount path on the
-				// CR already produces ETCD_CA_FILE via ETCDCAFileEnv, so the CR wins and
-				// the discovered one is skipped, otherwise the container would carry the
-				// env var twice and the apply would reject it.
-				if d.deploymentContext.ETCDCASecretName != "" &&
-					d.Spec.K8sSensor.ETCD.CA.MountPath == "" {
+				// Add the CA file env var if a CA secret was discovered, at the same path
+				// the volume below mounts it. ETCDCAFileEnv is suppressed above in this
+				// case, so the container gets ETCD_CA_FILE exactly once.
+				if useDiscoveredETCDCA {
 					envVars = append(envVars, corev1.EnvVar{
 						Name:  constants.EnvETCDCAFile,
 						Value: constants.ETCDCAMountPath + "/ca.crt",

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
@@ -1,5 +1,5 @@
 /*
-(c) Copyright IBM Corp. 2025
+(c) Copyright IBM Corp. 2026
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
@@ -1,0 +1,210 @@
+/*
+(c) Copyright IBM Corp. 2025
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	instanav1 "github.com/instana/instana-agent-operator/api/v1"
+	backend "github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/backends"
+	"github.com/instana/instana-agent-operator/pkg/k8s/object/builders/common/constants"
+	"github.com/instana/instana-agent-operator/pkg/k8s/operator/status"
+)
+
+func countEnvVars(envVars []corev1.EnvVar, name string) int {
+	count := 0
+	for _, env := range envVars {
+		if env.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func countVolumes(volumes []corev1.Volume, name string) int {
+	count := 0
+	for _, vol := range volumes {
+		if vol.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func countVolumeMounts(mounts []corev1.VolumeMount, name string) int {
+	count := 0
+	for _, mount := range mounts {
+		if mount.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+// agentWithCustomETCDCA returns an agent that configures its own ETCD CA, without
+// pinning the targets, so ETCD discovery still runs and reports a CA of its own.
+func agentWithCustomETCDCA() *instanav1.InstanaAgent {
+	return &instanav1.InstanaAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+		Spec: instanav1.InstanaAgentSpec{
+			Agent: instanav1.BaseAgentSpec{
+				Key: "test-key",
+			},
+			Zone: instanav1.Name{
+				Name: "test-zone",
+			},
+			K8sSensor: instanav1.K8sSpec{
+				ETCD: instanav1.ETCDSpec{
+					CA: instanav1.CASpec{
+						SecretName: "custom-etcd-ca",
+						MountPath:  "/custom/etcd",
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA covers a CR that configures
+// its own ETCD CA on a cluster where discovery also finds one. Both used to be
+// emitted, giving the container two ETCD_CA_FILE entries and the pod two volumes
+// named etcd-ca, which the API server rejects as duplicates.
+func TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA(t *testing.T) {
+	// Given
+	agent := agentWithCustomETCDCA()
+
+	mockStatusManager := &status.MockAgentStatusManager{}
+	backendObj := backend.NewK8SensorBackend("", "test-key", "", "test-host", "443")
+
+	deploymentContext := &DeploymentContext{
+		DiscoveredETCDTargets: []string{"https://10.0.0.1:2379/metrics"},
+		ETCDCASecretName:      constants.ETCDCASecretName,
+	}
+
+	builder := NewDeploymentBuilder(
+		agent,
+		false,
+		mockStatusManager,
+		*backendObj,
+		nil,
+		deploymentContext,
+	).(*deploymentBuilder)
+
+	// When
+	envVars := builder.getEnvVars()
+	volumes, mounts := builder.getVolumes()
+
+	// Then - the CR configuration wins and nothing is emitted twice
+	assert.Equal(
+		t,
+		1,
+		countEnvVars(envVars, constants.EnvETCDCAFile),
+		"ETCD_CA_FILE should be set exactly once",
+	)
+	assert.Equal(
+		t,
+		"/custom/etcd/ca.crt",
+		findEnvVar(envVars, constants.EnvETCDCAFile).Value,
+		"the CA file configured on the CR should win over the discovered one",
+	)
+
+	assert.Equal(t, 1, countVolumes(volumes, "etcd-ca"), "there should be one etcd-ca volume")
+	assert.Equal(
+		t,
+		"custom-etcd-ca",
+		findVolume(volumes, "etcd-ca").Secret.SecretName,
+		"the CA secret configured on the CR should win over the discovered one",
+	)
+	assert.Equal(
+		t,
+		1,
+		countVolumeMounts(mounts, "etcd-ca"),
+		"there should be one etcd-ca mount",
+	)
+
+	// The discovered targets are still applied, only the CA is left to the CR
+	assert.Equal(
+		t,
+		"https://10.0.0.1:2379/metrics",
+		findEnvVar(envVars, constants.EnvETCDTargets).Value,
+		"discovered targets should still be applied",
+	)
+}
+
+// TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA is the counterpart: with
+// no CA on the CR, the discovered one is still mounted as before.
+func TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA(t *testing.T) {
+	// Given
+	agent := agentWithCustomETCDCA()
+	agent.Spec.K8sSensor.ETCD.CA = instanav1.CASpec{}
+
+	mockStatusManager := &status.MockAgentStatusManager{}
+	backendObj := backend.NewK8SensorBackend("", "test-key", "", "test-host", "443")
+
+	deploymentContext := &DeploymentContext{
+		DiscoveredETCDTargets: []string{"https://10.0.0.1:2379/metrics"},
+		ETCDCASecretName:      constants.ETCDCASecretName,
+	}
+
+	builder := NewDeploymentBuilder(
+		agent,
+		false,
+		mockStatusManager,
+		*backendObj,
+		nil,
+		deploymentContext,
+	).(*deploymentBuilder)
+
+	// When
+	envVars := builder.getEnvVars()
+	volumes, mounts := builder.getVolumes()
+
+	// Then
+	assert.Equal(
+		t,
+		1,
+		countEnvVars(envVars, constants.EnvETCDCAFile),
+		"ETCD_CA_FILE should be set exactly once",
+	)
+	assert.Equal(
+		t,
+		constants.ETCDCAMountPath+"/ca.crt",
+		findEnvVar(envVars, constants.EnvETCDCAFile).Value,
+		"the discovered CA file should be used when the CR configures none",
+	)
+
+	assert.Equal(t, 1, countVolumes(volumes, "etcd-ca"), "there should be one etcd-ca volume")
+	assert.Equal(
+		t,
+		constants.ETCDCASecretName,
+		findVolume(volumes, "etcd-ca").Secret.SecretName,
+		"the discovered CA secret should be mounted",
+	)
+	assert.Equal(
+		t,
+		1,
+		countVolumeMounts(mounts, "etcd-ca"),
+		"there should be one etcd-ca mount",
+	)
+}

--- a/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
+++ b/pkg/k8s/object/builders/k8s-sensor/deployment/deployment_etcd_ca_conflict_test.go
@@ -61,8 +61,11 @@ func countVolumeMounts(mounts []corev1.VolumeMount, name string) int {
 
 // agentWithCustomETCDCA returns an agent that configures its own ETCD CA, without
 // pinning the targets, so ETCD discovery still runs and reports a CA of its own.
+// It is defaulted the same way the controller defaults it before the builders run,
+// otherwise the test exercises a CR shape that cannot reach the builder and misses
+// anything that depends on a defaulted field, such as the ETCD CA mount path.
 func agentWithCustomETCDCA() *instanav1.InstanaAgent {
-	return &instanav1.InstanaAgent{
+	agent := &instanav1.InstanaAgent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-agent",
 			Namespace: "test-ns",
@@ -84,6 +87,8 @@ func agentWithCustomETCDCA() *instanav1.InstanaAgent {
 			},
 		},
 	}
+	agent.Default()
+	return agent
 }
 
 // TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA covers a CR that configures
@@ -155,9 +160,12 @@ func TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA(t *testing.T) {
 // TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA is the counterpart: with
 // no CA on the CR, the discovered one is still mounted as before.
 func TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA(t *testing.T) {
-	// Given
+	// Given a CR that configures no CA of its own. Clear only the secret name and
+	// re-default, so the CA mount path keeps the defaulted value the builder actually
+	// sees rather than an empty string that cannot occur in production.
 	agent := agentWithCustomETCDCA()
 	agent.Spec.K8sSensor.ETCD.CA = instanav1.CASpec{}
+	agent.Default()
 
 	mockStatusManager := &status.MockAgentStatusManager{}
 	backendObj := backend.NewK8SensorBackend("", "test-key", "", "test-host", "443")


### PR DESCRIPTION
## Why

A cluster that configures its own ETCD CA on the InstanaAgent CR, while ETCD discovery also finds a CA of its own, renders a k8sensor Deployment that the API server rejects.

The container ends up with two `ETCD_CA_FILE` environment variables, and the pod spec with two volumes and two volume mounts all named `etcd-ca`. Duplicate names in those lists are invalid, so the apply fails and the k8sensor is never updated.

The precondition is narrow, it needs `k8sSensor.etcd.ca` set on the CR, no explicit `k8sSensor.etcd.targets`, and an `etcd-ca` secret present in the agent namespace for discovery to pick up, but when it is met the component simply does not deploy.

## What

The deployment builder emits the ETCD CA from two independent places:

- from the CR, via `ETCDCAFileEnv` and `volume.ETCDCAVolume`, whenever `k8sSensor.etcd.ca.mountPath` or `.secretName` is set
- from discovery, via the deployment context, whenever an `etcd-ca` secret was found

Neither knew about the other, so when both applied, both were emitted.

The CR configuration now wins and the discovered CA is skipped, which is the same precedence the builder already applies to targets: discovered targets are only added when `k8sSensor.etcd.targets` is empty. Two guards, one on the env var and one on the volume, in `pkg/k8s/object/builders/k8s-sensor/deployment/deployment.go`.

This is pre-existing and independent of the `ETCD_TARGETS` flapping work. It was found while reviewing that change, and it applies cleanly on its own, so it is raised separately rather than bundled in.

Test coverage:

- `TestDeploymentBuilder_CustomETCDCAWinsOverDiscoveredCA` pins the precedence. Against the old code it fails three times over, reporting two `ETCD_CA_FILE` env vars, two `etcd-ca` volumes and two `etcd-ca` mounts, and it also asserts the discovered targets are still applied so only the CA is left to the CR.
- `TestDeploymentBuilder_DiscoveredETCDCAUsedWithoutCustomCA` is the counterpart, confirming the discovered CA is still mounted when the CR configures none.

## References

- [Story / Card](https://jsw.ibm.com/browse/INSTA-105465)

<!-- Found while reviewing INSTA-105465 but a distinct, pre-existing defect. Happy to move this under its own card if preferred. -->

## Checklist

- [x] Backwards compatible?
- [x] unit/e2e test coverage added or updated?

Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
