### PR TITLE
fix: update GCP VM image to Ubuntu 26.04 (resolute)

### DIFF
--- a/ci/sps-scripts/ephemeral-k8s-e2e.sh
+++ b/ci/sps-scripts/ephemeral-k8s-e2e.sh
@@ -95,7 +95,7 @@ gcloud compute instances create ${VM_NAME} \
   --project=${PROJECT_ID} \
   --zone=${ZONE} \
   --machine-type=e2-standard-4 \
-  --image=projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2404-noble-amd64-v20251002 \
+  --image=projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2604-resolute-amd64-v20260723 \
   --labels="purpose=e2e-testing,creation-time=$(date +%s),max-lifetime=90m" \
   --metadata="startup-script=#!/bin/bash
     # Install k3s with tls-san to include the external IP in the certificate


### PR DESCRIPTION
## Why

GCP flagged the Ubuntu 24.04 image `ubuntu-minimal-2404-noble-amd64-v20251002` used in the ephemeral k8s e2e test VM as deprecated. Without this fix, new VM creation would fail (or generate blocking warnings) in CI. Upgrading to Ubuntu 26.04 LTS keeps the ephemeral test environment on a current, supported image.

## What

Replaced the deprecated GCP image in `ci/sps-scripts/ephemeral-k8s-e2e.sh` with the latest READY amd64 image from the `ubuntu-os-cloud` project:

- **Before:** `projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2404-noble-amd64-v20251002`
- **After:** `projects/ubuntu-os-cloud/global/images/ubuntu-minimal-2604-resolute-amd64-v20260723`

Ubuntu 26.04 LTS (Resolute) is fully compatible with k3s and the rest of the e2e setup.

## References

<!-- Please include links to other artifacts related to this code change. -->

- Story / Card: N/A (CI maintenance)
- Documentation: N/A

## Checklist

- [x] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?