### PR TITLE
ci: fix GKE e2e tests to target correct clusters in europe-central2

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -544,7 +544,7 @@ jobs:
                   password: ((icr-api-key.password))
               params:
                 GIT_COMMIT: ((.:git-commit))
-                CLUSTER_INFO: '{ "name": "project-berlin-lowest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                CLUSTER_INFO: '{ "name": "operator-lowest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                 CLUSTER_TYPE: gke
                 NAME: gke-operator-lowest
                 GCP_KEY_JSON: ((project-berlin-tests-gcp-instana-qa))
@@ -602,7 +602,7 @@ jobs:
                   platform: linux
                   image_resource: *e2e-test-image-resource
                   params:
-                    CLUSTER_INFO: '{ "name": "project-berlin-lowest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                    CLUSTER_INFO: '{ "name": "operator-lowest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                     CLUSTER_TYPE: gke
                     NAME: gke-operator-lowest
                     GCP_KEY_JSON: ((project-berlin-tests-gcp-instana-qa))
@@ -652,7 +652,7 @@ jobs:
               <<: *gke-e2e-test-config
               params:
                 GIT_COMMIT: ((.:git-commit))
-                CLUSTER_INFO: '{ "name": "project-berlin-latest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                CLUSTER_INFO: '{ "name": "operator-latest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                 CLUSTER_TYPE: gke
                 NAME: gke-operator-latest
                 GCP_KEY_JSON: ((project-berlin-tests-gcp-instana-qa))
@@ -711,7 +711,7 @@ jobs:
                   platform: linux
                   image_resource: *e2e-test-image-resource
                   params:
-                    CLUSTER_INFO: '{ "name": "project-berlin-latest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                    CLUSTER_INFO: '{ "name": "operator-latest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                     CLUSTER_TYPE: gke
                     NAME: gke-operator-latest
 


### PR DESCRIPTION
## Why

The e2e tests were incorrectly targeting the `project-berlin-lowest` and `project-berlin-latest` clusters in `us-central1`. These clusters no longer match the intended test targets. The correct clusters are `operator-lowest` and `operator-latest`, located in the `europe-central2` region.

## What

Updated `CLUSTER_INFO` in all four affected GKE e2e test job configurations in `ci/pipeline.yaml`:

- `project-berlin-lowest` (us-central1) → `operator-lowest` (europe-central2)
- `project-berlin-latest` (us-central1) → `operator-latest` (europe-central2)

## References

<!-- Please include links to other artifacts related to this code change. -->

- [Story / Card](https://jsw.ibm.com/browse/INSTA-XXXXX)

## Checklist

- [x] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?