### PR TITLE
chore(INSTA-105980): Fix broken `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761016216,
-        "narHash": "sha256-G/iC4t/9j/52i/nm+0/4ybBmAF4hzR8CNHC75qEhjHo=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "481cf557888e05d3128a76f14c76397b7d7cc869",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description =
     "A nix-flake-based Go/Kubernetes Controller development environment using operator-sdk";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
   outputs = { self, nixpkgs }:
     let


### PR DESCRIPTION
## Why
Because the env was broken:

```
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at «github:NixOS/nixpkgs/ac62194c3917d5f474c1a844b6fd6da2db95077d?narHash=sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w%3D»/pkgs/stdenv/generic/make-derivation.nix:480:13

       … while evaluating attribute 'nativeBuildInputs' of derivation 'nix-shell'
         at «github:NixOS/nixpkgs/ac62194c3917d5f474c1a844b6fd6da2db95077d?narHash=sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w%3D»/pkgs/stdenv/generic/make-derivation.nix:532:13:
          531|             depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          532|             nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |             ^
          533|             depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'go_1_26' missing
       at /home/ferenc/github.com/instana/instana-agent-operator/flake.nix:33:46:
           32|     in {
           33|       overlays.default = final: prev: { go = final."go_${versionForOverlay}"; };
             |                                              ^
           34|
       Did you mean one of go_1_22, go_1_23, go_1_24 or go_1_25?
```

## What

Update nix branch to the latest to get latest golang toolchain.

## References

[INSTA-105980](https://jsw.ibm.com/browse/INSTA-105980)

## Checklist

- [x] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?


~~Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.~~
