### PR TITLE
ci: fix GKE e2e tests to target correct clusters in europe-central2 (backport #582)

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -546,7 +546,7 @@ jobs:
                   password: ((icr-api-key.password))
               params:
                 GIT_COMMIT: ((.:git-commit))
-                CLUSTER_INFO: '{ "name": "project-berlin-lowest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                CLUSTER_INFO: '{ "name": "operator-lowest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                 CLUSTER_TYPE: gke
                 NAME: gke-operator-lowest
                 GCP_KEY_JSON: ((project-berlin-tests-gcp-instana-qa))
@@ -604,7 +604,7 @@ jobs:
                   platform: linux
                   image_resource: *e2e-test-image-resource
                   params:
-                    CLUSTER_INFO: '{ "name": "project-berlin-lowest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                    CLUSTER_INFO: '{ "name": "operator-lowest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                     CLUSTER_TYPE: gke
                     NAME: gke-operator-lowest
                     GCP_KEY_JSON: ((project-berlin-tests-gcp-instana-qa))
@@ -654,7 +654,7 @@ jobs:
               <<: *gke-e2e-test-config
               params:
                 GIT_COMMIT: ((.:git-commit))
-                CLUSTER_INFO: '{ "name": "project-berlin-latest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                CLUSTER_INFO: '{ "name": "operator-latest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                 CLUSTER_TYPE: gke
                 NAME: gke-operator-latest
                 GCP_KEY_JSON: ((project-berlin-tests-gcp-instana-qa))
@@ -713,7 +713,7 @@ jobs:
                   platform: linux
                   image_resource: *e2e-test-image-resource
                   params:
-                    CLUSTER_INFO: '{ "name": "project-berlin-latest", "zone": "us-central1", "project": "instana-agent-qa" }'
+                    CLUSTER_INFO: '{ "name": "operator-latest", "zone": "europe-central2", "project": "instana-agent-qa" }'
                     CLUSTER_TYPE: gke
                     NAME: gke-operator-latest
 

--- a/ci/scripts/ephemeral-k8s-e2e.sh
+++ b/ci/scripts/ephemeral-k8s-e2e.sh
@@ -68,7 +68,7 @@ trap cleanup EXIT SIGINT SIGTERM
 
 # Authenticate to GCP
 echo "Authenticating to GCP..."
-echo -n "$(get_env GOOGLE_APPLICATION_CREDENTIALS_BASE64)" | base64 -d > gcp-key.json
+echo -n "$(get_secret GOOGLE_APPLICATION_CREDENTIALS_BASE64)" | base64 -d > gcp-key.json
 gcloud auth activate-service-account --key-file gcp-key.json
 gcloud config set project ${PROJECT_ID}
 
@@ -139,7 +139,7 @@ ICR_PASSWORD=$(cat /config/api-key)
 
 # Setup Instana backend details
 echo "Setting up Instana backend details..."
-INSTANA_E2E_BACKEND_DETAILS=$(get_env instana-e2e-backend-details)
+INSTANA_E2E_BACKEND_DETAILS=$(get_secret instana-e2e-backend-details)
 INSTANA_ENDPOINT_HOST=$(echo "${INSTANA_E2E_BACKEND_DETAILS}" | jq -r ".endpoint_host")
 INSTANA_ENDPOINT_PORT=443
 INSTANA_API_KEY=$(echo "${INSTANA_E2E_BACKEND_DETAILS}" | jq -r ".agent_key")

--- a/ci/sps-scripts/e2e.sh
+++ b/ci/sps-scripts/e2e.sh
@@ -72,7 +72,7 @@ if [[ $(get_env run-"${CLUSTER_ID}") == "false" ]]; then
     exit 0
 fi
 
-CLUSTER_DETAILS=$(get_env "${CLUSTER_ID}")
+CLUSTER_DETAILS=$(get_secret "${CLUSTER_ID}")
 CLUSTER_TYPE=$(echo "${CLUSTER_DETAILS}" | jq -r ".type")
 CLUSTER_NAME=$(echo "${CLUSTER_DETAILS}" | jq -r ".name")
 ICR_USERNAME=iamapikey
@@ -133,7 +133,7 @@ elif [ "${CLUSTER_TYPE}" == "gke" ]; then
     CLUSTER_ZONE=$(echo "${CLUSTER_DETAILS}" | jq -r ".zone")
     CLUSTER_PROJECT=$(echo "${CLUSTER_DETAILS}" | jq -r ".project")
     # login into GCP
-    get_env gcp-service-account > keyfile.json
+    get_secret gcp-service-account > keyfile.json
     gcloud auth activate-service-account --key-file keyfile.json
     gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${CLUSTER_ZONE}" --project "${CLUSTER_PROJECT}"
 else
@@ -150,7 +150,7 @@ export PATH=${PATH}:/usr/local/go/bin:/usr/local/bin
 go version
 
 # fetching e2e test backend details
-INSTANA_E2E_BACKEND_DETAILS=$(get_env instana-e2e-backend-details)
+INSTANA_E2E_BACKEND_DETAILS=$(get_secret instana-e2e-backend-details)
 INSTANA_ENDPOINT_HOST=$(echo "${INSTANA_E2E_BACKEND_DETAILS}" | jq -r ".endpoint_host")
 INSTANA_ENDPOINT_PORT=443
 INSTANA_API_KEY=$(echo "${INSTANA_E2E_BACKEND_DETAILS}" | jq -r ".agent_key")

--- a/ci/sps-scripts/reslock.sh
+++ b/ci/sps-scripts/reslock.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+#
+# (c) Copyright IBM Corp. 2025
+#
 # Helper script to calculate CI Server specific metadata to be used for locking.
 # When invoked, it generates a unique lock owner name from concourse meta-data and
 # fetched the most recent go binary from github to execute the lock or release command. 
@@ -11,7 +14,7 @@ echo "${RESLOCK_COMMAND} lock ${RESLOCK_RESOURCE_NAME}"
 
 export RESLOCK_GITHUB_REPO_OWNER=instana
 export RESLOCK_LOCK_OWNER="${APP_REPO_NAME}/${BRANCH}/${PIPELINE_RUN_NAME}/${BUILD_NUMBER}"
-RESLOCK_GITHUB_TOKEN=$(get_env reslock-github-token)
+RESLOCK_GITHUB_TOKEN=$(get_secret reslock-github-token)
 export RESLOCK_GITHUB_TOKEN
 
 echo "RESLOCK_GITHUB_REPO_OWNER=${RESLOCK_GITHUB_REPO_OWNER}"


### PR DESCRIPTION
## Why

Backport of #582 to `release-2.1`.

The e2e tests were incorrectly targeting the `project-berlin-lowest` and `project-berlin-latest` clusters in `us-central1`. These clusters no longer match the intended test targets. The correct clusters are `operator-lowest` and `operator-latest`, located in the `europe-central2` region.

## What

Updated `CLUSTER_INFO` in all four affected GKE e2e test job configurations in `ci/pipeline.yaml`:

- `project-berlin-lowest` (us-central1) → `operator-lowest` (europe-central2)
- `project-berlin-latest` (us-central1) → `operator-latest` (europe-central2)

Migrated sensitive `get_env` calls to `get_secret` across CI scripts:

- `reslock-github-token` in `ci/sps-scripts/reslock.sh`
- `${CLUSTER_ID}` (cluster credentials), `gcp-service-account`, `instana-e2e-backend-details` in `ci/sps-scripts/e2e.sh`
- `GOOGLE_APPLICATION_CREDENTIALS_BASE64`, `instana-e2e-backend-details` in `ci/scripts/ephemeral-k8s-e2e.sh`

Non-sensitive config values (`pipeline_namespace`, run-flags, `branch`) remain as `get_env`.

## References

- Original PR: #582

## Checklist

- [x] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?