### PR TITLE
ci: increase e2e timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test: manifests generate fmt vet lint envtest ## Run tests but ignore specific d
 
 .PHONY: e2e
 e2e: ## Run end-to-end tests
-	go test -timeout=60m -count=1 -failfast -v github.com/instana/instana-agent-operator/e2e
+	go test -timeout=90m -count=1 -failfast -v github.com/instana/instana-agent-operator/e2e
 
 ##@ Build
 

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -533,7 +533,7 @@ jobs:
               run:
                 path: agent-operator-git-source/ci/scripts/reslock.sh
           - task: run-e2e-test-gke-operator-lowest
-            timeout: 55m
+            timeout: 85m
             attempts: 1
             config: &gke-e2e-test-config
               platform: linux
@@ -648,7 +648,7 @@ jobs:
               run:
                 path: agent-operator-git-source/ci/scripts/reslock.sh
           - task: run-e2e-test-gke-operator-latest
-            timeout: 55m
+            timeout: 85m
             attempts: 1
             config:
               <<: *gke-e2e-test-config

--- a/ci/scripts/reslock.sh
+++ b/ci/scripts/reslock.sh
@@ -30,7 +30,7 @@ echo "RESLOCK_LOCK_OWNER=${RESLOCK_LOCK_OWNER}"
 
 curl -s "https://${RESLOCK_GITHUB_TOKEN}@raw.github.ibm.com/instana/reslock/main/run.sh" > run.sh
 if [ "${RESLOCK_COMMAND}" == "claim" ]; then
-    bash run.sh claim k8s-clusters "${RESLOCK_RESOURCE_NAME}" -t 60m -w
+    bash run.sh claim k8s-clusters "${RESLOCK_RESOURCE_NAME}" -t 90m -w
 else
     bash run.sh "${RESLOCK_COMMAND}" k8s-clusters "${RESLOCK_RESOURCE_NAME}"
 fi


### PR DESCRIPTION
## Why

* we are hitting timeouts in the release pipeline

## What

* increase the timeout

## References

<!-- Please include links to other artifacts related to this code change. -->

- NA
## Checklist

<!-- Please tick of these checklist items if applicable (or remove if not applicable). -->

- [ ] Backwards compatible?
- [ ] unit/e2e test coverage added or updated?


Note: Remember to run a [helm chart](https://github.ibm.com/instana/instana-agent-charts) release after the the operator release to make the changes available thru helm.
